### PR TITLE
feat: improve client generation

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -79,81 +79,27 @@ const dynamodbLib = new TypeScriptLibProject({
   peerDeps: [...commonPeerDeps, dynamodbClient.package.packageName],
 });
 
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-eventbridge",
-  deps: [...commonDeps, "@aws-sdk/client-eventbridge@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
+const clients = [
+  {name: 'ec2'},
+  {name: 'elasticache'},
+  {name: 'eventbridge'},
+  {name: 'iam'},
+  {name: 'lambda'},
+  {name: 's3', extraDeps: ['@aws-sdk/s3-request-presigner@^3']},
+  {name: 'sfn'},
+  {name: 'sns'},
+  {name: 'sqs'},
+];
 
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-lambda",
-  deps: [...commonDeps, "@aws-sdk/client-lambda@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-s3",
-  deps: [
-    ...commonDeps,
-    "@aws-sdk/client-s3@^3",
-    "@aws-sdk/s3-request-presigner@^3",
-  ],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-sns",
-  deps: [...commonDeps, "@aws-sdk/client-sns@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-sqs",
-  deps: [...commonDeps, "@aws-sdk/client-sqs@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-sfn",
-  deps: [...commonDeps, "@aws-sdk/client-sfn@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-iam",
-  deps: [...commonDeps, "@aws-sdk/client-iam@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-elasticache",
-  deps: [...commonDeps, "@aws-sdk/client-elasticache@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
-
-new TypeScriptLibProject({
-  parent: project,
-  name: "client-ec2",
-  deps: [...commonDeps, "@aws-sdk/client-ec2@^3"],
-  devDeps: commonDevDeps,
-  peerDeps: commonPeerDeps,
-});
+for (const {name, extraDeps = []} of clients) {
+  new TypeScriptLibProject({
+    parent: project,
+    name: `client-${name}`,
+    deps: [...commonDeps, `@aws-sdk/client-${name}@^3`, ...extraDeps],
+    devDeps: commonDevDeps,
+    peerDeps: commonPeerDeps,
+  });
+}
 
 new TypeScriptLibProject({
   parent: project,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,6 +5,7 @@ import { Changesets, Docgen, TypeScriptLibProject, Vitest } from "./projenrc";
 const org = "floydspace";
 const name = "effect-aws";
 const repo = `${org}/${name}`;
+const awsSdkVersion = "3.556.0";
 
 const project = new monorepo.MonorepoTsProject({
   name: name,
@@ -54,7 +55,7 @@ new TypeScriptLibProject({
 new TypeScriptLibProject({
   parent: project,
   name: "client-api-gateway-management-api",
-  deps: [...commonDeps, "@aws-sdk/client-apigatewaymanagementapi@^3"],
+  deps: [...commonDeps, `@aws-sdk/client-apigatewaymanagementapi@^${awsSdkVersion}`],
   devDeps: commonDevDeps,
   peerDeps: commonPeerDeps,
 });
@@ -62,7 +63,7 @@ new TypeScriptLibProject({
 const dynamodbClient = new TypeScriptLibProject({
   parent: project,
   name: "client-dynamodb",
-  deps: [...commonDeps, "@aws-sdk/client-dynamodb@^3"],
+  deps: [...commonDeps, `@aws-sdk/client-dynamodb@^${awsSdkVersion}`],
   devDeps: commonDevDeps,
   peerDeps: commonPeerDeps,
 });
@@ -72,8 +73,8 @@ const dynamodbLib = new TypeScriptLibProject({
   name: "lib-dynamodb",
   deps: [
     ...commonDeps,
-    "@aws-sdk/client-dynamodb@^3",
-    "@aws-sdk/lib-dynamodb@^3",
+    `@aws-sdk/client-dynamodb@^${awsSdkVersion}`,
+    `@aws-sdk/lib-dynamodb@^${awsSdkVersion}`,
   ],
   devDeps: commonDevDeps,
   peerDeps: [...commonPeerDeps, dynamodbClient.package.packageName],
@@ -85,7 +86,7 @@ const clients = [
   {name: 'eventbridge'},
   {name: 'iam'},
   {name: 'lambda'},
-  {name: 's3', extraDeps: ['@aws-sdk/s3-request-presigner@^3']},
+  {name: 's3', extraDeps: [`@aws-sdk/s3-request-presigner@^${awsSdkVersion}`]},
   {name: 'sfn'},
   {name: 'sns'},
   {name: 'sqs'},
@@ -95,7 +96,7 @@ for (const {name, extraDeps = []} of clients) {
   new TypeScriptLibProject({
     parent: project,
     name: `client-${name}`,
-    deps: [...commonDeps, `@aws-sdk/client-${name}@^3`, ...extraDeps],
+    deps: [...commonDeps, `@aws-sdk/client-${name}@^${awsSdkVersion}`, ...extraDeps],
     devDeps: commonDevDeps,
     peerDeps: commonPeerDeps,
   });

--- a/packages/client-api-gateway-management-api/.projen/deps.json
+++ b/packages/client-api-gateway-management-api/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-apigatewaymanagementapi",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-api-gateway-management-api/package.json
+++ b/packages/client-api-gateway-management-api/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-apigatewaymanagementapi": "^3",
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-dynamodb/.projen/deps.json
+++ b/packages/client-dynamodb/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-dynamodb",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-dynamodb/package.json
+++ b/packages/client-dynamodb/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/client-dynamodb": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-ec2/.projen/deps.json
+++ b/packages/client-ec2/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-ec2",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-ec2/package.json
+++ b/packages/client-ec2/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-ec2": "^3",
+    "@aws-sdk/client-ec2": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-ec2/src/EC2Service.ts
+++ b/packages/client-ec2/src/EC2Service.ts
@@ -1804,635 +1804,629 @@ import {
 } from "@aws-sdk/client-ec2";
 import type { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
 import { Context, Data, Effect, Layer, Record } from "effect";
-import {
-  EC2ClientInstance,
-  EC2ClientInstanceLayer,
-} from "./EC2ClientInstance";
+import { EC2ClientInstance, EC2ClientInstanceLayer } from "./EC2ClientInstance";
 import { DefaultEC2ClientConfigLayer } from "./EC2ClientInstanceConfig";
-import {
-  type TaggedException,
-  SdkError,
-} from "./Errors";
+import { type TaggedException, SdkError } from "./Errors";
 
 const commands = {
   AcceptAddressTransferCommand,
- AcceptReservedInstancesExchangeQuoteCommand,
- AcceptTransitGatewayMulticastDomainAssociationsCommand,
- AcceptTransitGatewayPeeringAttachmentCommand,
- AcceptTransitGatewayVpcAttachmentCommand,
- AcceptVpcEndpointConnectionsCommand,
- AcceptVpcPeeringConnectionCommand,
- AdvertiseByoipCidrCommand,
- AllocateAddressCommand,
- AllocateHostsCommand,
- AllocateIpamPoolCidrCommand,
- ApplySecurityGroupsToClientVpnTargetNetworkCommand,
- AssignIpv6AddressesCommand,
- AssignPrivateIpAddressesCommand,
- AssignPrivateNatGatewayAddressCommand,
- AssociateAddressCommand,
- AssociateClientVpnTargetNetworkCommand,
- AssociateDhcpOptionsCommand,
- AssociateEnclaveCertificateIamRoleCommand,
- AssociateIamInstanceProfileCommand,
- AssociateInstanceEventWindowCommand,
- AssociateIpamByoasnCommand,
- AssociateIpamResourceDiscoveryCommand,
- AssociateNatGatewayAddressCommand,
- AssociateRouteTableCommand,
- AssociateSubnetCidrBlockCommand,
- AssociateTransitGatewayMulticastDomainCommand,
- AssociateTransitGatewayPolicyTableCommand,
- AssociateTransitGatewayRouteTableCommand,
- AssociateTrunkInterfaceCommand,
- AssociateVpcCidrBlockCommand,
- AttachClassicLinkVpcCommand,
- AttachInternetGatewayCommand,
- AttachNetworkInterfaceCommand,
- AttachVerifiedAccessTrustProviderCommand,
- AttachVolumeCommand,
- AttachVpnGatewayCommand,
- AuthorizeClientVpnIngressCommand,
- AuthorizeSecurityGroupEgressCommand,
- AuthorizeSecurityGroupIngressCommand,
- BundleInstanceCommand,
- CancelBundleTaskCommand,
- CancelCapacityReservationCommand,
- CancelCapacityReservationFleetsCommand,
- CancelConversionTaskCommand,
- CancelExportTaskCommand,
- CancelImageLaunchPermissionCommand,
- CancelImportTaskCommand,
- CancelReservedInstancesListingCommand,
- CancelSpotFleetRequestsCommand,
- CancelSpotInstanceRequestsCommand,
- ConfirmProductInstanceCommand,
- CopyFpgaImageCommand,
- CopyImageCommand,
- CopySnapshotCommand,
- CreateCapacityReservationCommand,
- CreateCapacityReservationFleetCommand,
- CreateCarrierGatewayCommand,
- CreateClientVpnEndpointCommand,
- CreateClientVpnRouteCommand,
- CreateCoipCidrCommand,
- CreateCoipPoolCommand,
- CreateCustomerGatewayCommand,
- CreateDefaultSubnetCommand,
- CreateDefaultVpcCommand,
- CreateDhcpOptionsCommand,
- CreateEgressOnlyInternetGatewayCommand,
- CreateFleetCommand,
- CreateFlowLogsCommand,
- CreateFpgaImageCommand,
- CreateImageCommand,
- CreateInstanceConnectEndpointCommand,
- CreateInstanceEventWindowCommand,
- CreateInstanceExportTaskCommand,
- CreateInternetGatewayCommand,
- CreateIpamCommand,
- CreateIpamPoolCommand,
- CreateIpamResourceDiscoveryCommand,
- CreateIpamScopeCommand,
- CreateKeyPairCommand,
- CreateLaunchTemplateCommand,
- CreateLaunchTemplateVersionCommand,
- CreateLocalGatewayRouteCommand,
- CreateLocalGatewayRouteTableCommand,
- CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
- CreateLocalGatewayRouteTableVpcAssociationCommand,
- CreateManagedPrefixListCommand,
- CreateNatGatewayCommand,
- CreateNetworkAclCommand,
- CreateNetworkAclEntryCommand,
- CreateNetworkInsightsAccessScopeCommand,
- CreateNetworkInsightsPathCommand,
- CreateNetworkInterfaceCommand,
- CreateNetworkInterfacePermissionCommand,
- CreatePlacementGroupCommand,
- CreatePublicIpv4PoolCommand,
- CreateReplaceRootVolumeTaskCommand,
- CreateReservedInstancesListingCommand,
- CreateRestoreImageTaskCommand,
- CreateRouteCommand,
- CreateRouteTableCommand,
- CreateSecurityGroupCommand,
- CreateSnapshotCommand,
- CreateSnapshotsCommand,
- CreateSpotDatafeedSubscriptionCommand,
- CreateStoreImageTaskCommand,
- CreateSubnetCommand,
- CreateSubnetCidrReservationCommand,
- CreateTagsCommand,
- CreateTrafficMirrorFilterCommand,
- CreateTrafficMirrorFilterRuleCommand,
- CreateTrafficMirrorSessionCommand,
- CreateTrafficMirrorTargetCommand,
- CreateTransitGatewayCommand,
- CreateTransitGatewayConnectCommand,
- CreateTransitGatewayConnectPeerCommand,
- CreateTransitGatewayMulticastDomainCommand,
- CreateTransitGatewayPeeringAttachmentCommand,
- CreateTransitGatewayPolicyTableCommand,
- CreateTransitGatewayPrefixListReferenceCommand,
- CreateTransitGatewayRouteCommand,
- CreateTransitGatewayRouteTableCommand,
- CreateTransitGatewayRouteTableAnnouncementCommand,
- CreateTransitGatewayVpcAttachmentCommand,
- CreateVerifiedAccessEndpointCommand,
- CreateVerifiedAccessGroupCommand,
- CreateVerifiedAccessInstanceCommand,
- CreateVerifiedAccessTrustProviderCommand,
- CreateVolumeCommand,
- CreateVpcCommand,
- CreateVpcEndpointCommand,
- CreateVpcEndpointConnectionNotificationCommand,
- CreateVpcEndpointServiceConfigurationCommand,
- CreateVpcPeeringConnectionCommand,
- CreateVpnConnectionCommand,
- CreateVpnConnectionRouteCommand,
- CreateVpnGatewayCommand,
- DeleteCarrierGatewayCommand,
- DeleteClientVpnEndpointCommand,
- DeleteClientVpnRouteCommand,
- DeleteCoipCidrCommand,
- DeleteCoipPoolCommand,
- DeleteCustomerGatewayCommand,
- DeleteDhcpOptionsCommand,
- DeleteEgressOnlyInternetGatewayCommand,
- DeleteFleetsCommand,
- DeleteFlowLogsCommand,
- DeleteFpgaImageCommand,
- DeleteInstanceConnectEndpointCommand,
- DeleteInstanceEventWindowCommand,
- DeleteInternetGatewayCommand,
- DeleteIpamCommand,
- DeleteIpamPoolCommand,
- DeleteIpamResourceDiscoveryCommand,
- DeleteIpamScopeCommand,
- DeleteKeyPairCommand,
- DeleteLaunchTemplateCommand,
- DeleteLaunchTemplateVersionsCommand,
- DeleteLocalGatewayRouteCommand,
- DeleteLocalGatewayRouteTableCommand,
- DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
- DeleteLocalGatewayRouteTableVpcAssociationCommand,
- DeleteManagedPrefixListCommand,
- DeleteNatGatewayCommand,
- DeleteNetworkAclCommand,
- DeleteNetworkAclEntryCommand,
- DeleteNetworkInsightsAccessScopeCommand,
- DeleteNetworkInsightsAccessScopeAnalysisCommand,
- DeleteNetworkInsightsAnalysisCommand,
- DeleteNetworkInsightsPathCommand,
- DeleteNetworkInterfaceCommand,
- DeleteNetworkInterfacePermissionCommand,
- DeletePlacementGroupCommand,
- DeletePublicIpv4PoolCommand,
- DeleteQueuedReservedInstancesCommand,
- DeleteRouteCommand,
- DeleteRouteTableCommand,
- DeleteSecurityGroupCommand,
- DeleteSnapshotCommand,
- DeleteSpotDatafeedSubscriptionCommand,
- DeleteSubnetCommand,
- DeleteSubnetCidrReservationCommand,
- DeleteTagsCommand,
- DeleteTrafficMirrorFilterCommand,
- DeleteTrafficMirrorFilterRuleCommand,
- DeleteTrafficMirrorSessionCommand,
- DeleteTrafficMirrorTargetCommand,
- DeleteTransitGatewayCommand,
- DeleteTransitGatewayConnectCommand,
- DeleteTransitGatewayConnectPeerCommand,
- DeleteTransitGatewayMulticastDomainCommand,
- DeleteTransitGatewayPeeringAttachmentCommand,
- DeleteTransitGatewayPolicyTableCommand,
- DeleteTransitGatewayPrefixListReferenceCommand,
- DeleteTransitGatewayRouteCommand,
- DeleteTransitGatewayRouteTableCommand,
- DeleteTransitGatewayRouteTableAnnouncementCommand,
- DeleteTransitGatewayVpcAttachmentCommand,
- DeleteVerifiedAccessEndpointCommand,
- DeleteVerifiedAccessGroupCommand,
- DeleteVerifiedAccessInstanceCommand,
- DeleteVerifiedAccessTrustProviderCommand,
- DeleteVolumeCommand,
- DeleteVpcCommand,
- DeleteVpcEndpointConnectionNotificationsCommand,
- DeleteVpcEndpointServiceConfigurationsCommand,
- DeleteVpcEndpointsCommand,
- DeleteVpcPeeringConnectionCommand,
- DeleteVpnConnectionCommand,
- DeleteVpnConnectionRouteCommand,
- DeleteVpnGatewayCommand,
- DeprovisionByoipCidrCommand,
- DeprovisionIpamByoasnCommand,
- DeprovisionIpamPoolCidrCommand,
- DeprovisionPublicIpv4PoolCidrCommand,
- DeregisterImageCommand,
- DeregisterInstanceEventNotificationAttributesCommand,
- DeregisterTransitGatewayMulticastGroupMembersCommand,
- DeregisterTransitGatewayMulticastGroupSourcesCommand,
- DescribeAccountAttributesCommand,
- DescribeAddressTransfersCommand,
- DescribeAddressesCommand,
- DescribeAddressesAttributeCommand,
- DescribeAggregateIdFormatCommand,
- DescribeAvailabilityZonesCommand,
- DescribeAwsNetworkPerformanceMetricSubscriptionsCommand,
- DescribeBundleTasksCommand,
- DescribeByoipCidrsCommand,
- DescribeCapacityBlockOfferingsCommand,
- DescribeCapacityReservationFleetsCommand,
- DescribeCapacityReservationsCommand,
- DescribeCarrierGatewaysCommand,
- DescribeClassicLinkInstancesCommand,
- DescribeClientVpnAuthorizationRulesCommand,
- DescribeClientVpnConnectionsCommand,
- DescribeClientVpnEndpointsCommand,
- DescribeClientVpnRoutesCommand,
- DescribeClientVpnTargetNetworksCommand,
- DescribeCoipPoolsCommand,
- DescribeConversionTasksCommand,
- DescribeCustomerGatewaysCommand,
- DescribeDhcpOptionsCommand,
- DescribeEgressOnlyInternetGatewaysCommand,
- DescribeElasticGpusCommand,
- DescribeExportImageTasksCommand,
- DescribeExportTasksCommand,
- DescribeFastLaunchImagesCommand,
- DescribeFastSnapshotRestoresCommand,
- DescribeFleetHistoryCommand,
- DescribeFleetInstancesCommand,
- DescribeFleetsCommand,
- DescribeFlowLogsCommand,
- DescribeFpgaImageAttributeCommand,
- DescribeFpgaImagesCommand,
- DescribeHostReservationOfferingsCommand,
- DescribeHostReservationsCommand,
- DescribeHostsCommand,
- DescribeIamInstanceProfileAssociationsCommand,
- DescribeIdFormatCommand,
- DescribeIdentityIdFormatCommand,
- DescribeImageAttributeCommand,
- DescribeImagesCommand,
- DescribeImportImageTasksCommand,
- DescribeImportSnapshotTasksCommand,
- DescribeInstanceAttributeCommand,
- DescribeInstanceConnectEndpointsCommand,
- DescribeInstanceCreditSpecificationsCommand,
- DescribeInstanceEventNotificationAttributesCommand,
- DescribeInstanceEventWindowsCommand,
- DescribeInstanceStatusCommand,
- DescribeInstanceTopologyCommand,
- DescribeInstanceTypeOfferingsCommand,
- DescribeInstanceTypesCommand,
- DescribeInstancesCommand,
- DescribeInternetGatewaysCommand,
- DescribeIpamByoasnCommand,
- DescribeIpamPoolsCommand,
- DescribeIpamResourceDiscoveriesCommand,
- DescribeIpamResourceDiscoveryAssociationsCommand,
- DescribeIpamScopesCommand,
- DescribeIpamsCommand,
- DescribeIpv6PoolsCommand,
- DescribeKeyPairsCommand,
- DescribeLaunchTemplateVersionsCommand,
- DescribeLaunchTemplatesCommand,
- DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
- DescribeLocalGatewayRouteTableVpcAssociationsCommand,
- DescribeLocalGatewayRouteTablesCommand,
- DescribeLocalGatewayVirtualInterfaceGroupsCommand,
- DescribeLocalGatewayVirtualInterfacesCommand,
- DescribeLocalGatewaysCommand,
- DescribeLockedSnapshotsCommand,
- DescribeMacHostsCommand,
- DescribeManagedPrefixListsCommand,
- DescribeMovingAddressesCommand,
- DescribeNatGatewaysCommand,
- DescribeNetworkAclsCommand,
- DescribeNetworkInsightsAccessScopeAnalysesCommand,
- DescribeNetworkInsightsAccessScopesCommand,
- DescribeNetworkInsightsAnalysesCommand,
- DescribeNetworkInsightsPathsCommand,
- DescribeNetworkInterfaceAttributeCommand,
- DescribeNetworkInterfacePermissionsCommand,
- DescribeNetworkInterfacesCommand,
- DescribePlacementGroupsCommand,
- DescribePrefixListsCommand,
- DescribePrincipalIdFormatCommand,
- DescribePublicIpv4PoolsCommand,
- DescribeRegionsCommand,
- DescribeReplaceRootVolumeTasksCommand,
- DescribeReservedInstancesCommand,
- DescribeReservedInstancesListingsCommand,
- DescribeReservedInstancesModificationsCommand,
- DescribeReservedInstancesOfferingsCommand,
- DescribeRouteTablesCommand,
- DescribeScheduledInstanceAvailabilityCommand,
- DescribeScheduledInstancesCommand,
- DescribeSecurityGroupReferencesCommand,
- DescribeSecurityGroupRulesCommand,
- DescribeSecurityGroupsCommand,
- DescribeSnapshotAttributeCommand,
- DescribeSnapshotTierStatusCommand,
- DescribeSnapshotsCommand,
- DescribeSpotDatafeedSubscriptionCommand,
- DescribeSpotFleetInstancesCommand,
- DescribeSpotFleetRequestHistoryCommand,
- DescribeSpotFleetRequestsCommand,
- DescribeSpotInstanceRequestsCommand,
- DescribeSpotPriceHistoryCommand,
- DescribeStaleSecurityGroupsCommand,
- DescribeStoreImageTasksCommand,
- DescribeSubnetsCommand,
- DescribeTagsCommand,
- DescribeTrafficMirrorFiltersCommand,
- DescribeTrafficMirrorSessionsCommand,
- DescribeTrafficMirrorTargetsCommand,
- DescribeTransitGatewayAttachmentsCommand,
- DescribeTransitGatewayConnectPeersCommand,
- DescribeTransitGatewayConnectsCommand,
- DescribeTransitGatewayMulticastDomainsCommand,
- DescribeTransitGatewayPeeringAttachmentsCommand,
- DescribeTransitGatewayPolicyTablesCommand,
- DescribeTransitGatewayRouteTableAnnouncementsCommand,
- DescribeTransitGatewayRouteTablesCommand,
- DescribeTransitGatewayVpcAttachmentsCommand,
- DescribeTransitGatewaysCommand,
- DescribeTrunkInterfaceAssociationsCommand,
- DescribeVerifiedAccessEndpointsCommand,
- DescribeVerifiedAccessGroupsCommand,
- DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
- DescribeVerifiedAccessInstancesCommand,
- DescribeVerifiedAccessTrustProvidersCommand,
- DescribeVolumeAttributeCommand,
- DescribeVolumeStatusCommand,
- DescribeVolumesCommand,
- DescribeVolumesModificationsCommand,
- DescribeVpcAttributeCommand,
- DescribeVpcClassicLinkCommand,
- DescribeVpcClassicLinkDnsSupportCommand,
- DescribeVpcEndpointConnectionNotificationsCommand,
- DescribeVpcEndpointConnectionsCommand,
- DescribeVpcEndpointServiceConfigurationsCommand,
- DescribeVpcEndpointServicePermissionsCommand,
- DescribeVpcEndpointServicesCommand,
- DescribeVpcEndpointsCommand,
- DescribeVpcPeeringConnectionsCommand,
- DescribeVpcsCommand,
- DescribeVpnConnectionsCommand,
- DescribeVpnGatewaysCommand,
- DetachClassicLinkVpcCommand,
- DetachInternetGatewayCommand,
- DetachNetworkInterfaceCommand,
- DetachVerifiedAccessTrustProviderCommand,
- DetachVolumeCommand,
- DetachVpnGatewayCommand,
- DisableAddressTransferCommand,
- DisableAwsNetworkPerformanceMetricSubscriptionCommand,
- DisableEbsEncryptionByDefaultCommand,
- DisableFastLaunchCommand,
- DisableFastSnapshotRestoresCommand,
- DisableImageCommand,
- DisableImageBlockPublicAccessCommand,
- DisableImageDeprecationCommand,
- DisableIpamOrganizationAdminAccountCommand,
- DisableSerialConsoleAccessCommand,
- DisableSnapshotBlockPublicAccessCommand,
- DisableTransitGatewayRouteTablePropagationCommand,
- DisableVgwRoutePropagationCommand,
- DisableVpcClassicLinkCommand,
- DisableVpcClassicLinkDnsSupportCommand,
- DisassociateAddressCommand,
- DisassociateClientVpnTargetNetworkCommand,
- DisassociateEnclaveCertificateIamRoleCommand,
- DisassociateIamInstanceProfileCommand,
- DisassociateInstanceEventWindowCommand,
- DisassociateIpamByoasnCommand,
- DisassociateIpamResourceDiscoveryCommand,
- DisassociateNatGatewayAddressCommand,
- DisassociateRouteTableCommand,
- DisassociateSubnetCidrBlockCommand,
- DisassociateTransitGatewayMulticastDomainCommand,
- DisassociateTransitGatewayPolicyTableCommand,
- DisassociateTransitGatewayRouteTableCommand,
- DisassociateTrunkInterfaceCommand,
- DisassociateVpcCidrBlockCommand,
- EnableAddressTransferCommand,
- EnableAwsNetworkPerformanceMetricSubscriptionCommand,
- EnableEbsEncryptionByDefaultCommand,
- EnableFastLaunchCommand,
- EnableFastSnapshotRestoresCommand,
- EnableImageCommand,
- EnableImageBlockPublicAccessCommand,
- EnableImageDeprecationCommand,
- EnableIpamOrganizationAdminAccountCommand,
- EnableReachabilityAnalyzerOrganizationSharingCommand,
- EnableSerialConsoleAccessCommand,
- EnableSnapshotBlockPublicAccessCommand,
- EnableTransitGatewayRouteTablePropagationCommand,
- EnableVgwRoutePropagationCommand,
- EnableVolumeIOCommand,
- EnableVpcClassicLinkCommand,
- EnableVpcClassicLinkDnsSupportCommand,
- ExportClientVpnClientCertificateRevocationListCommand,
- ExportClientVpnClientConfigurationCommand,
- ExportImageCommand,
- ExportTransitGatewayRoutesCommand,
- GetAssociatedEnclaveCertificateIamRolesCommand,
- GetAssociatedIpv6PoolCidrsCommand,
- GetAwsNetworkPerformanceDataCommand,
- GetCapacityReservationUsageCommand,
- GetCoipPoolUsageCommand,
- GetConsoleOutputCommand,
- GetConsoleScreenshotCommand,
- GetDefaultCreditSpecificationCommand,
- GetEbsDefaultKmsKeyIdCommand,
- GetEbsEncryptionByDefaultCommand,
- GetFlowLogsIntegrationTemplateCommand,
- GetGroupsForCapacityReservationCommand,
- GetHostReservationPurchasePreviewCommand,
- GetImageBlockPublicAccessStateCommand,
- GetInstanceMetadataDefaultsCommand,
- GetInstanceTypesFromInstanceRequirementsCommand,
- GetInstanceUefiDataCommand,
- GetIpamAddressHistoryCommand,
- GetIpamDiscoveredAccountsCommand,
- GetIpamDiscoveredPublicAddressesCommand,
- GetIpamDiscoveredResourceCidrsCommand,
- GetIpamPoolAllocationsCommand,
- GetIpamPoolCidrsCommand,
- GetIpamResourceCidrsCommand,
- GetLaunchTemplateDataCommand,
- GetManagedPrefixListAssociationsCommand,
- GetManagedPrefixListEntriesCommand,
- GetNetworkInsightsAccessScopeAnalysisFindingsCommand,
- GetNetworkInsightsAccessScopeContentCommand,
- GetPasswordDataCommand,
- GetReservedInstancesExchangeQuoteCommand,
- GetSecurityGroupsForVpcCommand,
- GetSerialConsoleAccessStatusCommand,
- GetSnapshotBlockPublicAccessStateCommand,
- GetSpotPlacementScoresCommand,
- GetSubnetCidrReservationsCommand,
- GetTransitGatewayAttachmentPropagationsCommand,
- GetTransitGatewayMulticastDomainAssociationsCommand,
- GetTransitGatewayPolicyTableAssociationsCommand,
- GetTransitGatewayPolicyTableEntriesCommand,
- GetTransitGatewayPrefixListReferencesCommand,
- GetTransitGatewayRouteTableAssociationsCommand,
- GetTransitGatewayRouteTablePropagationsCommand,
- GetVerifiedAccessEndpointPolicyCommand,
- GetVerifiedAccessGroupPolicyCommand,
- GetVpnConnectionDeviceSampleConfigurationCommand,
- GetVpnConnectionDeviceTypesCommand,
- GetVpnTunnelReplacementStatusCommand,
- ImportClientVpnClientCertificateRevocationListCommand,
- ImportImageCommand,
- ImportInstanceCommand,
- ImportKeyPairCommand,
- ImportSnapshotCommand,
- ImportVolumeCommand,
- ListImagesInRecycleBinCommand,
- ListSnapshotsInRecycleBinCommand,
- LockSnapshotCommand,
- ModifyAddressAttributeCommand,
- ModifyAvailabilityZoneGroupCommand,
- ModifyCapacityReservationCommand,
- ModifyCapacityReservationFleetCommand,
- ModifyClientVpnEndpointCommand,
- ModifyDefaultCreditSpecificationCommand,
- ModifyEbsDefaultKmsKeyIdCommand,
- ModifyFleetCommand,
- ModifyFpgaImageAttributeCommand,
- ModifyHostsCommand,
- ModifyIdFormatCommand,
- ModifyIdentityIdFormatCommand,
- ModifyImageAttributeCommand,
- ModifyInstanceAttributeCommand,
- ModifyInstanceCapacityReservationAttributesCommand,
- ModifyInstanceCreditSpecificationCommand,
- ModifyInstanceEventStartTimeCommand,
- ModifyInstanceEventWindowCommand,
- ModifyInstanceMaintenanceOptionsCommand,
- ModifyInstanceMetadataDefaultsCommand,
- ModifyInstanceMetadataOptionsCommand,
- ModifyInstancePlacementCommand,
- ModifyIpamCommand,
- ModifyIpamPoolCommand,
- ModifyIpamResourceCidrCommand,
- ModifyIpamResourceDiscoveryCommand,
- ModifyIpamScopeCommand,
- ModifyLaunchTemplateCommand,
- ModifyLocalGatewayRouteCommand,
- ModifyManagedPrefixListCommand,
- ModifyNetworkInterfaceAttributeCommand,
- ModifyPrivateDnsNameOptionsCommand,
- ModifyReservedInstancesCommand,
- ModifySecurityGroupRulesCommand,
- ModifySnapshotAttributeCommand,
- ModifySnapshotTierCommand,
- ModifySpotFleetRequestCommand,
- ModifySubnetAttributeCommand,
- ModifyTrafficMirrorFilterNetworkServicesCommand,
- ModifyTrafficMirrorFilterRuleCommand,
- ModifyTrafficMirrorSessionCommand,
- ModifyTransitGatewayCommand,
- ModifyTransitGatewayPrefixListReferenceCommand,
- ModifyTransitGatewayVpcAttachmentCommand,
- ModifyVerifiedAccessEndpointCommand,
- ModifyVerifiedAccessEndpointPolicyCommand,
- ModifyVerifiedAccessGroupCommand,
- ModifyVerifiedAccessGroupPolicyCommand,
- ModifyVerifiedAccessInstanceCommand,
- ModifyVerifiedAccessInstanceLoggingConfigurationCommand,
- ModifyVerifiedAccessTrustProviderCommand,
- ModifyVolumeCommand,
- ModifyVolumeAttributeCommand,
- ModifyVpcAttributeCommand,
- ModifyVpcEndpointCommand,
- ModifyVpcEndpointConnectionNotificationCommand,
- ModifyVpcEndpointServiceConfigurationCommand,
- ModifyVpcEndpointServicePayerResponsibilityCommand,
- ModifyVpcEndpointServicePermissionsCommand,
- ModifyVpcPeeringConnectionOptionsCommand,
- ModifyVpcTenancyCommand,
- ModifyVpnConnectionCommand,
- ModifyVpnConnectionOptionsCommand,
- ModifyVpnTunnelCertificateCommand,
- ModifyVpnTunnelOptionsCommand,
- MonitorInstancesCommand,
- MoveAddressToVpcCommand,
- MoveByoipCidrToIpamCommand,
- ProvisionByoipCidrCommand,
- ProvisionIpamByoasnCommand,
- ProvisionIpamPoolCidrCommand,
- ProvisionPublicIpv4PoolCidrCommand,
- PurchaseCapacityBlockCommand,
- PurchaseHostReservationCommand,
- PurchaseReservedInstancesOfferingCommand,
- PurchaseScheduledInstancesCommand,
- RebootInstancesCommand,
- RegisterImageCommand,
- RegisterInstanceEventNotificationAttributesCommand,
- RegisterTransitGatewayMulticastGroupMembersCommand,
- RegisterTransitGatewayMulticastGroupSourcesCommand,
- RejectTransitGatewayMulticastDomainAssociationsCommand,
- RejectTransitGatewayPeeringAttachmentCommand,
- RejectTransitGatewayVpcAttachmentCommand,
- RejectVpcEndpointConnectionsCommand,
- RejectVpcPeeringConnectionCommand,
- ReleaseAddressCommand,
- ReleaseHostsCommand,
- ReleaseIpamPoolAllocationCommand,
- ReplaceIamInstanceProfileAssociationCommand,
- ReplaceNetworkAclAssociationCommand,
- ReplaceNetworkAclEntryCommand,
- ReplaceRouteCommand,
- ReplaceRouteTableAssociationCommand,
- ReplaceTransitGatewayRouteCommand,
- ReplaceVpnTunnelCommand,
- ReportInstanceStatusCommand,
- RequestSpotFleetCommand,
- RequestSpotInstancesCommand,
- ResetAddressAttributeCommand,
- ResetEbsDefaultKmsKeyIdCommand,
- ResetFpgaImageAttributeCommand,
- ResetImageAttributeCommand,
- ResetInstanceAttributeCommand,
- ResetNetworkInterfaceAttributeCommand,
- ResetSnapshotAttributeCommand,
- RestoreAddressToClassicCommand,
- RestoreImageFromRecycleBinCommand,
- RestoreManagedPrefixListVersionCommand,
- RestoreSnapshotFromRecycleBinCommand,
- RestoreSnapshotTierCommand,
- RevokeClientVpnIngressCommand,
- RevokeSecurityGroupEgressCommand,
- RevokeSecurityGroupIngressCommand,
- RunInstancesCommand,
- RunScheduledInstancesCommand,
- SearchLocalGatewayRoutesCommand,
- SearchTransitGatewayMulticastGroupsCommand,
- SearchTransitGatewayRoutesCommand,
- SendDiagnosticInterruptCommand,
- StartInstancesCommand,
- StartNetworkInsightsAccessScopeAnalysisCommand,
- StartNetworkInsightsAnalysisCommand,
- StartVpcEndpointServicePrivateDnsVerificationCommand,
- StopInstancesCommand,
- TerminateClientVpnConnectionsCommand,
- TerminateInstancesCommand,
- UnassignIpv6AddressesCommand,
- UnassignPrivateIpAddressesCommand,
- UnassignPrivateNatGatewayAddressCommand,
- UnlockSnapshotCommand,
- UnmonitorInstancesCommand,
- UpdateSecurityGroupRuleDescriptionsEgressCommand,
- UpdateSecurityGroupRuleDescriptionsIngressCommand,
- WithdrawByoipCidrCommand
+  AcceptReservedInstancesExchangeQuoteCommand,
+  AcceptTransitGatewayMulticastDomainAssociationsCommand,
+  AcceptTransitGatewayPeeringAttachmentCommand,
+  AcceptTransitGatewayVpcAttachmentCommand,
+  AcceptVpcEndpointConnectionsCommand,
+  AcceptVpcPeeringConnectionCommand,
+  AdvertiseByoipCidrCommand,
+  AllocateAddressCommand,
+  AllocateHostsCommand,
+  AllocateIpamPoolCidrCommand,
+  ApplySecurityGroupsToClientVpnTargetNetworkCommand,
+  AssignIpv6AddressesCommand,
+  AssignPrivateIpAddressesCommand,
+  AssignPrivateNatGatewayAddressCommand,
+  AssociateAddressCommand,
+  AssociateClientVpnTargetNetworkCommand,
+  AssociateDhcpOptionsCommand,
+  AssociateEnclaveCertificateIamRoleCommand,
+  AssociateIamInstanceProfileCommand,
+  AssociateInstanceEventWindowCommand,
+  AssociateIpamByoasnCommand,
+  AssociateIpamResourceDiscoveryCommand,
+  AssociateNatGatewayAddressCommand,
+  AssociateRouteTableCommand,
+  AssociateSubnetCidrBlockCommand,
+  AssociateTransitGatewayMulticastDomainCommand,
+  AssociateTransitGatewayPolicyTableCommand,
+  AssociateTransitGatewayRouteTableCommand,
+  AssociateTrunkInterfaceCommand,
+  AssociateVpcCidrBlockCommand,
+  AttachClassicLinkVpcCommand,
+  AttachInternetGatewayCommand,
+  AttachNetworkInterfaceCommand,
+  AttachVerifiedAccessTrustProviderCommand,
+  AttachVolumeCommand,
+  AttachVpnGatewayCommand,
+  AuthorizeClientVpnIngressCommand,
+  AuthorizeSecurityGroupEgressCommand,
+  AuthorizeSecurityGroupIngressCommand,
+  BundleInstanceCommand,
+  CancelBundleTaskCommand,
+  CancelCapacityReservationCommand,
+  CancelCapacityReservationFleetsCommand,
+  CancelConversionTaskCommand,
+  CancelExportTaskCommand,
+  CancelImageLaunchPermissionCommand,
+  CancelImportTaskCommand,
+  CancelReservedInstancesListingCommand,
+  CancelSpotFleetRequestsCommand,
+  CancelSpotInstanceRequestsCommand,
+  ConfirmProductInstanceCommand,
+  CopyFpgaImageCommand,
+  CopyImageCommand,
+  CopySnapshotCommand,
+  CreateCapacityReservationCommand,
+  CreateCapacityReservationFleetCommand,
+  CreateCarrierGatewayCommand,
+  CreateClientVpnEndpointCommand,
+  CreateClientVpnRouteCommand,
+  CreateCoipCidrCommand,
+  CreateCoipPoolCommand,
+  CreateCustomerGatewayCommand,
+  CreateDefaultSubnetCommand,
+  CreateDefaultVpcCommand,
+  CreateDhcpOptionsCommand,
+  CreateEgressOnlyInternetGatewayCommand,
+  CreateFleetCommand,
+  CreateFlowLogsCommand,
+  CreateFpgaImageCommand,
+  CreateImageCommand,
+  CreateInstanceConnectEndpointCommand,
+  CreateInstanceEventWindowCommand,
+  CreateInstanceExportTaskCommand,
+  CreateInternetGatewayCommand,
+  CreateIpamCommand,
+  CreateIpamPoolCommand,
+  CreateIpamResourceDiscoveryCommand,
+  CreateIpamScopeCommand,
+  CreateKeyPairCommand,
+  CreateLaunchTemplateCommand,
+  CreateLaunchTemplateVersionCommand,
+  CreateLocalGatewayRouteCommand,
+  CreateLocalGatewayRouteTableCommand,
+  CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
+  CreateLocalGatewayRouteTableVpcAssociationCommand,
+  CreateManagedPrefixListCommand,
+  CreateNatGatewayCommand,
+  CreateNetworkAclCommand,
+  CreateNetworkAclEntryCommand,
+  CreateNetworkInsightsAccessScopeCommand,
+  CreateNetworkInsightsPathCommand,
+  CreateNetworkInterfaceCommand,
+  CreateNetworkInterfacePermissionCommand,
+  CreatePlacementGroupCommand,
+  CreatePublicIpv4PoolCommand,
+  CreateReplaceRootVolumeTaskCommand,
+  CreateReservedInstancesListingCommand,
+  CreateRestoreImageTaskCommand,
+  CreateRouteCommand,
+  CreateRouteTableCommand,
+  CreateSecurityGroupCommand,
+  CreateSnapshotCommand,
+  CreateSnapshotsCommand,
+  CreateSpotDatafeedSubscriptionCommand,
+  CreateStoreImageTaskCommand,
+  CreateSubnetCommand,
+  CreateSubnetCidrReservationCommand,
+  CreateTagsCommand,
+  CreateTrafficMirrorFilterCommand,
+  CreateTrafficMirrorFilterRuleCommand,
+  CreateTrafficMirrorSessionCommand,
+  CreateTrafficMirrorTargetCommand,
+  CreateTransitGatewayCommand,
+  CreateTransitGatewayConnectCommand,
+  CreateTransitGatewayConnectPeerCommand,
+  CreateTransitGatewayMulticastDomainCommand,
+  CreateTransitGatewayPeeringAttachmentCommand,
+  CreateTransitGatewayPolicyTableCommand,
+  CreateTransitGatewayPrefixListReferenceCommand,
+  CreateTransitGatewayRouteCommand,
+  CreateTransitGatewayRouteTableCommand,
+  CreateTransitGatewayRouteTableAnnouncementCommand,
+  CreateTransitGatewayVpcAttachmentCommand,
+  CreateVerifiedAccessEndpointCommand,
+  CreateVerifiedAccessGroupCommand,
+  CreateVerifiedAccessInstanceCommand,
+  CreateVerifiedAccessTrustProviderCommand,
+  CreateVolumeCommand,
+  CreateVpcCommand,
+  CreateVpcEndpointCommand,
+  CreateVpcEndpointConnectionNotificationCommand,
+  CreateVpcEndpointServiceConfigurationCommand,
+  CreateVpcPeeringConnectionCommand,
+  CreateVpnConnectionCommand,
+  CreateVpnConnectionRouteCommand,
+  CreateVpnGatewayCommand,
+  DeleteCarrierGatewayCommand,
+  DeleteClientVpnEndpointCommand,
+  DeleteClientVpnRouteCommand,
+  DeleteCoipCidrCommand,
+  DeleteCoipPoolCommand,
+  DeleteCustomerGatewayCommand,
+  DeleteDhcpOptionsCommand,
+  DeleteEgressOnlyInternetGatewayCommand,
+  DeleteFleetsCommand,
+  DeleteFlowLogsCommand,
+  DeleteFpgaImageCommand,
+  DeleteInstanceConnectEndpointCommand,
+  DeleteInstanceEventWindowCommand,
+  DeleteInternetGatewayCommand,
+  DeleteIpamCommand,
+  DeleteIpamPoolCommand,
+  DeleteIpamResourceDiscoveryCommand,
+  DeleteIpamScopeCommand,
+  DeleteKeyPairCommand,
+  DeleteLaunchTemplateCommand,
+  DeleteLaunchTemplateVersionsCommand,
+  DeleteLocalGatewayRouteCommand,
+  DeleteLocalGatewayRouteTableCommand,
+  DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
+  DeleteLocalGatewayRouteTableVpcAssociationCommand,
+  DeleteManagedPrefixListCommand,
+  DeleteNatGatewayCommand,
+  DeleteNetworkAclCommand,
+  DeleteNetworkAclEntryCommand,
+  DeleteNetworkInsightsAccessScopeCommand,
+  DeleteNetworkInsightsAccessScopeAnalysisCommand,
+  DeleteNetworkInsightsAnalysisCommand,
+  DeleteNetworkInsightsPathCommand,
+  DeleteNetworkInterfaceCommand,
+  DeleteNetworkInterfacePermissionCommand,
+  DeletePlacementGroupCommand,
+  DeletePublicIpv4PoolCommand,
+  DeleteQueuedReservedInstancesCommand,
+  DeleteRouteCommand,
+  DeleteRouteTableCommand,
+  DeleteSecurityGroupCommand,
+  DeleteSnapshotCommand,
+  DeleteSpotDatafeedSubscriptionCommand,
+  DeleteSubnetCommand,
+  DeleteSubnetCidrReservationCommand,
+  DeleteTagsCommand,
+  DeleteTrafficMirrorFilterCommand,
+  DeleteTrafficMirrorFilterRuleCommand,
+  DeleteTrafficMirrorSessionCommand,
+  DeleteTrafficMirrorTargetCommand,
+  DeleteTransitGatewayCommand,
+  DeleteTransitGatewayConnectCommand,
+  DeleteTransitGatewayConnectPeerCommand,
+  DeleteTransitGatewayMulticastDomainCommand,
+  DeleteTransitGatewayPeeringAttachmentCommand,
+  DeleteTransitGatewayPolicyTableCommand,
+  DeleteTransitGatewayPrefixListReferenceCommand,
+  DeleteTransitGatewayRouteCommand,
+  DeleteTransitGatewayRouteTableCommand,
+  DeleteTransitGatewayRouteTableAnnouncementCommand,
+  DeleteTransitGatewayVpcAttachmentCommand,
+  DeleteVerifiedAccessEndpointCommand,
+  DeleteVerifiedAccessGroupCommand,
+  DeleteVerifiedAccessInstanceCommand,
+  DeleteVerifiedAccessTrustProviderCommand,
+  DeleteVolumeCommand,
+  DeleteVpcCommand,
+  DeleteVpcEndpointConnectionNotificationsCommand,
+  DeleteVpcEndpointServiceConfigurationsCommand,
+  DeleteVpcEndpointsCommand,
+  DeleteVpcPeeringConnectionCommand,
+  DeleteVpnConnectionCommand,
+  DeleteVpnConnectionRouteCommand,
+  DeleteVpnGatewayCommand,
+  DeprovisionByoipCidrCommand,
+  DeprovisionIpamByoasnCommand,
+  DeprovisionIpamPoolCidrCommand,
+  DeprovisionPublicIpv4PoolCidrCommand,
+  DeregisterImageCommand,
+  DeregisterInstanceEventNotificationAttributesCommand,
+  DeregisterTransitGatewayMulticastGroupMembersCommand,
+  DeregisterTransitGatewayMulticastGroupSourcesCommand,
+  DescribeAccountAttributesCommand,
+  DescribeAddressTransfersCommand,
+  DescribeAddressesCommand,
+  DescribeAddressesAttributeCommand,
+  DescribeAggregateIdFormatCommand,
+  DescribeAvailabilityZonesCommand,
+  DescribeAwsNetworkPerformanceMetricSubscriptionsCommand,
+  DescribeBundleTasksCommand,
+  DescribeByoipCidrsCommand,
+  DescribeCapacityBlockOfferingsCommand,
+  DescribeCapacityReservationFleetsCommand,
+  DescribeCapacityReservationsCommand,
+  DescribeCarrierGatewaysCommand,
+  DescribeClassicLinkInstancesCommand,
+  DescribeClientVpnAuthorizationRulesCommand,
+  DescribeClientVpnConnectionsCommand,
+  DescribeClientVpnEndpointsCommand,
+  DescribeClientVpnRoutesCommand,
+  DescribeClientVpnTargetNetworksCommand,
+  DescribeCoipPoolsCommand,
+  DescribeConversionTasksCommand,
+  DescribeCustomerGatewaysCommand,
+  DescribeDhcpOptionsCommand,
+  DescribeEgressOnlyInternetGatewaysCommand,
+  DescribeElasticGpusCommand,
+  DescribeExportImageTasksCommand,
+  DescribeExportTasksCommand,
+  DescribeFastLaunchImagesCommand,
+  DescribeFastSnapshotRestoresCommand,
+  DescribeFleetHistoryCommand,
+  DescribeFleetInstancesCommand,
+  DescribeFleetsCommand,
+  DescribeFlowLogsCommand,
+  DescribeFpgaImageAttributeCommand,
+  DescribeFpgaImagesCommand,
+  DescribeHostReservationOfferingsCommand,
+  DescribeHostReservationsCommand,
+  DescribeHostsCommand,
+  DescribeIamInstanceProfileAssociationsCommand,
+  DescribeIdFormatCommand,
+  DescribeIdentityIdFormatCommand,
+  DescribeImageAttributeCommand,
+  DescribeImagesCommand,
+  DescribeImportImageTasksCommand,
+  DescribeImportSnapshotTasksCommand,
+  DescribeInstanceAttributeCommand,
+  DescribeInstanceConnectEndpointsCommand,
+  DescribeInstanceCreditSpecificationsCommand,
+  DescribeInstanceEventNotificationAttributesCommand,
+  DescribeInstanceEventWindowsCommand,
+  DescribeInstanceStatusCommand,
+  DescribeInstanceTopologyCommand,
+  DescribeInstanceTypeOfferingsCommand,
+  DescribeInstanceTypesCommand,
+  DescribeInstancesCommand,
+  DescribeInternetGatewaysCommand,
+  DescribeIpamByoasnCommand,
+  DescribeIpamPoolsCommand,
+  DescribeIpamResourceDiscoveriesCommand,
+  DescribeIpamResourceDiscoveryAssociationsCommand,
+  DescribeIpamScopesCommand,
+  DescribeIpamsCommand,
+  DescribeIpv6PoolsCommand,
+  DescribeKeyPairsCommand,
+  DescribeLaunchTemplateVersionsCommand,
+  DescribeLaunchTemplatesCommand,
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
+  DescribeLocalGatewayRouteTableVpcAssociationsCommand,
+  DescribeLocalGatewayRouteTablesCommand,
+  DescribeLocalGatewayVirtualInterfaceGroupsCommand,
+  DescribeLocalGatewayVirtualInterfacesCommand,
+  DescribeLocalGatewaysCommand,
+  DescribeLockedSnapshotsCommand,
+  DescribeMacHostsCommand,
+  DescribeManagedPrefixListsCommand,
+  DescribeMovingAddressesCommand,
+  DescribeNatGatewaysCommand,
+  DescribeNetworkAclsCommand,
+  DescribeNetworkInsightsAccessScopeAnalysesCommand,
+  DescribeNetworkInsightsAccessScopesCommand,
+  DescribeNetworkInsightsAnalysesCommand,
+  DescribeNetworkInsightsPathsCommand,
+  DescribeNetworkInterfaceAttributeCommand,
+  DescribeNetworkInterfacePermissionsCommand,
+  DescribeNetworkInterfacesCommand,
+  DescribePlacementGroupsCommand,
+  DescribePrefixListsCommand,
+  DescribePrincipalIdFormatCommand,
+  DescribePublicIpv4PoolsCommand,
+  DescribeRegionsCommand,
+  DescribeReplaceRootVolumeTasksCommand,
+  DescribeReservedInstancesCommand,
+  DescribeReservedInstancesListingsCommand,
+  DescribeReservedInstancesModificationsCommand,
+  DescribeReservedInstancesOfferingsCommand,
+  DescribeRouteTablesCommand,
+  DescribeScheduledInstanceAvailabilityCommand,
+  DescribeScheduledInstancesCommand,
+  DescribeSecurityGroupReferencesCommand,
+  DescribeSecurityGroupRulesCommand,
+  DescribeSecurityGroupsCommand,
+  DescribeSnapshotAttributeCommand,
+  DescribeSnapshotTierStatusCommand,
+  DescribeSnapshotsCommand,
+  DescribeSpotDatafeedSubscriptionCommand,
+  DescribeSpotFleetInstancesCommand,
+  DescribeSpotFleetRequestHistoryCommand,
+  DescribeSpotFleetRequestsCommand,
+  DescribeSpotInstanceRequestsCommand,
+  DescribeSpotPriceHistoryCommand,
+  DescribeStaleSecurityGroupsCommand,
+  DescribeStoreImageTasksCommand,
+  DescribeSubnetsCommand,
+  DescribeTagsCommand,
+  DescribeTrafficMirrorFiltersCommand,
+  DescribeTrafficMirrorSessionsCommand,
+  DescribeTrafficMirrorTargetsCommand,
+  DescribeTransitGatewayAttachmentsCommand,
+  DescribeTransitGatewayConnectPeersCommand,
+  DescribeTransitGatewayConnectsCommand,
+  DescribeTransitGatewayMulticastDomainsCommand,
+  DescribeTransitGatewayPeeringAttachmentsCommand,
+  DescribeTransitGatewayPolicyTablesCommand,
+  DescribeTransitGatewayRouteTableAnnouncementsCommand,
+  DescribeTransitGatewayRouteTablesCommand,
+  DescribeTransitGatewayVpcAttachmentsCommand,
+  DescribeTransitGatewaysCommand,
+  DescribeTrunkInterfaceAssociationsCommand,
+  DescribeVerifiedAccessEndpointsCommand,
+  DescribeVerifiedAccessGroupsCommand,
+  DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
+  DescribeVerifiedAccessInstancesCommand,
+  DescribeVerifiedAccessTrustProvidersCommand,
+  DescribeVolumeAttributeCommand,
+  DescribeVolumeStatusCommand,
+  DescribeVolumesCommand,
+  DescribeVolumesModificationsCommand,
+  DescribeVpcAttributeCommand,
+  DescribeVpcClassicLinkCommand,
+  DescribeVpcClassicLinkDnsSupportCommand,
+  DescribeVpcEndpointConnectionNotificationsCommand,
+  DescribeVpcEndpointConnectionsCommand,
+  DescribeVpcEndpointServiceConfigurationsCommand,
+  DescribeVpcEndpointServicePermissionsCommand,
+  DescribeVpcEndpointServicesCommand,
+  DescribeVpcEndpointsCommand,
+  DescribeVpcPeeringConnectionsCommand,
+  DescribeVpcsCommand,
+  DescribeVpnConnectionsCommand,
+  DescribeVpnGatewaysCommand,
+  DetachClassicLinkVpcCommand,
+  DetachInternetGatewayCommand,
+  DetachNetworkInterfaceCommand,
+  DetachVerifiedAccessTrustProviderCommand,
+  DetachVolumeCommand,
+  DetachVpnGatewayCommand,
+  DisableAddressTransferCommand,
+  DisableAwsNetworkPerformanceMetricSubscriptionCommand,
+  DisableEbsEncryptionByDefaultCommand,
+  DisableFastLaunchCommand,
+  DisableFastSnapshotRestoresCommand,
+  DisableImageCommand,
+  DisableImageBlockPublicAccessCommand,
+  DisableImageDeprecationCommand,
+  DisableIpamOrganizationAdminAccountCommand,
+  DisableSerialConsoleAccessCommand,
+  DisableSnapshotBlockPublicAccessCommand,
+  DisableTransitGatewayRouteTablePropagationCommand,
+  DisableVgwRoutePropagationCommand,
+  DisableVpcClassicLinkCommand,
+  DisableVpcClassicLinkDnsSupportCommand,
+  DisassociateAddressCommand,
+  DisassociateClientVpnTargetNetworkCommand,
+  DisassociateEnclaveCertificateIamRoleCommand,
+  DisassociateIamInstanceProfileCommand,
+  DisassociateInstanceEventWindowCommand,
+  DisassociateIpamByoasnCommand,
+  DisassociateIpamResourceDiscoveryCommand,
+  DisassociateNatGatewayAddressCommand,
+  DisassociateRouteTableCommand,
+  DisassociateSubnetCidrBlockCommand,
+  DisassociateTransitGatewayMulticastDomainCommand,
+  DisassociateTransitGatewayPolicyTableCommand,
+  DisassociateTransitGatewayRouteTableCommand,
+  DisassociateTrunkInterfaceCommand,
+  DisassociateVpcCidrBlockCommand,
+  EnableAddressTransferCommand,
+  EnableAwsNetworkPerformanceMetricSubscriptionCommand,
+  EnableEbsEncryptionByDefaultCommand,
+  EnableFastLaunchCommand,
+  EnableFastSnapshotRestoresCommand,
+  EnableImageCommand,
+  EnableImageBlockPublicAccessCommand,
+  EnableImageDeprecationCommand,
+  EnableIpamOrganizationAdminAccountCommand,
+  EnableReachabilityAnalyzerOrganizationSharingCommand,
+  EnableSerialConsoleAccessCommand,
+  EnableSnapshotBlockPublicAccessCommand,
+  EnableTransitGatewayRouteTablePropagationCommand,
+  EnableVgwRoutePropagationCommand,
+  EnableVolumeIOCommand,
+  EnableVpcClassicLinkCommand,
+  EnableVpcClassicLinkDnsSupportCommand,
+  ExportClientVpnClientCertificateRevocationListCommand,
+  ExportClientVpnClientConfigurationCommand,
+  ExportImageCommand,
+  ExportTransitGatewayRoutesCommand,
+  GetAssociatedEnclaveCertificateIamRolesCommand,
+  GetAssociatedIpv6PoolCidrsCommand,
+  GetAwsNetworkPerformanceDataCommand,
+  GetCapacityReservationUsageCommand,
+  GetCoipPoolUsageCommand,
+  GetConsoleOutputCommand,
+  GetConsoleScreenshotCommand,
+  GetDefaultCreditSpecificationCommand,
+  GetEbsDefaultKmsKeyIdCommand,
+  GetEbsEncryptionByDefaultCommand,
+  GetFlowLogsIntegrationTemplateCommand,
+  GetGroupsForCapacityReservationCommand,
+  GetHostReservationPurchasePreviewCommand,
+  GetImageBlockPublicAccessStateCommand,
+  GetInstanceMetadataDefaultsCommand,
+  GetInstanceTypesFromInstanceRequirementsCommand,
+  GetInstanceUefiDataCommand,
+  GetIpamAddressHistoryCommand,
+  GetIpamDiscoveredAccountsCommand,
+  GetIpamDiscoveredPublicAddressesCommand,
+  GetIpamDiscoveredResourceCidrsCommand,
+  GetIpamPoolAllocationsCommand,
+  GetIpamPoolCidrsCommand,
+  GetIpamResourceCidrsCommand,
+  GetLaunchTemplateDataCommand,
+  GetManagedPrefixListAssociationsCommand,
+  GetManagedPrefixListEntriesCommand,
+  GetNetworkInsightsAccessScopeAnalysisFindingsCommand,
+  GetNetworkInsightsAccessScopeContentCommand,
+  GetPasswordDataCommand,
+  GetReservedInstancesExchangeQuoteCommand,
+  GetSecurityGroupsForVpcCommand,
+  GetSerialConsoleAccessStatusCommand,
+  GetSnapshotBlockPublicAccessStateCommand,
+  GetSpotPlacementScoresCommand,
+  GetSubnetCidrReservationsCommand,
+  GetTransitGatewayAttachmentPropagationsCommand,
+  GetTransitGatewayMulticastDomainAssociationsCommand,
+  GetTransitGatewayPolicyTableAssociationsCommand,
+  GetTransitGatewayPolicyTableEntriesCommand,
+  GetTransitGatewayPrefixListReferencesCommand,
+  GetTransitGatewayRouteTableAssociationsCommand,
+  GetTransitGatewayRouteTablePropagationsCommand,
+  GetVerifiedAccessEndpointPolicyCommand,
+  GetVerifiedAccessGroupPolicyCommand,
+  GetVpnConnectionDeviceSampleConfigurationCommand,
+  GetVpnConnectionDeviceTypesCommand,
+  GetVpnTunnelReplacementStatusCommand,
+  ImportClientVpnClientCertificateRevocationListCommand,
+  ImportImageCommand,
+  ImportInstanceCommand,
+  ImportKeyPairCommand,
+  ImportSnapshotCommand,
+  ImportVolumeCommand,
+  ListImagesInRecycleBinCommand,
+  ListSnapshotsInRecycleBinCommand,
+  LockSnapshotCommand,
+  ModifyAddressAttributeCommand,
+  ModifyAvailabilityZoneGroupCommand,
+  ModifyCapacityReservationCommand,
+  ModifyCapacityReservationFleetCommand,
+  ModifyClientVpnEndpointCommand,
+  ModifyDefaultCreditSpecificationCommand,
+  ModifyEbsDefaultKmsKeyIdCommand,
+  ModifyFleetCommand,
+  ModifyFpgaImageAttributeCommand,
+  ModifyHostsCommand,
+  ModifyIdFormatCommand,
+  ModifyIdentityIdFormatCommand,
+  ModifyImageAttributeCommand,
+  ModifyInstanceAttributeCommand,
+  ModifyInstanceCapacityReservationAttributesCommand,
+  ModifyInstanceCreditSpecificationCommand,
+  ModifyInstanceEventStartTimeCommand,
+  ModifyInstanceEventWindowCommand,
+  ModifyInstanceMaintenanceOptionsCommand,
+  ModifyInstanceMetadataDefaultsCommand,
+  ModifyInstanceMetadataOptionsCommand,
+  ModifyInstancePlacementCommand,
+  ModifyIpamCommand,
+  ModifyIpamPoolCommand,
+  ModifyIpamResourceCidrCommand,
+  ModifyIpamResourceDiscoveryCommand,
+  ModifyIpamScopeCommand,
+  ModifyLaunchTemplateCommand,
+  ModifyLocalGatewayRouteCommand,
+  ModifyManagedPrefixListCommand,
+  ModifyNetworkInterfaceAttributeCommand,
+  ModifyPrivateDnsNameOptionsCommand,
+  ModifyReservedInstancesCommand,
+  ModifySecurityGroupRulesCommand,
+  ModifySnapshotAttributeCommand,
+  ModifySnapshotTierCommand,
+  ModifySpotFleetRequestCommand,
+  ModifySubnetAttributeCommand,
+  ModifyTrafficMirrorFilterNetworkServicesCommand,
+  ModifyTrafficMirrorFilterRuleCommand,
+  ModifyTrafficMirrorSessionCommand,
+  ModifyTransitGatewayCommand,
+  ModifyTransitGatewayPrefixListReferenceCommand,
+  ModifyTransitGatewayVpcAttachmentCommand,
+  ModifyVerifiedAccessEndpointCommand,
+  ModifyVerifiedAccessEndpointPolicyCommand,
+  ModifyVerifiedAccessGroupCommand,
+  ModifyVerifiedAccessGroupPolicyCommand,
+  ModifyVerifiedAccessInstanceCommand,
+  ModifyVerifiedAccessInstanceLoggingConfigurationCommand,
+  ModifyVerifiedAccessTrustProviderCommand,
+  ModifyVolumeCommand,
+  ModifyVolumeAttributeCommand,
+  ModifyVpcAttributeCommand,
+  ModifyVpcEndpointCommand,
+  ModifyVpcEndpointConnectionNotificationCommand,
+  ModifyVpcEndpointServiceConfigurationCommand,
+  ModifyVpcEndpointServicePayerResponsibilityCommand,
+  ModifyVpcEndpointServicePermissionsCommand,
+  ModifyVpcPeeringConnectionOptionsCommand,
+  ModifyVpcTenancyCommand,
+  ModifyVpnConnectionCommand,
+  ModifyVpnConnectionOptionsCommand,
+  ModifyVpnTunnelCertificateCommand,
+  ModifyVpnTunnelOptionsCommand,
+  MonitorInstancesCommand,
+  MoveAddressToVpcCommand,
+  MoveByoipCidrToIpamCommand,
+  ProvisionByoipCidrCommand,
+  ProvisionIpamByoasnCommand,
+  ProvisionIpamPoolCidrCommand,
+  ProvisionPublicIpv4PoolCidrCommand,
+  PurchaseCapacityBlockCommand,
+  PurchaseHostReservationCommand,
+  PurchaseReservedInstancesOfferingCommand,
+  PurchaseScheduledInstancesCommand,
+  RebootInstancesCommand,
+  RegisterImageCommand,
+  RegisterInstanceEventNotificationAttributesCommand,
+  RegisterTransitGatewayMulticastGroupMembersCommand,
+  RegisterTransitGatewayMulticastGroupSourcesCommand,
+  RejectTransitGatewayMulticastDomainAssociationsCommand,
+  RejectTransitGatewayPeeringAttachmentCommand,
+  RejectTransitGatewayVpcAttachmentCommand,
+  RejectVpcEndpointConnectionsCommand,
+  RejectVpcPeeringConnectionCommand,
+  ReleaseAddressCommand,
+  ReleaseHostsCommand,
+  ReleaseIpamPoolAllocationCommand,
+  ReplaceIamInstanceProfileAssociationCommand,
+  ReplaceNetworkAclAssociationCommand,
+  ReplaceNetworkAclEntryCommand,
+  ReplaceRouteCommand,
+  ReplaceRouteTableAssociationCommand,
+  ReplaceTransitGatewayRouteCommand,
+  ReplaceVpnTunnelCommand,
+  ReportInstanceStatusCommand,
+  RequestSpotFleetCommand,
+  RequestSpotInstancesCommand,
+  ResetAddressAttributeCommand,
+  ResetEbsDefaultKmsKeyIdCommand,
+  ResetFpgaImageAttributeCommand,
+  ResetImageAttributeCommand,
+  ResetInstanceAttributeCommand,
+  ResetNetworkInterfaceAttributeCommand,
+  ResetSnapshotAttributeCommand,
+  RestoreAddressToClassicCommand,
+  RestoreImageFromRecycleBinCommand,
+  RestoreManagedPrefixListVersionCommand,
+  RestoreSnapshotFromRecycleBinCommand,
+  RestoreSnapshotTierCommand,
+  RevokeClientVpnIngressCommand,
+  RevokeSecurityGroupEgressCommand,
+  RevokeSecurityGroupIngressCommand,
+  RunInstancesCommand,
+  RunScheduledInstancesCommand,
+  SearchLocalGatewayRoutesCommand,
+  SearchTransitGatewayMulticastGroupsCommand,
+  SearchTransitGatewayRoutesCommand,
+  SendDiagnosticInterruptCommand,
+  StartInstancesCommand,
+  StartNetworkInsightsAccessScopeAnalysisCommand,
+  StartNetworkInsightsAnalysisCommand,
+  StartVpcEndpointServicePrivateDnsVerificationCommand,
+  StopInstancesCommand,
+  TerminateClientVpnConnectionsCommand,
+  TerminateInstancesCommand,
+  UnassignIpv6AddressesCommand,
+  UnassignPrivateIpAddressesCommand,
+  UnassignPrivateNatGatewayAddressCommand,
+  UnlockSnapshotCommand,
+  UnmonitorInstancesCommand,
+  UpdateSecurityGroupRuleDescriptionsEgressCommand,
+  UpdateSecurityGroupRuleDescriptionsIngressCommand,
+  WithdrawByoipCidrCommand,
 };
 
 /**
@@ -2448,10 +2442,7 @@ export interface EC2Service {
   acceptAddressTransfer(
     args: AcceptAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptAddressTransferResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptAddressTransferResult, SdkError>;
 
   /**
    * @see {@link AcceptReservedInstancesExchangeQuoteCommand}
@@ -2459,10 +2450,7 @@ export interface EC2Service {
   acceptReservedInstancesExchangeQuote(
     args: AcceptReservedInstancesExchangeQuoteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptReservedInstancesExchangeQuoteResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptReservedInstancesExchangeQuoteResult, SdkError>;
 
   /**
    * @see {@link AcceptTransitGatewayMulticastDomainAssociationsCommand}
@@ -2471,9 +2459,9 @@ export interface EC2Service {
     args: AcceptTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  AcceptTransitGatewayMulticastDomainAssociationsResult,
-    | SdkError
-  >
+    AcceptTransitGatewayMulticastDomainAssociationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link AcceptTransitGatewayPeeringAttachmentCommand}
@@ -2481,10 +2469,7 @@ export interface EC2Service {
   acceptTransitGatewayPeeringAttachment(
     args: AcceptTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptTransitGatewayPeeringAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptTransitGatewayPeeringAttachmentResult, SdkError>;
 
   /**
    * @see {@link AcceptTransitGatewayVpcAttachmentCommand}
@@ -2492,10 +2477,7 @@ export interface EC2Service {
   acceptTransitGatewayVpcAttachment(
     args: AcceptTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptTransitGatewayVpcAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptTransitGatewayVpcAttachmentResult, SdkError>;
 
   /**
    * @see {@link AcceptVpcEndpointConnectionsCommand}
@@ -2503,10 +2485,7 @@ export interface EC2Service {
   acceptVpcEndpointConnections(
     args: AcceptVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptVpcEndpointConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptVpcEndpointConnectionsResult, SdkError>;
 
   /**
    * @see {@link AcceptVpcPeeringConnectionCommand}
@@ -2514,10 +2493,7 @@ export interface EC2Service {
   acceptVpcPeeringConnection(
     args: AcceptVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AcceptVpcPeeringConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<AcceptVpcPeeringConnectionResult, SdkError>;
 
   /**
    * @see {@link AdvertiseByoipCidrCommand}
@@ -2525,10 +2501,7 @@ export interface EC2Service {
   advertiseByoipCidr(
     args: AdvertiseByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AdvertiseByoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<AdvertiseByoipCidrResult, SdkError>;
 
   /**
    * @see {@link AllocateAddressCommand}
@@ -2536,10 +2509,7 @@ export interface EC2Service {
   allocateAddress(
     args: AllocateAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AllocateAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AllocateAddressResult, SdkError>;
 
   /**
    * @see {@link AllocateHostsCommand}
@@ -2547,10 +2517,7 @@ export interface EC2Service {
   allocateHosts(
     args: AllocateHostsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AllocateHostsResult,
-    | SdkError
-  >
+  ): Effect.Effect<AllocateHostsResult, SdkError>;
 
   /**
    * @see {@link AllocateIpamPoolCidrCommand}
@@ -2558,10 +2525,7 @@ export interface EC2Service {
   allocateIpamPoolCidr(
     args: AllocateIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AllocateIpamPoolCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<AllocateIpamPoolCidrResult, SdkError>;
 
   /**
    * @see {@link ApplySecurityGroupsToClientVpnTargetNetworkCommand}
@@ -2569,10 +2533,7 @@ export interface EC2Service {
   applySecurityGroupsToClientVpnTargetNetwork(
     args: ApplySecurityGroupsToClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ApplySecurityGroupsToClientVpnTargetNetworkResult,
-    | SdkError
-  >
+  ): Effect.Effect<ApplySecurityGroupsToClientVpnTargetNetworkResult, SdkError>;
 
   /**
    * @see {@link AssignIpv6AddressesCommand}
@@ -2580,10 +2541,7 @@ export interface EC2Service {
   assignIpv6Addresses(
     args: AssignIpv6AddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssignIpv6AddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssignIpv6AddressesResult, SdkError>;
 
   /**
    * @see {@link AssignPrivateIpAddressesCommand}
@@ -2591,10 +2549,7 @@ export interface EC2Service {
   assignPrivateIpAddresses(
     args: AssignPrivateIpAddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssignPrivateIpAddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssignPrivateIpAddressesResult, SdkError>;
 
   /**
    * @see {@link AssignPrivateNatGatewayAddressCommand}
@@ -2602,10 +2557,7 @@ export interface EC2Service {
   assignPrivateNatGatewayAddress(
     args: AssignPrivateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssignPrivateNatGatewayAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssignPrivateNatGatewayAddressResult, SdkError>;
 
   /**
    * @see {@link AssociateAddressCommand}
@@ -2613,10 +2565,7 @@ export interface EC2Service {
   associateAddress(
     args: AssociateAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateAddressResult, SdkError>;
 
   /**
    * @see {@link AssociateClientVpnTargetNetworkCommand}
@@ -2624,10 +2573,7 @@ export interface EC2Service {
   associateClientVpnTargetNetwork(
     args: AssociateClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateClientVpnTargetNetworkResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateClientVpnTargetNetworkResult, SdkError>;
 
   /**
    * @see {@link AssociateDhcpOptionsCommand}
@@ -2635,10 +2581,7 @@ export interface EC2Service {
   associateDhcpOptions(
     args: AssociateDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link AssociateEnclaveCertificateIamRoleCommand}
@@ -2646,10 +2589,7 @@ export interface EC2Service {
   associateEnclaveCertificateIamRole(
     args: AssociateEnclaveCertificateIamRoleRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateEnclaveCertificateIamRoleResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateEnclaveCertificateIamRoleResult, SdkError>;
 
   /**
    * @see {@link AssociateIamInstanceProfileCommand}
@@ -2657,10 +2597,7 @@ export interface EC2Service {
   associateIamInstanceProfile(
     args: AssociateIamInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateIamInstanceProfileResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateIamInstanceProfileResult, SdkError>;
 
   /**
    * @see {@link AssociateInstanceEventWindowCommand}
@@ -2668,10 +2605,7 @@ export interface EC2Service {
   associateInstanceEventWindow(
     args: AssociateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateInstanceEventWindowResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateInstanceEventWindowResult, SdkError>;
 
   /**
    * @see {@link AssociateIpamByoasnCommand}
@@ -2679,10 +2613,7 @@ export interface EC2Service {
   associateIpamByoasn(
     args: AssociateIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateIpamByoasnResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateIpamByoasnResult, SdkError>;
 
   /**
    * @see {@link AssociateIpamResourceDiscoveryCommand}
@@ -2690,10 +2621,7 @@ export interface EC2Service {
   associateIpamResourceDiscovery(
     args: AssociateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateIpamResourceDiscoveryResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateIpamResourceDiscoveryResult, SdkError>;
 
   /**
    * @see {@link AssociateNatGatewayAddressCommand}
@@ -2701,10 +2629,7 @@ export interface EC2Service {
   associateNatGatewayAddress(
     args: AssociateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateNatGatewayAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateNatGatewayAddressResult, SdkError>;
 
   /**
    * @see {@link AssociateRouteTableCommand}
@@ -2712,10 +2637,7 @@ export interface EC2Service {
   associateRouteTable(
     args: AssociateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateRouteTableResult, SdkError>;
 
   /**
    * @see {@link AssociateSubnetCidrBlockCommand}
@@ -2723,10 +2645,7 @@ export interface EC2Service {
   associateSubnetCidrBlock(
     args: AssociateSubnetCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateSubnetCidrBlockResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateSubnetCidrBlockResult, SdkError>;
 
   /**
    * @see {@link AssociateTransitGatewayMulticastDomainCommand}
@@ -2734,10 +2653,7 @@ export interface EC2Service {
   associateTransitGatewayMulticastDomain(
     args: AssociateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateTransitGatewayMulticastDomainResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateTransitGatewayMulticastDomainResult, SdkError>;
 
   /**
    * @see {@link AssociateTransitGatewayPolicyTableCommand}
@@ -2745,10 +2661,7 @@ export interface EC2Service {
   associateTransitGatewayPolicyTable(
     args: AssociateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateTransitGatewayPolicyTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateTransitGatewayPolicyTableResult, SdkError>;
 
   /**
    * @see {@link AssociateTransitGatewayRouteTableCommand}
@@ -2756,10 +2669,7 @@ export interface EC2Service {
   associateTransitGatewayRouteTable(
     args: AssociateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateTransitGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateTransitGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link AssociateTrunkInterfaceCommand}
@@ -2767,10 +2677,7 @@ export interface EC2Service {
   associateTrunkInterface(
     args: AssociateTrunkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateTrunkInterfaceResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateTrunkInterfaceResult, SdkError>;
 
   /**
    * @see {@link AssociateVpcCidrBlockCommand}
@@ -2778,10 +2685,7 @@ export interface EC2Service {
   associateVpcCidrBlock(
     args: AssociateVpcCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AssociateVpcCidrBlockResult,
-    | SdkError
-  >
+  ): Effect.Effect<AssociateVpcCidrBlockResult, SdkError>;
 
   /**
    * @see {@link AttachClassicLinkVpcCommand}
@@ -2789,10 +2693,7 @@ export interface EC2Service {
   attachClassicLinkVpc(
     args: AttachClassicLinkVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AttachClassicLinkVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<AttachClassicLinkVpcResult, SdkError>;
 
   /**
    * @see {@link AttachInternetGatewayCommand}
@@ -2800,10 +2701,7 @@ export interface EC2Service {
   attachInternetGateway(
     args: AttachInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link AttachNetworkInterfaceCommand}
@@ -2811,10 +2709,7 @@ export interface EC2Service {
   attachNetworkInterface(
     args: AttachNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AttachNetworkInterfaceResult,
-    | SdkError
-  >
+  ): Effect.Effect<AttachNetworkInterfaceResult, SdkError>;
 
   /**
    * @see {@link AttachVerifiedAccessTrustProviderCommand}
@@ -2822,10 +2717,7 @@ export interface EC2Service {
   attachVerifiedAccessTrustProvider(
     args: AttachVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AttachVerifiedAccessTrustProviderResult,
-    | SdkError
-  >
+  ): Effect.Effect<AttachVerifiedAccessTrustProviderResult, SdkError>;
 
   /**
    * @see {@link AttachVolumeCommand}
@@ -2833,10 +2725,7 @@ export interface EC2Service {
   attachVolume(
     args: AttachVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  VolumeAttachment,
-    | SdkError
-  >
+  ): Effect.Effect<VolumeAttachment, SdkError>;
 
   /**
    * @see {@link AttachVpnGatewayCommand}
@@ -2844,10 +2733,7 @@ export interface EC2Service {
   attachVpnGateway(
     args: AttachVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AttachVpnGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<AttachVpnGatewayResult, SdkError>;
 
   /**
    * @see {@link AuthorizeClientVpnIngressCommand}
@@ -2855,10 +2741,7 @@ export interface EC2Service {
   authorizeClientVpnIngress(
     args: AuthorizeClientVpnIngressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AuthorizeClientVpnIngressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AuthorizeClientVpnIngressResult, SdkError>;
 
   /**
    * @see {@link AuthorizeSecurityGroupEgressCommand}
@@ -2866,10 +2749,7 @@ export interface EC2Service {
   authorizeSecurityGroupEgress(
     args: AuthorizeSecurityGroupEgressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AuthorizeSecurityGroupEgressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AuthorizeSecurityGroupEgressResult, SdkError>;
 
   /**
    * @see {@link AuthorizeSecurityGroupIngressCommand}
@@ -2877,10 +2757,7 @@ export interface EC2Service {
   authorizeSecurityGroupIngress(
     args: AuthorizeSecurityGroupIngressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  AuthorizeSecurityGroupIngressResult,
-    | SdkError
-  >
+  ): Effect.Effect<AuthorizeSecurityGroupIngressResult, SdkError>;
 
   /**
    * @see {@link BundleInstanceCommand}
@@ -2888,10 +2765,7 @@ export interface EC2Service {
   bundleInstance(
     args: BundleInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  BundleInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<BundleInstanceResult, SdkError>;
 
   /**
    * @see {@link CancelBundleTaskCommand}
@@ -2899,10 +2773,7 @@ export interface EC2Service {
   cancelBundleTask(
     args: CancelBundleTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelBundleTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelBundleTaskResult, SdkError>;
 
   /**
    * @see {@link CancelCapacityReservationCommand}
@@ -2910,10 +2781,7 @@ export interface EC2Service {
   cancelCapacityReservation(
     args: CancelCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelCapacityReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelCapacityReservationResult, SdkError>;
 
   /**
    * @see {@link CancelCapacityReservationFleetsCommand}
@@ -2921,10 +2789,7 @@ export interface EC2Service {
   cancelCapacityReservationFleets(
     args: CancelCapacityReservationFleetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelCapacityReservationFleetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelCapacityReservationFleetsResult, SdkError>;
 
   /**
    * @see {@link CancelConversionTaskCommand}
@@ -2932,10 +2797,7 @@ export interface EC2Service {
   cancelConversionTask(
     args: CancelConversionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link CancelExportTaskCommand}
@@ -2943,10 +2805,7 @@ export interface EC2Service {
   cancelExportTask(
     args: CancelExportTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link CancelImageLaunchPermissionCommand}
@@ -2954,10 +2813,7 @@ export interface EC2Service {
   cancelImageLaunchPermission(
     args: CancelImageLaunchPermissionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelImageLaunchPermissionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelImageLaunchPermissionResult, SdkError>;
 
   /**
    * @see {@link CancelImportTaskCommand}
@@ -2965,10 +2821,7 @@ export interface EC2Service {
   cancelImportTask(
     args: CancelImportTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelImportTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelImportTaskResult, SdkError>;
 
   /**
    * @see {@link CancelReservedInstancesListingCommand}
@@ -2976,10 +2829,7 @@ export interface EC2Service {
   cancelReservedInstancesListing(
     args: CancelReservedInstancesListingRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelReservedInstancesListingResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelReservedInstancesListingResult, SdkError>;
 
   /**
    * @see {@link CancelSpotFleetRequestsCommand}
@@ -2987,10 +2837,7 @@ export interface EC2Service {
   cancelSpotFleetRequests(
     args: CancelSpotFleetRequestsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelSpotFleetRequestsResponse,
-    | SdkError
-  >
+  ): Effect.Effect<CancelSpotFleetRequestsResponse, SdkError>;
 
   /**
    * @see {@link CancelSpotInstanceRequestsCommand}
@@ -2998,10 +2845,7 @@ export interface EC2Service {
   cancelSpotInstanceRequests(
     args: CancelSpotInstanceRequestsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CancelSpotInstanceRequestsResult,
-    | SdkError
-  >
+  ): Effect.Effect<CancelSpotInstanceRequestsResult, SdkError>;
 
   /**
    * @see {@link ConfirmProductInstanceCommand}
@@ -3009,10 +2853,7 @@ export interface EC2Service {
   confirmProductInstance(
     args: ConfirmProductInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ConfirmProductInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<ConfirmProductInstanceResult, SdkError>;
 
   /**
    * @see {@link CopyFpgaImageCommand}
@@ -3020,10 +2861,7 @@ export interface EC2Service {
   copyFpgaImage(
     args: CopyFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CopyFpgaImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<CopyFpgaImageResult, SdkError>;
 
   /**
    * @see {@link CopyImageCommand}
@@ -3031,10 +2869,7 @@ export interface EC2Service {
   copyImage(
     args: CopyImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CopyImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<CopyImageResult, SdkError>;
 
   /**
    * @see {@link CopySnapshotCommand}
@@ -3042,10 +2877,7 @@ export interface EC2Service {
   copySnapshot(
     args: CopySnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CopySnapshotResult,
-    | SdkError
-  >
+  ): Effect.Effect<CopySnapshotResult, SdkError>;
 
   /**
    * @see {@link CreateCapacityReservationCommand}
@@ -3053,10 +2885,7 @@ export interface EC2Service {
   createCapacityReservation(
     args: CreateCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCapacityReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCapacityReservationResult, SdkError>;
 
   /**
    * @see {@link CreateCapacityReservationFleetCommand}
@@ -3064,10 +2893,7 @@ export interface EC2Service {
   createCapacityReservationFleet(
     args: CreateCapacityReservationFleetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCapacityReservationFleetResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCapacityReservationFleetResult, SdkError>;
 
   /**
    * @see {@link CreateCarrierGatewayCommand}
@@ -3075,10 +2901,7 @@ export interface EC2Service {
   createCarrierGateway(
     args: CreateCarrierGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCarrierGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCarrierGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateClientVpnEndpointCommand}
@@ -3086,10 +2909,7 @@ export interface EC2Service {
   createClientVpnEndpoint(
     args: CreateClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateClientVpnEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateClientVpnEndpointResult, SdkError>;
 
   /**
    * @see {@link CreateClientVpnRouteCommand}
@@ -3097,10 +2917,7 @@ export interface EC2Service {
   createClientVpnRoute(
     args: CreateClientVpnRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateClientVpnRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateClientVpnRouteResult, SdkError>;
 
   /**
    * @see {@link CreateCoipCidrCommand}
@@ -3108,10 +2925,7 @@ export interface EC2Service {
   createCoipCidr(
     args: CreateCoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCoipCidrResult, SdkError>;
 
   /**
    * @see {@link CreateCoipPoolCommand}
@@ -3119,10 +2933,7 @@ export interface EC2Service {
   createCoipPool(
     args: CreateCoipPoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCoipPoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCoipPoolResult, SdkError>;
 
   /**
    * @see {@link CreateCustomerGatewayCommand}
@@ -3130,10 +2941,7 @@ export interface EC2Service {
   createCustomerGateway(
     args: CreateCustomerGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateCustomerGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateCustomerGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateDefaultSubnetCommand}
@@ -3141,10 +2949,7 @@ export interface EC2Service {
   createDefaultSubnet(
     args: CreateDefaultSubnetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateDefaultSubnetResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateDefaultSubnetResult, SdkError>;
 
   /**
    * @see {@link CreateDefaultVpcCommand}
@@ -3152,10 +2957,7 @@ export interface EC2Service {
   createDefaultVpc(
     args: CreateDefaultVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateDefaultVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateDefaultVpcResult, SdkError>;
 
   /**
    * @see {@link CreateDhcpOptionsCommand}
@@ -3163,10 +2965,7 @@ export interface EC2Service {
   createDhcpOptions(
     args: CreateDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateDhcpOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateDhcpOptionsResult, SdkError>;
 
   /**
    * @see {@link CreateEgressOnlyInternetGatewayCommand}
@@ -3174,10 +2973,7 @@ export interface EC2Service {
   createEgressOnlyInternetGateway(
     args: CreateEgressOnlyInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateEgressOnlyInternetGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateEgressOnlyInternetGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateFleetCommand}
@@ -3185,10 +2981,7 @@ export interface EC2Service {
   createFleet(
     args: CreateFleetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateFleetResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateFleetResult, SdkError>;
 
   /**
    * @see {@link CreateFlowLogsCommand}
@@ -3196,10 +2989,7 @@ export interface EC2Service {
   createFlowLogs(
     args: CreateFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateFlowLogsResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateFlowLogsResult, SdkError>;
 
   /**
    * @see {@link CreateFpgaImageCommand}
@@ -3207,10 +2997,7 @@ export interface EC2Service {
   createFpgaImage(
     args: CreateFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateFpgaImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateFpgaImageResult, SdkError>;
 
   /**
    * @see {@link CreateImageCommand}
@@ -3218,10 +3005,7 @@ export interface EC2Service {
   createImage(
     args: CreateImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateImageResult, SdkError>;
 
   /**
    * @see {@link CreateInstanceConnectEndpointCommand}
@@ -3229,10 +3013,7 @@ export interface EC2Service {
   createInstanceConnectEndpoint(
     args: CreateInstanceConnectEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateInstanceConnectEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateInstanceConnectEndpointResult, SdkError>;
 
   /**
    * @see {@link CreateInstanceEventWindowCommand}
@@ -3240,10 +3021,7 @@ export interface EC2Service {
   createInstanceEventWindow(
     args: CreateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateInstanceEventWindowResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateInstanceEventWindowResult, SdkError>;
 
   /**
    * @see {@link CreateInstanceExportTaskCommand}
@@ -3251,10 +3029,7 @@ export interface EC2Service {
   createInstanceExportTask(
     args: CreateInstanceExportTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateInstanceExportTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateInstanceExportTaskResult, SdkError>;
 
   /**
    * @see {@link CreateInternetGatewayCommand}
@@ -3262,10 +3037,7 @@ export interface EC2Service {
   createInternetGateway(
     args: CreateInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateInternetGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateInternetGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateIpamCommand}
@@ -3273,10 +3045,7 @@ export interface EC2Service {
   createIpam(
     args: CreateIpamRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateIpamResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateIpamResult, SdkError>;
 
   /**
    * @see {@link CreateIpamPoolCommand}
@@ -3284,10 +3053,7 @@ export interface EC2Service {
   createIpamPool(
     args: CreateIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateIpamPoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateIpamPoolResult, SdkError>;
 
   /**
    * @see {@link CreateIpamResourceDiscoveryCommand}
@@ -3295,10 +3061,7 @@ export interface EC2Service {
   createIpamResourceDiscovery(
     args: CreateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateIpamResourceDiscoveryResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateIpamResourceDiscoveryResult, SdkError>;
 
   /**
    * @see {@link CreateIpamScopeCommand}
@@ -3306,10 +3069,7 @@ export interface EC2Service {
   createIpamScope(
     args: CreateIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateIpamScopeResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateIpamScopeResult, SdkError>;
 
   /**
    * @see {@link CreateKeyPairCommand}
@@ -3317,10 +3077,7 @@ export interface EC2Service {
   createKeyPair(
     args: CreateKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  KeyPair,
-    | SdkError
-  >
+  ): Effect.Effect<KeyPair, SdkError>;
 
   /**
    * @see {@link CreateLaunchTemplateCommand}
@@ -3328,10 +3085,7 @@ export interface EC2Service {
   createLaunchTemplate(
     args: CreateLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateLaunchTemplateResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateLaunchTemplateResult, SdkError>;
 
   /**
    * @see {@link CreateLaunchTemplateVersionCommand}
@@ -3339,10 +3093,7 @@ export interface EC2Service {
   createLaunchTemplateVersion(
     args: CreateLaunchTemplateVersionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateLaunchTemplateVersionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateLaunchTemplateVersionResult, SdkError>;
 
   /**
    * @see {@link CreateLocalGatewayRouteCommand}
@@ -3350,10 +3101,7 @@ export interface EC2Service {
   createLocalGatewayRoute(
     args: CreateLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateLocalGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateLocalGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link CreateLocalGatewayRouteTableCommand}
@@ -3361,10 +3109,7 @@ export interface EC2Service {
   createLocalGatewayRouteTable(
     args: CreateLocalGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateLocalGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateLocalGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand}
@@ -3373,9 +3118,9 @@ export interface EC2Service {
     args: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
-    | SdkError
-  >
+    CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+    SdkError
+  >;
 
   /**
    * @see {@link CreateLocalGatewayRouteTableVpcAssociationCommand}
@@ -3383,10 +3128,7 @@ export interface EC2Service {
   createLocalGatewayRouteTableVpcAssociation(
     args: CreateLocalGatewayRouteTableVpcAssociationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateLocalGatewayRouteTableVpcAssociationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateLocalGatewayRouteTableVpcAssociationResult, SdkError>;
 
   /**
    * @see {@link CreateManagedPrefixListCommand}
@@ -3394,10 +3136,7 @@ export interface EC2Service {
   createManagedPrefixList(
     args: CreateManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateManagedPrefixListResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateManagedPrefixListResult, SdkError>;
 
   /**
    * @see {@link CreateNatGatewayCommand}
@@ -3405,10 +3144,7 @@ export interface EC2Service {
   createNatGateway(
     args: CreateNatGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNatGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNatGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateNetworkAclCommand}
@@ -3416,10 +3152,7 @@ export interface EC2Service {
   createNetworkAcl(
     args: CreateNetworkAclRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNetworkAclResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNetworkAclResult, SdkError>;
 
   /**
    * @see {@link CreateNetworkAclEntryCommand}
@@ -3427,10 +3160,7 @@ export interface EC2Service {
   createNetworkAclEntry(
     args: CreateNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link CreateNetworkInsightsAccessScopeCommand}
@@ -3438,10 +3168,7 @@ export interface EC2Service {
   createNetworkInsightsAccessScope(
     args: CreateNetworkInsightsAccessScopeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNetworkInsightsAccessScopeResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNetworkInsightsAccessScopeResult, SdkError>;
 
   /**
    * @see {@link CreateNetworkInsightsPathCommand}
@@ -3449,10 +3176,7 @@ export interface EC2Service {
   createNetworkInsightsPath(
     args: CreateNetworkInsightsPathRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNetworkInsightsPathResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNetworkInsightsPathResult, SdkError>;
 
   /**
    * @see {@link CreateNetworkInterfaceCommand}
@@ -3460,10 +3184,7 @@ export interface EC2Service {
   createNetworkInterface(
     args: CreateNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNetworkInterfaceResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNetworkInterfaceResult, SdkError>;
 
   /**
    * @see {@link CreateNetworkInterfacePermissionCommand}
@@ -3471,10 +3192,7 @@ export interface EC2Service {
   createNetworkInterfacePermission(
     args: CreateNetworkInterfacePermissionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateNetworkInterfacePermissionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateNetworkInterfacePermissionResult, SdkError>;
 
   /**
    * @see {@link CreatePlacementGroupCommand}
@@ -3482,10 +3200,7 @@ export interface EC2Service {
   createPlacementGroup(
     args: CreatePlacementGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreatePlacementGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreatePlacementGroupResult, SdkError>;
 
   /**
    * @see {@link CreatePublicIpv4PoolCommand}
@@ -3493,10 +3208,7 @@ export interface EC2Service {
   createPublicIpv4Pool(
     args: CreatePublicIpv4PoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreatePublicIpv4PoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreatePublicIpv4PoolResult, SdkError>;
 
   /**
    * @see {@link CreateReplaceRootVolumeTaskCommand}
@@ -3504,10 +3216,7 @@ export interface EC2Service {
   createReplaceRootVolumeTask(
     args: CreateReplaceRootVolumeTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateReplaceRootVolumeTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateReplaceRootVolumeTaskResult, SdkError>;
 
   /**
    * @see {@link CreateReservedInstancesListingCommand}
@@ -3515,10 +3224,7 @@ export interface EC2Service {
   createReservedInstancesListing(
     args: CreateReservedInstancesListingRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateReservedInstancesListingResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateReservedInstancesListingResult, SdkError>;
 
   /**
    * @see {@link CreateRestoreImageTaskCommand}
@@ -3526,10 +3232,7 @@ export interface EC2Service {
   createRestoreImageTask(
     args: CreateRestoreImageTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateRestoreImageTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateRestoreImageTaskResult, SdkError>;
 
   /**
    * @see {@link CreateRouteCommand}
@@ -3537,10 +3240,7 @@ export interface EC2Service {
   createRoute(
     args: CreateRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateRouteResult, SdkError>;
 
   /**
    * @see {@link CreateRouteTableCommand}
@@ -3548,10 +3248,7 @@ export interface EC2Service {
   createRouteTable(
     args: CreateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateRouteTableResult, SdkError>;
 
   /**
    * @see {@link CreateSecurityGroupCommand}
@@ -3559,10 +3256,7 @@ export interface EC2Service {
   createSecurityGroup(
     args: CreateSecurityGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateSecurityGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateSecurityGroupResult, SdkError>;
 
   /**
    * @see {@link CreateSnapshotCommand}
@@ -3570,10 +3264,7 @@ export interface EC2Service {
   createSnapshot(
     args: CreateSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  Snapshot,
-    | SdkError
-  >
+  ): Effect.Effect<Snapshot, SdkError>;
 
   /**
    * @see {@link CreateSnapshotsCommand}
@@ -3581,10 +3272,7 @@ export interface EC2Service {
   createSnapshots(
     args: CreateSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateSnapshotsResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateSnapshotsResult, SdkError>;
 
   /**
    * @see {@link CreateSpotDatafeedSubscriptionCommand}
@@ -3592,10 +3280,7 @@ export interface EC2Service {
   createSpotDatafeedSubscription(
     args: CreateSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateSpotDatafeedSubscriptionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateSpotDatafeedSubscriptionResult, SdkError>;
 
   /**
    * @see {@link CreateStoreImageTaskCommand}
@@ -3603,10 +3288,7 @@ export interface EC2Service {
   createStoreImageTask(
     args: CreateStoreImageTaskRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateStoreImageTaskResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateStoreImageTaskResult, SdkError>;
 
   /**
    * @see {@link CreateSubnetCommand}
@@ -3614,10 +3296,7 @@ export interface EC2Service {
   createSubnet(
     args: CreateSubnetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateSubnetResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateSubnetResult, SdkError>;
 
   /**
    * @see {@link CreateSubnetCidrReservationCommand}
@@ -3625,10 +3304,7 @@ export interface EC2Service {
   createSubnetCidrReservation(
     args: CreateSubnetCidrReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateSubnetCidrReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateSubnetCidrReservationResult, SdkError>;
 
   /**
    * @see {@link CreateTagsCommand}
@@ -3636,10 +3312,7 @@ export interface EC2Service {
   createTags(
     args: CreateTagsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link CreateTrafficMirrorFilterCommand}
@@ -3647,10 +3320,7 @@ export interface EC2Service {
   createTrafficMirrorFilter(
     args: CreateTrafficMirrorFilterRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTrafficMirrorFilterResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTrafficMirrorFilterResult, SdkError>;
 
   /**
    * @see {@link CreateTrafficMirrorFilterRuleCommand}
@@ -3658,10 +3328,7 @@ export interface EC2Service {
   createTrafficMirrorFilterRule(
     args: CreateTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTrafficMirrorFilterRuleResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTrafficMirrorFilterRuleResult, SdkError>;
 
   /**
    * @see {@link CreateTrafficMirrorSessionCommand}
@@ -3669,10 +3336,7 @@ export interface EC2Service {
   createTrafficMirrorSession(
     args: CreateTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTrafficMirrorSessionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTrafficMirrorSessionResult, SdkError>;
 
   /**
    * @see {@link CreateTrafficMirrorTargetCommand}
@@ -3680,10 +3344,7 @@ export interface EC2Service {
   createTrafficMirrorTarget(
     args: CreateTrafficMirrorTargetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTrafficMirrorTargetResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTrafficMirrorTargetResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayCommand}
@@ -3691,10 +3352,7 @@ export interface EC2Service {
   createTransitGateway(
     args: CreateTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayConnectCommand}
@@ -3702,10 +3360,7 @@ export interface EC2Service {
   createTransitGatewayConnect(
     args: CreateTransitGatewayConnectRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayConnectResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayConnectResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayConnectPeerCommand}
@@ -3713,10 +3368,7 @@ export interface EC2Service {
   createTransitGatewayConnectPeer(
     args: CreateTransitGatewayConnectPeerRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayConnectPeerResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayConnectPeerResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayMulticastDomainCommand}
@@ -3724,10 +3376,7 @@ export interface EC2Service {
   createTransitGatewayMulticastDomain(
     args: CreateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayMulticastDomainResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayMulticastDomainResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayPeeringAttachmentCommand}
@@ -3735,10 +3384,7 @@ export interface EC2Service {
   createTransitGatewayPeeringAttachment(
     args: CreateTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayPeeringAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayPeeringAttachmentResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayPolicyTableCommand}
@@ -3746,10 +3392,7 @@ export interface EC2Service {
   createTransitGatewayPolicyTable(
     args: CreateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayPolicyTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayPolicyTableResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayPrefixListReferenceCommand}
@@ -3757,10 +3400,7 @@ export interface EC2Service {
   createTransitGatewayPrefixListReference(
     args: CreateTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayPrefixListReferenceResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayPrefixListReferenceResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayRouteCommand}
@@ -3768,10 +3408,7 @@ export interface EC2Service {
   createTransitGatewayRoute(
     args: CreateTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayRouteTableCommand}
@@ -3779,10 +3416,7 @@ export interface EC2Service {
   createTransitGatewayRouteTable(
     args: CreateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayRouteTableAnnouncementCommand}
@@ -3790,10 +3424,7 @@ export interface EC2Service {
   createTransitGatewayRouteTableAnnouncement(
     args: CreateTransitGatewayRouteTableAnnouncementRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayRouteTableAnnouncementResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayRouteTableAnnouncementResult, SdkError>;
 
   /**
    * @see {@link CreateTransitGatewayVpcAttachmentCommand}
@@ -3801,10 +3432,7 @@ export interface EC2Service {
   createTransitGatewayVpcAttachment(
     args: CreateTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateTransitGatewayVpcAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateTransitGatewayVpcAttachmentResult, SdkError>;
 
   /**
    * @see {@link CreateVerifiedAccessEndpointCommand}
@@ -3812,10 +3440,7 @@ export interface EC2Service {
   createVerifiedAccessEndpoint(
     args: CreateVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVerifiedAccessEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVerifiedAccessEndpointResult, SdkError>;
 
   /**
    * @see {@link CreateVerifiedAccessGroupCommand}
@@ -3823,10 +3448,7 @@ export interface EC2Service {
   createVerifiedAccessGroup(
     args: CreateVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVerifiedAccessGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVerifiedAccessGroupResult, SdkError>;
 
   /**
    * @see {@link CreateVerifiedAccessInstanceCommand}
@@ -3834,10 +3456,7 @@ export interface EC2Service {
   createVerifiedAccessInstance(
     args: CreateVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVerifiedAccessInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVerifiedAccessInstanceResult, SdkError>;
 
   /**
    * @see {@link CreateVerifiedAccessTrustProviderCommand}
@@ -3845,10 +3464,7 @@ export interface EC2Service {
   createVerifiedAccessTrustProvider(
     args: CreateVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVerifiedAccessTrustProviderResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVerifiedAccessTrustProviderResult, SdkError>;
 
   /**
    * @see {@link CreateVolumeCommand}
@@ -3856,10 +3472,7 @@ export interface EC2Service {
   createVolume(
     args: CreateVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  Volume,
-    | SdkError
-  >
+  ): Effect.Effect<Volume, SdkError>;
 
   /**
    * @see {@link CreateVpcCommand}
@@ -3867,10 +3480,7 @@ export interface EC2Service {
   createVpc(
     args: CreateVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpcResult, SdkError>;
 
   /**
    * @see {@link CreateVpcEndpointCommand}
@@ -3878,10 +3488,7 @@ export interface EC2Service {
   createVpcEndpoint(
     args: CreateVpcEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpcEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpcEndpointResult, SdkError>;
 
   /**
    * @see {@link CreateVpcEndpointConnectionNotificationCommand}
@@ -3889,10 +3496,7 @@ export interface EC2Service {
   createVpcEndpointConnectionNotification(
     args: CreateVpcEndpointConnectionNotificationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpcEndpointConnectionNotificationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpcEndpointConnectionNotificationResult, SdkError>;
 
   /**
    * @see {@link CreateVpcEndpointServiceConfigurationCommand}
@@ -3900,10 +3504,7 @@ export interface EC2Service {
   createVpcEndpointServiceConfiguration(
     args: CreateVpcEndpointServiceConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpcEndpointServiceConfigurationResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpcEndpointServiceConfigurationResult, SdkError>;
 
   /**
    * @see {@link CreateVpcPeeringConnectionCommand}
@@ -3911,10 +3512,7 @@ export interface EC2Service {
   createVpcPeeringConnection(
     args: CreateVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpcPeeringConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpcPeeringConnectionResult, SdkError>;
 
   /**
    * @see {@link CreateVpnConnectionCommand}
@@ -3922,10 +3520,7 @@ export interface EC2Service {
   createVpnConnection(
     args: CreateVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpnConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpnConnectionResult, SdkError>;
 
   /**
    * @see {@link CreateVpnConnectionRouteCommand}
@@ -3933,10 +3528,7 @@ export interface EC2Service {
   createVpnConnectionRoute(
     args: CreateVpnConnectionRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link CreateVpnGatewayCommand}
@@ -3944,10 +3536,7 @@ export interface EC2Service {
   createVpnGateway(
     args: CreateVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  CreateVpnGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<CreateVpnGatewayResult, SdkError>;
 
   /**
    * @see {@link DeleteCarrierGatewayCommand}
@@ -3955,10 +3544,7 @@ export interface EC2Service {
   deleteCarrierGateway(
     args: DeleteCarrierGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteCarrierGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteCarrierGatewayResult, SdkError>;
 
   /**
    * @see {@link DeleteClientVpnEndpointCommand}
@@ -3966,10 +3552,7 @@ export interface EC2Service {
   deleteClientVpnEndpoint(
     args: DeleteClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteClientVpnEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteClientVpnEndpointResult, SdkError>;
 
   /**
    * @see {@link DeleteClientVpnRouteCommand}
@@ -3977,10 +3560,7 @@ export interface EC2Service {
   deleteClientVpnRoute(
     args: DeleteClientVpnRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteClientVpnRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteClientVpnRouteResult, SdkError>;
 
   /**
    * @see {@link DeleteCoipCidrCommand}
@@ -3988,10 +3568,7 @@ export interface EC2Service {
   deleteCoipCidr(
     args: DeleteCoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteCoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteCoipCidrResult, SdkError>;
 
   /**
    * @see {@link DeleteCoipPoolCommand}
@@ -3999,10 +3576,7 @@ export interface EC2Service {
   deleteCoipPool(
     args: DeleteCoipPoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteCoipPoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteCoipPoolResult, SdkError>;
 
   /**
    * @see {@link DeleteCustomerGatewayCommand}
@@ -4010,10 +3584,7 @@ export interface EC2Service {
   deleteCustomerGateway(
     args: DeleteCustomerGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteDhcpOptionsCommand}
@@ -4021,10 +3592,7 @@ export interface EC2Service {
   deleteDhcpOptions(
     args: DeleteDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteEgressOnlyInternetGatewayCommand}
@@ -4032,10 +3600,7 @@ export interface EC2Service {
   deleteEgressOnlyInternetGateway(
     args: DeleteEgressOnlyInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteEgressOnlyInternetGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteEgressOnlyInternetGatewayResult, SdkError>;
 
   /**
    * @see {@link DeleteFleetsCommand}
@@ -4043,10 +3608,7 @@ export interface EC2Service {
   deleteFleets(
     args: DeleteFleetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteFleetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteFleetsResult, SdkError>;
 
   /**
    * @see {@link DeleteFlowLogsCommand}
@@ -4054,10 +3616,7 @@ export interface EC2Service {
   deleteFlowLogs(
     args: DeleteFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteFlowLogsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteFlowLogsResult, SdkError>;
 
   /**
    * @see {@link DeleteFpgaImageCommand}
@@ -4065,10 +3624,7 @@ export interface EC2Service {
   deleteFpgaImage(
     args: DeleteFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteFpgaImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteFpgaImageResult, SdkError>;
 
   /**
    * @see {@link DeleteInstanceConnectEndpointCommand}
@@ -4076,10 +3632,7 @@ export interface EC2Service {
   deleteInstanceConnectEndpoint(
     args: DeleteInstanceConnectEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteInstanceConnectEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteInstanceConnectEndpointResult, SdkError>;
 
   /**
    * @see {@link DeleteInstanceEventWindowCommand}
@@ -4087,10 +3640,7 @@ export interface EC2Service {
   deleteInstanceEventWindow(
     args: DeleteInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteInstanceEventWindowResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteInstanceEventWindowResult, SdkError>;
 
   /**
    * @see {@link DeleteInternetGatewayCommand}
@@ -4098,10 +3648,7 @@ export interface EC2Service {
   deleteInternetGateway(
     args: DeleteInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteIpamCommand}
@@ -4109,10 +3656,7 @@ export interface EC2Service {
   deleteIpam(
     args: DeleteIpamRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteIpamResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteIpamResult, SdkError>;
 
   /**
    * @see {@link DeleteIpamPoolCommand}
@@ -4120,10 +3664,7 @@ export interface EC2Service {
   deleteIpamPool(
     args: DeleteIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteIpamPoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteIpamPoolResult, SdkError>;
 
   /**
    * @see {@link DeleteIpamResourceDiscoveryCommand}
@@ -4131,10 +3672,7 @@ export interface EC2Service {
   deleteIpamResourceDiscovery(
     args: DeleteIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteIpamResourceDiscoveryResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteIpamResourceDiscoveryResult, SdkError>;
 
   /**
    * @see {@link DeleteIpamScopeCommand}
@@ -4142,10 +3680,7 @@ export interface EC2Service {
   deleteIpamScope(
     args: DeleteIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteIpamScopeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteIpamScopeResult, SdkError>;
 
   /**
    * @see {@link DeleteKeyPairCommand}
@@ -4153,10 +3688,7 @@ export interface EC2Service {
   deleteKeyPair(
     args: DeleteKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteKeyPairResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteKeyPairResult, SdkError>;
 
   /**
    * @see {@link DeleteLaunchTemplateCommand}
@@ -4164,10 +3696,7 @@ export interface EC2Service {
   deleteLaunchTemplate(
     args: DeleteLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteLaunchTemplateResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteLaunchTemplateResult, SdkError>;
 
   /**
    * @see {@link DeleteLaunchTemplateVersionsCommand}
@@ -4175,10 +3704,7 @@ export interface EC2Service {
   deleteLaunchTemplateVersions(
     args: DeleteLaunchTemplateVersionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteLaunchTemplateVersionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteLaunchTemplateVersionsResult, SdkError>;
 
   /**
    * @see {@link DeleteLocalGatewayRouteCommand}
@@ -4186,10 +3712,7 @@ export interface EC2Service {
   deleteLocalGatewayRoute(
     args: DeleteLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteLocalGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteLocalGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableCommand}
@@ -4197,10 +3720,7 @@ export interface EC2Service {
   deleteLocalGatewayRouteTable(
     args: DeleteLocalGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteLocalGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteLocalGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand}
@@ -4209,9 +3729,9 @@ export interface EC2Service {
     args: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
-    | SdkError
-  >
+    DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableVpcAssociationCommand}
@@ -4219,10 +3739,7 @@ export interface EC2Service {
   deleteLocalGatewayRouteTableVpcAssociation(
     args: DeleteLocalGatewayRouteTableVpcAssociationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteLocalGatewayRouteTableVpcAssociationResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteLocalGatewayRouteTableVpcAssociationResult, SdkError>;
 
   /**
    * @see {@link DeleteManagedPrefixListCommand}
@@ -4230,10 +3747,7 @@ export interface EC2Service {
   deleteManagedPrefixList(
     args: DeleteManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteManagedPrefixListResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteManagedPrefixListResult, SdkError>;
 
   /**
    * @see {@link DeleteNatGatewayCommand}
@@ -4241,10 +3755,7 @@ export interface EC2Service {
   deleteNatGateway(
     args: DeleteNatGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNatGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNatGatewayResult, SdkError>;
 
   /**
    * @see {@link DeleteNetworkAclCommand}
@@ -4252,10 +3763,7 @@ export interface EC2Service {
   deleteNetworkAcl(
     args: DeleteNetworkAclRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteNetworkAclEntryCommand}
@@ -4263,10 +3771,7 @@ export interface EC2Service {
   deleteNetworkAclEntry(
     args: DeleteNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInsightsAccessScopeCommand}
@@ -4274,10 +3779,7 @@ export interface EC2Service {
   deleteNetworkInsightsAccessScope(
     args: DeleteNetworkInsightsAccessScopeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNetworkInsightsAccessScopeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNetworkInsightsAccessScopeResult, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInsightsAccessScopeAnalysisCommand}
@@ -4285,10 +3787,7 @@ export interface EC2Service {
   deleteNetworkInsightsAccessScopeAnalysis(
     args: DeleteNetworkInsightsAccessScopeAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNetworkInsightsAccessScopeAnalysisResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNetworkInsightsAccessScopeAnalysisResult, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInsightsAnalysisCommand}
@@ -4296,10 +3795,7 @@ export interface EC2Service {
   deleteNetworkInsightsAnalysis(
     args: DeleteNetworkInsightsAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNetworkInsightsAnalysisResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNetworkInsightsAnalysisResult, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInsightsPathCommand}
@@ -4307,10 +3803,7 @@ export interface EC2Service {
   deleteNetworkInsightsPath(
     args: DeleteNetworkInsightsPathRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNetworkInsightsPathResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNetworkInsightsPathResult, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInterfaceCommand}
@@ -4318,10 +3811,7 @@ export interface EC2Service {
   deleteNetworkInterface(
     args: DeleteNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteNetworkInterfacePermissionCommand}
@@ -4329,10 +3819,7 @@ export interface EC2Service {
   deleteNetworkInterfacePermission(
     args: DeleteNetworkInterfacePermissionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteNetworkInterfacePermissionResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteNetworkInterfacePermissionResult, SdkError>;
 
   /**
    * @see {@link DeletePlacementGroupCommand}
@@ -4340,10 +3827,7 @@ export interface EC2Service {
   deletePlacementGroup(
     args: DeletePlacementGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeletePublicIpv4PoolCommand}
@@ -4351,10 +3835,7 @@ export interface EC2Service {
   deletePublicIpv4Pool(
     args: DeletePublicIpv4PoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeletePublicIpv4PoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeletePublicIpv4PoolResult, SdkError>;
 
   /**
    * @see {@link DeleteQueuedReservedInstancesCommand}
@@ -4362,10 +3843,7 @@ export interface EC2Service {
   deleteQueuedReservedInstances(
     args: DeleteQueuedReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteQueuedReservedInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteQueuedReservedInstancesResult, SdkError>;
 
   /**
    * @see {@link DeleteRouteCommand}
@@ -4373,10 +3851,7 @@ export interface EC2Service {
   deleteRoute(
     args: DeleteRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteRouteTableCommand}
@@ -4384,10 +3859,7 @@ export interface EC2Service {
   deleteRouteTable(
     args: DeleteRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteSecurityGroupCommand}
@@ -4395,10 +3867,7 @@ export interface EC2Service {
   deleteSecurityGroup(
     args: DeleteSecurityGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteSnapshotCommand}
@@ -4406,10 +3875,7 @@ export interface EC2Service {
   deleteSnapshot(
     args: DeleteSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteSpotDatafeedSubscriptionCommand}
@@ -4417,10 +3883,7 @@ export interface EC2Service {
   deleteSpotDatafeedSubscription(
     args: DeleteSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteSubnetCommand}
@@ -4428,10 +3891,7 @@ export interface EC2Service {
   deleteSubnet(
     args: DeleteSubnetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteSubnetCidrReservationCommand}
@@ -4439,10 +3899,7 @@ export interface EC2Service {
   deleteSubnetCidrReservation(
     args: DeleteSubnetCidrReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteSubnetCidrReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteSubnetCidrReservationResult, SdkError>;
 
   /**
    * @see {@link DeleteTagsCommand}
@@ -4450,10 +3907,7 @@ export interface EC2Service {
   deleteTags(
     args: DeleteTagsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteTrafficMirrorFilterCommand}
@@ -4461,10 +3915,7 @@ export interface EC2Service {
   deleteTrafficMirrorFilter(
     args: DeleteTrafficMirrorFilterRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTrafficMirrorFilterResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTrafficMirrorFilterResult, SdkError>;
 
   /**
    * @see {@link DeleteTrafficMirrorFilterRuleCommand}
@@ -4472,10 +3923,7 @@ export interface EC2Service {
   deleteTrafficMirrorFilterRule(
     args: DeleteTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTrafficMirrorFilterRuleResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTrafficMirrorFilterRuleResult, SdkError>;
 
   /**
    * @see {@link DeleteTrafficMirrorSessionCommand}
@@ -4483,10 +3931,7 @@ export interface EC2Service {
   deleteTrafficMirrorSession(
     args: DeleteTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTrafficMirrorSessionResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTrafficMirrorSessionResult, SdkError>;
 
   /**
    * @see {@link DeleteTrafficMirrorTargetCommand}
@@ -4494,10 +3939,7 @@ export interface EC2Service {
   deleteTrafficMirrorTarget(
     args: DeleteTrafficMirrorTargetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTrafficMirrorTargetResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTrafficMirrorTargetResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayCommand}
@@ -4505,10 +3947,7 @@ export interface EC2Service {
   deleteTransitGateway(
     args: DeleteTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayConnectCommand}
@@ -4516,10 +3955,7 @@ export interface EC2Service {
   deleteTransitGatewayConnect(
     args: DeleteTransitGatewayConnectRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayConnectResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayConnectResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayConnectPeerCommand}
@@ -4527,10 +3963,7 @@ export interface EC2Service {
   deleteTransitGatewayConnectPeer(
     args: DeleteTransitGatewayConnectPeerRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayConnectPeerResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayConnectPeerResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayMulticastDomainCommand}
@@ -4538,10 +3971,7 @@ export interface EC2Service {
   deleteTransitGatewayMulticastDomain(
     args: DeleteTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayMulticastDomainResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayMulticastDomainResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayPeeringAttachmentCommand}
@@ -4549,10 +3979,7 @@ export interface EC2Service {
   deleteTransitGatewayPeeringAttachment(
     args: DeleteTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayPeeringAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayPeeringAttachmentResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayPolicyTableCommand}
@@ -4560,10 +3987,7 @@ export interface EC2Service {
   deleteTransitGatewayPolicyTable(
     args: DeleteTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayPolicyTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayPolicyTableResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayPrefixListReferenceCommand}
@@ -4571,10 +3995,7 @@ export interface EC2Service {
   deleteTransitGatewayPrefixListReference(
     args: DeleteTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayPrefixListReferenceResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayPrefixListReferenceResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayRouteCommand}
@@ -4582,10 +4003,7 @@ export interface EC2Service {
   deleteTransitGatewayRoute(
     args: DeleteTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayRouteTableCommand}
@@ -4593,10 +4011,7 @@ export interface EC2Service {
   deleteTransitGatewayRouteTable(
     args: DeleteTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayRouteTableAnnouncementCommand}
@@ -4604,10 +4019,7 @@ export interface EC2Service {
   deleteTransitGatewayRouteTableAnnouncement(
     args: DeleteTransitGatewayRouteTableAnnouncementRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayRouteTableAnnouncementResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayRouteTableAnnouncementResult, SdkError>;
 
   /**
    * @see {@link DeleteTransitGatewayVpcAttachmentCommand}
@@ -4615,10 +4027,7 @@ export interface EC2Service {
   deleteTransitGatewayVpcAttachment(
     args: DeleteTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteTransitGatewayVpcAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteTransitGatewayVpcAttachmentResult, SdkError>;
 
   /**
    * @see {@link DeleteVerifiedAccessEndpointCommand}
@@ -4626,10 +4035,7 @@ export interface EC2Service {
   deleteVerifiedAccessEndpoint(
     args: DeleteVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVerifiedAccessEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVerifiedAccessEndpointResult, SdkError>;
 
   /**
    * @see {@link DeleteVerifiedAccessGroupCommand}
@@ -4637,10 +4043,7 @@ export interface EC2Service {
   deleteVerifiedAccessGroup(
     args: DeleteVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVerifiedAccessGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVerifiedAccessGroupResult, SdkError>;
 
   /**
    * @see {@link DeleteVerifiedAccessInstanceCommand}
@@ -4648,10 +4051,7 @@ export interface EC2Service {
   deleteVerifiedAccessInstance(
     args: DeleteVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVerifiedAccessInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVerifiedAccessInstanceResult, SdkError>;
 
   /**
    * @see {@link DeleteVerifiedAccessTrustProviderCommand}
@@ -4659,10 +4059,7 @@ export interface EC2Service {
   deleteVerifiedAccessTrustProvider(
     args: DeleteVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVerifiedAccessTrustProviderResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVerifiedAccessTrustProviderResult, SdkError>;
 
   /**
    * @see {@link DeleteVolumeCommand}
@@ -4670,10 +4067,7 @@ export interface EC2Service {
   deleteVolume(
     args: DeleteVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteVpcCommand}
@@ -4681,10 +4075,7 @@ export interface EC2Service {
   deleteVpc(
     args: DeleteVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteVpcEndpointConnectionNotificationsCommand}
@@ -4692,10 +4083,7 @@ export interface EC2Service {
   deleteVpcEndpointConnectionNotifications(
     args: DeleteVpcEndpointConnectionNotificationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVpcEndpointConnectionNotificationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVpcEndpointConnectionNotificationsResult, SdkError>;
 
   /**
    * @see {@link DeleteVpcEndpointServiceConfigurationsCommand}
@@ -4703,10 +4091,7 @@ export interface EC2Service {
   deleteVpcEndpointServiceConfigurations(
     args: DeleteVpcEndpointServiceConfigurationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVpcEndpointServiceConfigurationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVpcEndpointServiceConfigurationsResult, SdkError>;
 
   /**
    * @see {@link DeleteVpcEndpointsCommand}
@@ -4714,10 +4099,7 @@ export interface EC2Service {
   deleteVpcEndpoints(
     args: DeleteVpcEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVpcEndpointsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVpcEndpointsResult, SdkError>;
 
   /**
    * @see {@link DeleteVpcPeeringConnectionCommand}
@@ -4725,10 +4107,7 @@ export interface EC2Service {
   deleteVpcPeeringConnection(
     args: DeleteVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeleteVpcPeeringConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeleteVpcPeeringConnectionResult, SdkError>;
 
   /**
    * @see {@link DeleteVpnConnectionCommand}
@@ -4736,10 +4115,7 @@ export interface EC2Service {
   deleteVpnConnection(
     args: DeleteVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteVpnConnectionRouteCommand}
@@ -4747,10 +4123,7 @@ export interface EC2Service {
   deleteVpnConnectionRoute(
     args: DeleteVpnConnectionRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeleteVpnGatewayCommand}
@@ -4758,10 +4131,7 @@ export interface EC2Service {
   deleteVpnGateway(
     args: DeleteVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeprovisionByoipCidrCommand}
@@ -4769,10 +4139,7 @@ export interface EC2Service {
   deprovisionByoipCidr(
     args: DeprovisionByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeprovisionByoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeprovisionByoipCidrResult, SdkError>;
 
   /**
    * @see {@link DeprovisionIpamByoasnCommand}
@@ -4780,10 +4147,7 @@ export interface EC2Service {
   deprovisionIpamByoasn(
     args: DeprovisionIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeprovisionIpamByoasnResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeprovisionIpamByoasnResult, SdkError>;
 
   /**
    * @see {@link DeprovisionIpamPoolCidrCommand}
@@ -4791,10 +4155,7 @@ export interface EC2Service {
   deprovisionIpamPoolCidr(
     args: DeprovisionIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeprovisionIpamPoolCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeprovisionIpamPoolCidrResult, SdkError>;
 
   /**
    * @see {@link DeprovisionPublicIpv4PoolCidrCommand}
@@ -4802,10 +4163,7 @@ export interface EC2Service {
   deprovisionPublicIpv4PoolCidr(
     args: DeprovisionPublicIpv4PoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DeprovisionPublicIpv4PoolCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<DeprovisionPublicIpv4PoolCidrResult, SdkError>;
 
   /**
    * @see {@link DeregisterImageCommand}
@@ -4813,10 +4171,7 @@ export interface EC2Service {
   deregisterImage(
     args: DeregisterImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DeregisterInstanceEventNotificationAttributesCommand}
@@ -4825,9 +4180,9 @@ export interface EC2Service {
     args: DeregisterInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DeregisterInstanceEventNotificationAttributesResult,
-    | SdkError
-  >
+    DeregisterInstanceEventNotificationAttributesResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DeregisterTransitGatewayMulticastGroupMembersCommand}
@@ -4836,9 +4191,9 @@ export interface EC2Service {
     args: DeregisterTransitGatewayMulticastGroupMembersRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DeregisterTransitGatewayMulticastGroupMembersResult,
-    | SdkError
-  >
+    DeregisterTransitGatewayMulticastGroupMembersResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DeregisterTransitGatewayMulticastGroupSourcesCommand}
@@ -4847,9 +4202,9 @@ export interface EC2Service {
     args: DeregisterTransitGatewayMulticastGroupSourcesRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DeregisterTransitGatewayMulticastGroupSourcesResult,
-    | SdkError
-  >
+    DeregisterTransitGatewayMulticastGroupSourcesResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeAccountAttributesCommand}
@@ -4857,10 +4212,7 @@ export interface EC2Service {
   describeAccountAttributes(
     args: DescribeAccountAttributesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAccountAttributesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAccountAttributesResult, SdkError>;
 
   /**
    * @see {@link DescribeAddressTransfersCommand}
@@ -4868,10 +4220,7 @@ export interface EC2Service {
   describeAddressTransfers(
     args: DescribeAddressTransfersRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAddressTransfersResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAddressTransfersResult, SdkError>;
 
   /**
    * @see {@link DescribeAddressesCommand}
@@ -4879,10 +4228,7 @@ export interface EC2Service {
   describeAddresses(
     args: DescribeAddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAddressesResult, SdkError>;
 
   /**
    * @see {@link DescribeAddressesAttributeCommand}
@@ -4890,10 +4236,7 @@ export interface EC2Service {
   describeAddressesAttribute(
     args: DescribeAddressesAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAddressesAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAddressesAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeAggregateIdFormatCommand}
@@ -4901,10 +4244,7 @@ export interface EC2Service {
   describeAggregateIdFormat(
     args: DescribeAggregateIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAggregateIdFormatResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAggregateIdFormatResult, SdkError>;
 
   /**
    * @see {@link DescribeAvailabilityZonesCommand}
@@ -4912,10 +4252,7 @@ export interface EC2Service {
   describeAvailabilityZones(
     args: DescribeAvailabilityZonesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeAvailabilityZonesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeAvailabilityZonesResult, SdkError>;
 
   /**
    * @see {@link DescribeAwsNetworkPerformanceMetricSubscriptionsCommand}
@@ -4924,9 +4261,9 @@ export interface EC2Service {
     args: DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DescribeAwsNetworkPerformanceMetricSubscriptionsResult,
-    | SdkError
-  >
+    DescribeAwsNetworkPerformanceMetricSubscriptionsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeBundleTasksCommand}
@@ -4934,10 +4271,7 @@ export interface EC2Service {
   describeBundleTasks(
     args: DescribeBundleTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeBundleTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeBundleTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeByoipCidrsCommand}
@@ -4945,10 +4279,7 @@ export interface EC2Service {
   describeByoipCidrs(
     args: DescribeByoipCidrsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeByoipCidrsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeByoipCidrsResult, SdkError>;
 
   /**
    * @see {@link DescribeCapacityBlockOfferingsCommand}
@@ -4956,10 +4287,7 @@ export interface EC2Service {
   describeCapacityBlockOfferings(
     args: DescribeCapacityBlockOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCapacityBlockOfferingsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCapacityBlockOfferingsResult, SdkError>;
 
   /**
    * @see {@link DescribeCapacityReservationFleetsCommand}
@@ -4967,10 +4295,7 @@ export interface EC2Service {
   describeCapacityReservationFleets(
     args: DescribeCapacityReservationFleetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCapacityReservationFleetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCapacityReservationFleetsResult, SdkError>;
 
   /**
    * @see {@link DescribeCapacityReservationsCommand}
@@ -4978,10 +4303,7 @@ export interface EC2Service {
   describeCapacityReservations(
     args: DescribeCapacityReservationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCapacityReservationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCapacityReservationsResult, SdkError>;
 
   /**
    * @see {@link DescribeCarrierGatewaysCommand}
@@ -4989,10 +4311,7 @@ export interface EC2Service {
   describeCarrierGateways(
     args: DescribeCarrierGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCarrierGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCarrierGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeClassicLinkInstancesCommand}
@@ -5000,10 +4319,7 @@ export interface EC2Service {
   describeClassicLinkInstances(
     args: DescribeClassicLinkInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClassicLinkInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClassicLinkInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeClientVpnAuthorizationRulesCommand}
@@ -5011,10 +4327,7 @@ export interface EC2Service {
   describeClientVpnAuthorizationRules(
     args: DescribeClientVpnAuthorizationRulesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClientVpnAuthorizationRulesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClientVpnAuthorizationRulesResult, SdkError>;
 
   /**
    * @see {@link DescribeClientVpnConnectionsCommand}
@@ -5022,10 +4335,7 @@ export interface EC2Service {
   describeClientVpnConnections(
     args: DescribeClientVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClientVpnConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClientVpnConnectionsResult, SdkError>;
 
   /**
    * @see {@link DescribeClientVpnEndpointsCommand}
@@ -5033,10 +4343,7 @@ export interface EC2Service {
   describeClientVpnEndpoints(
     args: DescribeClientVpnEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClientVpnEndpointsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClientVpnEndpointsResult, SdkError>;
 
   /**
    * @see {@link DescribeClientVpnRoutesCommand}
@@ -5044,10 +4351,7 @@ export interface EC2Service {
   describeClientVpnRoutes(
     args: DescribeClientVpnRoutesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClientVpnRoutesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClientVpnRoutesResult, SdkError>;
 
   /**
    * @see {@link DescribeClientVpnTargetNetworksCommand}
@@ -5055,10 +4359,7 @@ export interface EC2Service {
   describeClientVpnTargetNetworks(
     args: DescribeClientVpnTargetNetworksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeClientVpnTargetNetworksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeClientVpnTargetNetworksResult, SdkError>;
 
   /**
    * @see {@link DescribeCoipPoolsCommand}
@@ -5066,10 +4367,7 @@ export interface EC2Service {
   describeCoipPools(
     args: DescribeCoipPoolsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCoipPoolsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCoipPoolsResult, SdkError>;
 
   /**
    * @see {@link DescribeConversionTasksCommand}
@@ -5077,10 +4375,7 @@ export interface EC2Service {
   describeConversionTasks(
     args: DescribeConversionTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeConversionTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeConversionTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeCustomerGatewaysCommand}
@@ -5088,10 +4383,7 @@ export interface EC2Service {
   describeCustomerGateways(
     args: DescribeCustomerGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeCustomerGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeCustomerGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeDhcpOptionsCommand}
@@ -5099,10 +4391,7 @@ export interface EC2Service {
   describeDhcpOptions(
     args: DescribeDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeDhcpOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeDhcpOptionsResult, SdkError>;
 
   /**
    * @see {@link DescribeEgressOnlyInternetGatewaysCommand}
@@ -5110,10 +4399,7 @@ export interface EC2Service {
   describeEgressOnlyInternetGateways(
     args: DescribeEgressOnlyInternetGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeEgressOnlyInternetGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeEgressOnlyInternetGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeElasticGpusCommand}
@@ -5121,10 +4407,7 @@ export interface EC2Service {
   describeElasticGpus(
     args: DescribeElasticGpusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeElasticGpusResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeElasticGpusResult, SdkError>;
 
   /**
    * @see {@link DescribeExportImageTasksCommand}
@@ -5132,10 +4415,7 @@ export interface EC2Service {
   describeExportImageTasks(
     args: DescribeExportImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeExportImageTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeExportImageTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeExportTasksCommand}
@@ -5143,10 +4423,7 @@ export interface EC2Service {
   describeExportTasks(
     args: DescribeExportTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeExportTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeExportTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeFastLaunchImagesCommand}
@@ -5154,10 +4431,7 @@ export interface EC2Service {
   describeFastLaunchImages(
     args: DescribeFastLaunchImagesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFastLaunchImagesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFastLaunchImagesResult, SdkError>;
 
   /**
    * @see {@link DescribeFastSnapshotRestoresCommand}
@@ -5165,10 +4439,7 @@ export interface EC2Service {
   describeFastSnapshotRestores(
     args: DescribeFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFastSnapshotRestoresResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFastSnapshotRestoresResult, SdkError>;
 
   /**
    * @see {@link DescribeFleetHistoryCommand}
@@ -5176,10 +4447,7 @@ export interface EC2Service {
   describeFleetHistory(
     args: DescribeFleetHistoryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFleetHistoryResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFleetHistoryResult, SdkError>;
 
   /**
    * @see {@link DescribeFleetInstancesCommand}
@@ -5187,10 +4455,7 @@ export interface EC2Service {
   describeFleetInstances(
     args: DescribeFleetInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFleetInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFleetInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeFleetsCommand}
@@ -5198,10 +4463,7 @@ export interface EC2Service {
   describeFleets(
     args: DescribeFleetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFleetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFleetsResult, SdkError>;
 
   /**
    * @see {@link DescribeFlowLogsCommand}
@@ -5209,10 +4471,7 @@ export interface EC2Service {
   describeFlowLogs(
     args: DescribeFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFlowLogsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFlowLogsResult, SdkError>;
 
   /**
    * @see {@link DescribeFpgaImageAttributeCommand}
@@ -5220,10 +4479,7 @@ export interface EC2Service {
   describeFpgaImageAttribute(
     args: DescribeFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFpgaImageAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFpgaImageAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeFpgaImagesCommand}
@@ -5231,10 +4487,7 @@ export interface EC2Service {
   describeFpgaImages(
     args: DescribeFpgaImagesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeFpgaImagesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeFpgaImagesResult, SdkError>;
 
   /**
    * @see {@link DescribeHostReservationOfferingsCommand}
@@ -5242,10 +4495,7 @@ export interface EC2Service {
   describeHostReservationOfferings(
     args: DescribeHostReservationOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeHostReservationOfferingsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeHostReservationOfferingsResult, SdkError>;
 
   /**
    * @see {@link DescribeHostReservationsCommand}
@@ -5253,10 +4503,7 @@ export interface EC2Service {
   describeHostReservations(
     args: DescribeHostReservationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeHostReservationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeHostReservationsResult, SdkError>;
 
   /**
    * @see {@link DescribeHostsCommand}
@@ -5264,10 +4511,7 @@ export interface EC2Service {
   describeHosts(
     args: DescribeHostsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeHostsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeHostsResult, SdkError>;
 
   /**
    * @see {@link DescribeIamInstanceProfileAssociationsCommand}
@@ -5275,10 +4519,7 @@ export interface EC2Service {
   describeIamInstanceProfileAssociations(
     args: DescribeIamInstanceProfileAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIamInstanceProfileAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIamInstanceProfileAssociationsResult, SdkError>;
 
   /**
    * @see {@link DescribeIdFormatCommand}
@@ -5286,10 +4527,7 @@ export interface EC2Service {
   describeIdFormat(
     args: DescribeIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIdFormatResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIdFormatResult, SdkError>;
 
   /**
    * @see {@link DescribeIdentityIdFormatCommand}
@@ -5297,10 +4535,7 @@ export interface EC2Service {
   describeIdentityIdFormat(
     args: DescribeIdentityIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIdentityIdFormatResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIdentityIdFormatResult, SdkError>;
 
   /**
    * @see {@link DescribeImageAttributeCommand}
@@ -5308,10 +4543,7 @@ export interface EC2Service {
   describeImageAttribute(
     args: DescribeImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImageAttribute,
-    | SdkError
-  >
+  ): Effect.Effect<ImageAttribute, SdkError>;
 
   /**
    * @see {@link DescribeImagesCommand}
@@ -5319,10 +4551,7 @@ export interface EC2Service {
   describeImages(
     args: DescribeImagesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeImagesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeImagesResult, SdkError>;
 
   /**
    * @see {@link DescribeImportImageTasksCommand}
@@ -5330,10 +4559,7 @@ export interface EC2Service {
   describeImportImageTasks(
     args: DescribeImportImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeImportImageTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeImportImageTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeImportSnapshotTasksCommand}
@@ -5341,10 +4567,7 @@ export interface EC2Service {
   describeImportSnapshotTasks(
     args: DescribeImportSnapshotTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeImportSnapshotTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeImportSnapshotTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceAttributeCommand}
@@ -5352,10 +4575,7 @@ export interface EC2Service {
   describeInstanceAttribute(
     args: DescribeInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  InstanceAttribute,
-    | SdkError
-  >
+  ): Effect.Effect<InstanceAttribute, SdkError>;
 
   /**
    * @see {@link DescribeInstanceConnectEndpointsCommand}
@@ -5363,10 +4583,7 @@ export interface EC2Service {
   describeInstanceConnectEndpoints(
     args: DescribeInstanceConnectEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceConnectEndpointsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceConnectEndpointsResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceCreditSpecificationsCommand}
@@ -5374,10 +4591,7 @@ export interface EC2Service {
   describeInstanceCreditSpecifications(
     args: DescribeInstanceCreditSpecificationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceCreditSpecificationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceCreditSpecificationsResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceEventNotificationAttributesCommand}
@@ -5385,10 +4599,7 @@ export interface EC2Service {
   describeInstanceEventNotificationAttributes(
     args: DescribeInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceEventNotificationAttributesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceEventNotificationAttributesResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceEventWindowsCommand}
@@ -5396,10 +4607,7 @@ export interface EC2Service {
   describeInstanceEventWindows(
     args: DescribeInstanceEventWindowsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceEventWindowsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceEventWindowsResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceStatusCommand}
@@ -5407,10 +4615,7 @@ export interface EC2Service {
   describeInstanceStatus(
     args: DescribeInstanceStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceStatusResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceStatusResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceTopologyCommand}
@@ -5418,10 +4623,7 @@ export interface EC2Service {
   describeInstanceTopology(
     args: DescribeInstanceTopologyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceTopologyResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceTopologyResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceTypeOfferingsCommand}
@@ -5429,10 +4631,7 @@ export interface EC2Service {
   describeInstanceTypeOfferings(
     args: DescribeInstanceTypeOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceTypeOfferingsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceTypeOfferingsResult, SdkError>;
 
   /**
    * @see {@link DescribeInstanceTypesCommand}
@@ -5440,10 +4639,7 @@ export interface EC2Service {
   describeInstanceTypes(
     args: DescribeInstanceTypesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstanceTypesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstanceTypesResult, SdkError>;
 
   /**
    * @see {@link DescribeInstancesCommand}
@@ -5451,10 +4647,7 @@ export interface EC2Service {
   describeInstances(
     args: DescribeInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeInternetGatewaysCommand}
@@ -5462,10 +4655,7 @@ export interface EC2Service {
   describeInternetGateways(
     args: DescribeInternetGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeInternetGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeInternetGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamByoasnCommand}
@@ -5473,10 +4663,7 @@ export interface EC2Service {
   describeIpamByoasn(
     args: DescribeIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamByoasnResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamByoasnResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamPoolsCommand}
@@ -5484,10 +4671,7 @@ export interface EC2Service {
   describeIpamPools(
     args: DescribeIpamPoolsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamPoolsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamPoolsResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamResourceDiscoveriesCommand}
@@ -5495,10 +4679,7 @@ export interface EC2Service {
   describeIpamResourceDiscoveries(
     args: DescribeIpamResourceDiscoveriesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamResourceDiscoveriesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamResourceDiscoveriesResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamResourceDiscoveryAssociationsCommand}
@@ -5506,10 +4687,7 @@ export interface EC2Service {
   describeIpamResourceDiscoveryAssociations(
     args: DescribeIpamResourceDiscoveryAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamResourceDiscoveryAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamResourceDiscoveryAssociationsResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamScopesCommand}
@@ -5517,10 +4695,7 @@ export interface EC2Service {
   describeIpamScopes(
     args: DescribeIpamScopesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamScopesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamScopesResult, SdkError>;
 
   /**
    * @see {@link DescribeIpamsCommand}
@@ -5528,10 +4703,7 @@ export interface EC2Service {
   describeIpams(
     args: DescribeIpamsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpamsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpamsResult, SdkError>;
 
   /**
    * @see {@link DescribeIpv6PoolsCommand}
@@ -5539,10 +4711,7 @@ export interface EC2Service {
   describeIpv6Pools(
     args: DescribeIpv6PoolsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeIpv6PoolsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeIpv6PoolsResult, SdkError>;
 
   /**
    * @see {@link DescribeKeyPairsCommand}
@@ -5550,10 +4719,7 @@ export interface EC2Service {
   describeKeyPairs(
     args: DescribeKeyPairsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeKeyPairsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeKeyPairsResult, SdkError>;
 
   /**
    * @see {@link DescribeLaunchTemplateVersionsCommand}
@@ -5561,10 +4727,7 @@ export interface EC2Service {
   describeLaunchTemplateVersions(
     args: DescribeLaunchTemplateVersionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLaunchTemplateVersionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLaunchTemplateVersionsResult, SdkError>;
 
   /**
    * @see {@link DescribeLaunchTemplatesCommand}
@@ -5572,10 +4735,7 @@ export interface EC2Service {
   describeLaunchTemplates(
     args: DescribeLaunchTemplatesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLaunchTemplatesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLaunchTemplatesResult, SdkError>;
 
   /**
    * @see {@link DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand}
@@ -5584,9 +4744,9 @@ export interface EC2Service {
     args: DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult,
-    | SdkError
-  >
+    DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeLocalGatewayRouteTableVpcAssociationsCommand}
@@ -5595,9 +4755,9 @@ export interface EC2Service {
     args: DescribeLocalGatewayRouteTableVpcAssociationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DescribeLocalGatewayRouteTableVpcAssociationsResult,
-    | SdkError
-  >
+    DescribeLocalGatewayRouteTableVpcAssociationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeLocalGatewayRouteTablesCommand}
@@ -5605,10 +4765,7 @@ export interface EC2Service {
   describeLocalGatewayRouteTables(
     args: DescribeLocalGatewayRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLocalGatewayRouteTablesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLocalGatewayRouteTablesResult, SdkError>;
 
   /**
    * @see {@link DescribeLocalGatewayVirtualInterfaceGroupsCommand}
@@ -5616,10 +4773,7 @@ export interface EC2Service {
   describeLocalGatewayVirtualInterfaceGroups(
     args: DescribeLocalGatewayVirtualInterfaceGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLocalGatewayVirtualInterfaceGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLocalGatewayVirtualInterfaceGroupsResult, SdkError>;
 
   /**
    * @see {@link DescribeLocalGatewayVirtualInterfacesCommand}
@@ -5627,10 +4781,7 @@ export interface EC2Service {
   describeLocalGatewayVirtualInterfaces(
     args: DescribeLocalGatewayVirtualInterfacesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLocalGatewayVirtualInterfacesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLocalGatewayVirtualInterfacesResult, SdkError>;
 
   /**
    * @see {@link DescribeLocalGatewaysCommand}
@@ -5638,10 +4789,7 @@ export interface EC2Service {
   describeLocalGateways(
     args: DescribeLocalGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLocalGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLocalGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeLockedSnapshotsCommand}
@@ -5649,10 +4797,7 @@ export interface EC2Service {
   describeLockedSnapshots(
     args: DescribeLockedSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeLockedSnapshotsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeLockedSnapshotsResult, SdkError>;
 
   /**
    * @see {@link DescribeMacHostsCommand}
@@ -5660,10 +4805,7 @@ export interface EC2Service {
   describeMacHosts(
     args: DescribeMacHostsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeMacHostsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeMacHostsResult, SdkError>;
 
   /**
    * @see {@link DescribeManagedPrefixListsCommand}
@@ -5671,10 +4813,7 @@ export interface EC2Service {
   describeManagedPrefixLists(
     args: DescribeManagedPrefixListsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeManagedPrefixListsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeManagedPrefixListsResult, SdkError>;
 
   /**
    * @see {@link DescribeMovingAddressesCommand}
@@ -5682,10 +4821,7 @@ export interface EC2Service {
   describeMovingAddresses(
     args: DescribeMovingAddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeMovingAddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeMovingAddressesResult, SdkError>;
 
   /**
    * @see {@link DescribeNatGatewaysCommand}
@@ -5693,10 +4829,7 @@ export interface EC2Service {
   describeNatGateways(
     args: DescribeNatGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNatGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNatGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkAclsCommand}
@@ -5704,10 +4837,7 @@ export interface EC2Service {
   describeNetworkAcls(
     args: DescribeNetworkAclsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkAclsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkAclsResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInsightsAccessScopeAnalysesCommand}
@@ -5715,10 +4845,7 @@ export interface EC2Service {
   describeNetworkInsightsAccessScopeAnalyses(
     args: DescribeNetworkInsightsAccessScopeAnalysesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInsightsAccessScopeAnalysesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInsightsAccessScopeAnalysesResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInsightsAccessScopesCommand}
@@ -5726,10 +4853,7 @@ export interface EC2Service {
   describeNetworkInsightsAccessScopes(
     args: DescribeNetworkInsightsAccessScopesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInsightsAccessScopesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInsightsAccessScopesResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInsightsAnalysesCommand}
@@ -5737,10 +4861,7 @@ export interface EC2Service {
   describeNetworkInsightsAnalyses(
     args: DescribeNetworkInsightsAnalysesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInsightsAnalysesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInsightsAnalysesResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInsightsPathsCommand}
@@ -5748,10 +4869,7 @@ export interface EC2Service {
   describeNetworkInsightsPaths(
     args: DescribeNetworkInsightsPathsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInsightsPathsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInsightsPathsResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInterfaceAttributeCommand}
@@ -5759,10 +4877,7 @@ export interface EC2Service {
   describeNetworkInterfaceAttribute(
     args: DescribeNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInterfaceAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInterfaceAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInterfacePermissionsCommand}
@@ -5770,10 +4885,7 @@ export interface EC2Service {
   describeNetworkInterfacePermissions(
     args: DescribeNetworkInterfacePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInterfacePermissionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInterfacePermissionsResult, SdkError>;
 
   /**
    * @see {@link DescribeNetworkInterfacesCommand}
@@ -5781,10 +4893,7 @@ export interface EC2Service {
   describeNetworkInterfaces(
     args: DescribeNetworkInterfacesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeNetworkInterfacesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeNetworkInterfacesResult, SdkError>;
 
   /**
    * @see {@link DescribePlacementGroupsCommand}
@@ -5792,10 +4901,7 @@ export interface EC2Service {
   describePlacementGroups(
     args: DescribePlacementGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribePlacementGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribePlacementGroupsResult, SdkError>;
 
   /**
    * @see {@link DescribePrefixListsCommand}
@@ -5803,10 +4909,7 @@ export interface EC2Service {
   describePrefixLists(
     args: DescribePrefixListsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribePrefixListsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribePrefixListsResult, SdkError>;
 
   /**
    * @see {@link DescribePrincipalIdFormatCommand}
@@ -5814,10 +4917,7 @@ export interface EC2Service {
   describePrincipalIdFormat(
     args: DescribePrincipalIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribePrincipalIdFormatResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribePrincipalIdFormatResult, SdkError>;
 
   /**
    * @see {@link DescribePublicIpv4PoolsCommand}
@@ -5825,10 +4925,7 @@ export interface EC2Service {
   describePublicIpv4Pools(
     args: DescribePublicIpv4PoolsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribePublicIpv4PoolsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribePublicIpv4PoolsResult, SdkError>;
 
   /**
    * @see {@link DescribeRegionsCommand}
@@ -5836,10 +4933,7 @@ export interface EC2Service {
   describeRegions(
     args: DescribeRegionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeRegionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeRegionsResult, SdkError>;
 
   /**
    * @see {@link DescribeReplaceRootVolumeTasksCommand}
@@ -5847,10 +4941,7 @@ export interface EC2Service {
   describeReplaceRootVolumeTasks(
     args: DescribeReplaceRootVolumeTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeReplaceRootVolumeTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeReplaceRootVolumeTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeReservedInstancesCommand}
@@ -5858,10 +4949,7 @@ export interface EC2Service {
   describeReservedInstances(
     args: DescribeReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeReservedInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeReservedInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeReservedInstancesListingsCommand}
@@ -5869,10 +4957,7 @@ export interface EC2Service {
   describeReservedInstancesListings(
     args: DescribeReservedInstancesListingsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeReservedInstancesListingsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeReservedInstancesListingsResult, SdkError>;
 
   /**
    * @see {@link DescribeReservedInstancesModificationsCommand}
@@ -5880,10 +4965,7 @@ export interface EC2Service {
   describeReservedInstancesModifications(
     args: DescribeReservedInstancesModificationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeReservedInstancesModificationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeReservedInstancesModificationsResult, SdkError>;
 
   /**
    * @see {@link DescribeReservedInstancesOfferingsCommand}
@@ -5891,10 +4973,7 @@ export interface EC2Service {
   describeReservedInstancesOfferings(
     args: DescribeReservedInstancesOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeReservedInstancesOfferingsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeReservedInstancesOfferingsResult, SdkError>;
 
   /**
    * @see {@link DescribeRouteTablesCommand}
@@ -5902,10 +4981,7 @@ export interface EC2Service {
   describeRouteTables(
     args: DescribeRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeRouteTablesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeRouteTablesResult, SdkError>;
 
   /**
    * @see {@link DescribeScheduledInstanceAvailabilityCommand}
@@ -5913,10 +4989,7 @@ export interface EC2Service {
   describeScheduledInstanceAvailability(
     args: DescribeScheduledInstanceAvailabilityRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeScheduledInstanceAvailabilityResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeScheduledInstanceAvailabilityResult, SdkError>;
 
   /**
    * @see {@link DescribeScheduledInstancesCommand}
@@ -5924,10 +4997,7 @@ export interface EC2Service {
   describeScheduledInstances(
     args: DescribeScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeScheduledInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeScheduledInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeSecurityGroupReferencesCommand}
@@ -5935,10 +5005,7 @@ export interface EC2Service {
   describeSecurityGroupReferences(
     args: DescribeSecurityGroupReferencesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSecurityGroupReferencesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSecurityGroupReferencesResult, SdkError>;
 
   /**
    * @see {@link DescribeSecurityGroupRulesCommand}
@@ -5946,10 +5013,7 @@ export interface EC2Service {
   describeSecurityGroupRules(
     args: DescribeSecurityGroupRulesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSecurityGroupRulesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSecurityGroupRulesResult, SdkError>;
 
   /**
    * @see {@link DescribeSecurityGroupsCommand}
@@ -5957,10 +5021,7 @@ export interface EC2Service {
   describeSecurityGroups(
     args: DescribeSecurityGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSecurityGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSecurityGroupsResult, SdkError>;
 
   /**
    * @see {@link DescribeSnapshotAttributeCommand}
@@ -5968,10 +5029,7 @@ export interface EC2Service {
   describeSnapshotAttribute(
     args: DescribeSnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSnapshotAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSnapshotAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeSnapshotTierStatusCommand}
@@ -5979,10 +5037,7 @@ export interface EC2Service {
   describeSnapshotTierStatus(
     args: DescribeSnapshotTierStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSnapshotTierStatusResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSnapshotTierStatusResult, SdkError>;
 
   /**
    * @see {@link DescribeSnapshotsCommand}
@@ -5990,10 +5045,7 @@ export interface EC2Service {
   describeSnapshots(
     args: DescribeSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSnapshotsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSnapshotsResult, SdkError>;
 
   /**
    * @see {@link DescribeSpotDatafeedSubscriptionCommand}
@@ -6001,10 +5053,7 @@ export interface EC2Service {
   describeSpotDatafeedSubscription(
     args: DescribeSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotDatafeedSubscriptionResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotDatafeedSubscriptionResult, SdkError>;
 
   /**
    * @see {@link DescribeSpotFleetInstancesCommand}
@@ -6012,10 +5061,7 @@ export interface EC2Service {
   describeSpotFleetInstances(
     args: DescribeSpotFleetInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotFleetInstancesResponse,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotFleetInstancesResponse, SdkError>;
 
   /**
    * @see {@link DescribeSpotFleetRequestHistoryCommand}
@@ -6023,10 +5069,7 @@ export interface EC2Service {
   describeSpotFleetRequestHistory(
     args: DescribeSpotFleetRequestHistoryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotFleetRequestHistoryResponse,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotFleetRequestHistoryResponse, SdkError>;
 
   /**
    * @see {@link DescribeSpotFleetRequestsCommand}
@@ -6034,10 +5077,7 @@ export interface EC2Service {
   describeSpotFleetRequests(
     args: DescribeSpotFleetRequestsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotFleetRequestsResponse,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotFleetRequestsResponse, SdkError>;
 
   /**
    * @see {@link DescribeSpotInstanceRequestsCommand}
@@ -6045,10 +5085,7 @@ export interface EC2Service {
   describeSpotInstanceRequests(
     args: DescribeSpotInstanceRequestsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotInstanceRequestsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotInstanceRequestsResult, SdkError>;
 
   /**
    * @see {@link DescribeSpotPriceHistoryCommand}
@@ -6056,10 +5093,7 @@ export interface EC2Service {
   describeSpotPriceHistory(
     args: DescribeSpotPriceHistoryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSpotPriceHistoryResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSpotPriceHistoryResult, SdkError>;
 
   /**
    * @see {@link DescribeStaleSecurityGroupsCommand}
@@ -6067,10 +5101,7 @@ export interface EC2Service {
   describeStaleSecurityGroups(
     args: DescribeStaleSecurityGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeStaleSecurityGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeStaleSecurityGroupsResult, SdkError>;
 
   /**
    * @see {@link DescribeStoreImageTasksCommand}
@@ -6078,10 +5109,7 @@ export interface EC2Service {
   describeStoreImageTasks(
     args: DescribeStoreImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeStoreImageTasksResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeStoreImageTasksResult, SdkError>;
 
   /**
    * @see {@link DescribeSubnetsCommand}
@@ -6089,10 +5117,7 @@ export interface EC2Service {
   describeSubnets(
     args: DescribeSubnetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeSubnetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeSubnetsResult, SdkError>;
 
   /**
    * @see {@link DescribeTagsCommand}
@@ -6100,10 +5125,7 @@ export interface EC2Service {
   describeTags(
     args: DescribeTagsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTagsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTagsResult, SdkError>;
 
   /**
    * @see {@link DescribeTrafficMirrorFiltersCommand}
@@ -6111,10 +5133,7 @@ export interface EC2Service {
   describeTrafficMirrorFilters(
     args: DescribeTrafficMirrorFiltersRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTrafficMirrorFiltersResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTrafficMirrorFiltersResult, SdkError>;
 
   /**
    * @see {@link DescribeTrafficMirrorSessionsCommand}
@@ -6122,10 +5141,7 @@ export interface EC2Service {
   describeTrafficMirrorSessions(
     args: DescribeTrafficMirrorSessionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTrafficMirrorSessionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTrafficMirrorSessionsResult, SdkError>;
 
   /**
    * @see {@link DescribeTrafficMirrorTargetsCommand}
@@ -6133,10 +5149,7 @@ export interface EC2Service {
   describeTrafficMirrorTargets(
     args: DescribeTrafficMirrorTargetsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTrafficMirrorTargetsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTrafficMirrorTargetsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayAttachmentsCommand}
@@ -6144,10 +5157,7 @@ export interface EC2Service {
   describeTransitGatewayAttachments(
     args: DescribeTransitGatewayAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayAttachmentsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayAttachmentsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayConnectPeersCommand}
@@ -6155,10 +5165,7 @@ export interface EC2Service {
   describeTransitGatewayConnectPeers(
     args: DescribeTransitGatewayConnectPeersRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayConnectPeersResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayConnectPeersResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayConnectsCommand}
@@ -6166,10 +5173,7 @@ export interface EC2Service {
   describeTransitGatewayConnects(
     args: DescribeTransitGatewayConnectsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayConnectsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayConnectsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayMulticastDomainsCommand}
@@ -6177,10 +5181,7 @@ export interface EC2Service {
   describeTransitGatewayMulticastDomains(
     args: DescribeTransitGatewayMulticastDomainsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayMulticastDomainsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayMulticastDomainsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayPeeringAttachmentsCommand}
@@ -6188,10 +5189,7 @@ export interface EC2Service {
   describeTransitGatewayPeeringAttachments(
     args: DescribeTransitGatewayPeeringAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayPeeringAttachmentsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayPeeringAttachmentsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayPolicyTablesCommand}
@@ -6199,10 +5197,7 @@ export interface EC2Service {
   describeTransitGatewayPolicyTables(
     args: DescribeTransitGatewayPolicyTablesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayPolicyTablesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayPolicyTablesResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayRouteTableAnnouncementsCommand}
@@ -6211,9 +5206,9 @@ export interface EC2Service {
     args: DescribeTransitGatewayRouteTableAnnouncementsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DescribeTransitGatewayRouteTableAnnouncementsResult,
-    | SdkError
-  >
+    DescribeTransitGatewayRouteTableAnnouncementsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeTransitGatewayRouteTablesCommand}
@@ -6221,10 +5216,7 @@ export interface EC2Service {
   describeTransitGatewayRouteTables(
     args: DescribeTransitGatewayRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayRouteTablesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayRouteTablesResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewayVpcAttachmentsCommand}
@@ -6232,10 +5224,7 @@ export interface EC2Service {
   describeTransitGatewayVpcAttachments(
     args: DescribeTransitGatewayVpcAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewayVpcAttachmentsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewayVpcAttachmentsResult, SdkError>;
 
   /**
    * @see {@link DescribeTransitGatewaysCommand}
@@ -6243,10 +5232,7 @@ export interface EC2Service {
   describeTransitGateways(
     args: DescribeTransitGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTransitGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTransitGatewaysResult, SdkError>;
 
   /**
    * @see {@link DescribeTrunkInterfaceAssociationsCommand}
@@ -6254,10 +5240,7 @@ export interface EC2Service {
   describeTrunkInterfaceAssociations(
     args: DescribeTrunkInterfaceAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeTrunkInterfaceAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeTrunkInterfaceAssociationsResult, SdkError>;
 
   /**
    * @see {@link DescribeVerifiedAccessEndpointsCommand}
@@ -6265,10 +5248,7 @@ export interface EC2Service {
   describeVerifiedAccessEndpoints(
     args: DescribeVerifiedAccessEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVerifiedAccessEndpointsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVerifiedAccessEndpointsResult, SdkError>;
 
   /**
    * @see {@link DescribeVerifiedAccessGroupsCommand}
@@ -6276,10 +5256,7 @@ export interface EC2Service {
   describeVerifiedAccessGroups(
     args: DescribeVerifiedAccessGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVerifiedAccessGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVerifiedAccessGroupsResult, SdkError>;
 
   /**
    * @see {@link DescribeVerifiedAccessInstanceLoggingConfigurationsCommand}
@@ -6288,9 +5265,9 @@ export interface EC2Service {
     args: DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
-    | SdkError
-  >
+    DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DescribeVerifiedAccessInstancesCommand}
@@ -6298,10 +5275,7 @@ export interface EC2Service {
   describeVerifiedAccessInstances(
     args: DescribeVerifiedAccessInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVerifiedAccessInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVerifiedAccessInstancesResult, SdkError>;
 
   /**
    * @see {@link DescribeVerifiedAccessTrustProvidersCommand}
@@ -6309,10 +5283,7 @@ export interface EC2Service {
   describeVerifiedAccessTrustProviders(
     args: DescribeVerifiedAccessTrustProvidersRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVerifiedAccessTrustProvidersResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVerifiedAccessTrustProvidersResult, SdkError>;
 
   /**
    * @see {@link DescribeVolumeAttributeCommand}
@@ -6320,10 +5291,7 @@ export interface EC2Service {
   describeVolumeAttribute(
     args: DescribeVolumeAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVolumeAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVolumeAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeVolumeStatusCommand}
@@ -6331,10 +5299,7 @@ export interface EC2Service {
   describeVolumeStatus(
     args: DescribeVolumeStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVolumeStatusResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVolumeStatusResult, SdkError>;
 
   /**
    * @see {@link DescribeVolumesCommand}
@@ -6342,10 +5307,7 @@ export interface EC2Service {
   describeVolumes(
     args: DescribeVolumesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVolumesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVolumesResult, SdkError>;
 
   /**
    * @see {@link DescribeVolumesModificationsCommand}
@@ -6353,10 +5315,7 @@ export interface EC2Service {
   describeVolumesModifications(
     args: DescribeVolumesModificationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVolumesModificationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVolumesModificationsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcAttributeCommand}
@@ -6364,10 +5323,7 @@ export interface EC2Service {
   describeVpcAttribute(
     args: DescribeVpcAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcAttributeResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcClassicLinkCommand}
@@ -6375,10 +5331,7 @@ export interface EC2Service {
   describeVpcClassicLink(
     args: DescribeVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcClassicLinkResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcClassicLinkResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcClassicLinkDnsSupportCommand}
@@ -6386,10 +5339,7 @@ export interface EC2Service {
   describeVpcClassicLinkDnsSupport(
     args: DescribeVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcClassicLinkDnsSupportResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcClassicLinkDnsSupportResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointConnectionNotificationsCommand}
@@ -6397,10 +5347,7 @@ export interface EC2Service {
   describeVpcEndpointConnectionNotifications(
     args: DescribeVpcEndpointConnectionNotificationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointConnectionNotificationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointConnectionNotificationsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointConnectionsCommand}
@@ -6408,10 +5355,7 @@ export interface EC2Service {
   describeVpcEndpointConnections(
     args: DescribeVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointConnectionsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointServiceConfigurationsCommand}
@@ -6419,10 +5363,7 @@ export interface EC2Service {
   describeVpcEndpointServiceConfigurations(
     args: DescribeVpcEndpointServiceConfigurationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointServiceConfigurationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointServiceConfigurationsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointServicePermissionsCommand}
@@ -6430,10 +5371,7 @@ export interface EC2Service {
   describeVpcEndpointServicePermissions(
     args: DescribeVpcEndpointServicePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointServicePermissionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointServicePermissionsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointServicesCommand}
@@ -6441,10 +5379,7 @@ export interface EC2Service {
   describeVpcEndpointServices(
     args: DescribeVpcEndpointServicesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointServicesResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointServicesResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcEndpointsCommand}
@@ -6452,10 +5387,7 @@ export interface EC2Service {
   describeVpcEndpoints(
     args: DescribeVpcEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcEndpointsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcEndpointsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcPeeringConnectionsCommand}
@@ -6463,10 +5395,7 @@ export interface EC2Service {
   describeVpcPeeringConnections(
     args: DescribeVpcPeeringConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcPeeringConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcPeeringConnectionsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpcsCommand}
@@ -6474,10 +5403,7 @@ export interface EC2Service {
   describeVpcs(
     args: DescribeVpcsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpcsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpcsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpnConnectionsCommand}
@@ -6485,10 +5411,7 @@ export interface EC2Service {
   describeVpnConnections(
     args: DescribeVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpnConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpnConnectionsResult, SdkError>;
 
   /**
    * @see {@link DescribeVpnGatewaysCommand}
@@ -6496,10 +5419,7 @@ export interface EC2Service {
   describeVpnGateways(
     args: DescribeVpnGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DescribeVpnGatewaysResult,
-    | SdkError
-  >
+  ): Effect.Effect<DescribeVpnGatewaysResult, SdkError>;
 
   /**
    * @see {@link DetachClassicLinkVpcCommand}
@@ -6507,10 +5427,7 @@ export interface EC2Service {
   detachClassicLinkVpc(
     args: DetachClassicLinkVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DetachClassicLinkVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<DetachClassicLinkVpcResult, SdkError>;
 
   /**
    * @see {@link DetachInternetGatewayCommand}
@@ -6518,10 +5435,7 @@ export interface EC2Service {
   detachInternetGateway(
     args: DetachInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DetachNetworkInterfaceCommand}
@@ -6529,10 +5443,7 @@ export interface EC2Service {
   detachNetworkInterface(
     args: DetachNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DetachVerifiedAccessTrustProviderCommand}
@@ -6540,10 +5451,7 @@ export interface EC2Service {
   detachVerifiedAccessTrustProvider(
     args: DetachVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DetachVerifiedAccessTrustProviderResult,
-    | SdkError
-  >
+  ): Effect.Effect<DetachVerifiedAccessTrustProviderResult, SdkError>;
 
   /**
    * @see {@link DetachVolumeCommand}
@@ -6551,10 +5459,7 @@ export interface EC2Service {
   detachVolume(
     args: DetachVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  VolumeAttachment,
-    | SdkError
-  >
+  ): Effect.Effect<VolumeAttachment, SdkError>;
 
   /**
    * @see {@link DetachVpnGatewayCommand}
@@ -6562,10 +5467,7 @@ export interface EC2Service {
   detachVpnGateway(
     args: DetachVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DisableAddressTransferCommand}
@@ -6573,10 +5475,7 @@ export interface EC2Service {
   disableAddressTransfer(
     args: DisableAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableAddressTransferResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableAddressTransferResult, SdkError>;
 
   /**
    * @see {@link DisableAwsNetworkPerformanceMetricSubscriptionCommand}
@@ -6585,9 +5484,9 @@ export interface EC2Service {
     args: DisableAwsNetworkPerformanceMetricSubscriptionRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  DisableAwsNetworkPerformanceMetricSubscriptionResult,
-    | SdkError
-  >
+    DisableAwsNetworkPerformanceMetricSubscriptionResult,
+    SdkError
+  >;
 
   /**
    * @see {@link DisableEbsEncryptionByDefaultCommand}
@@ -6595,10 +5494,7 @@ export interface EC2Service {
   disableEbsEncryptionByDefault(
     args: DisableEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableEbsEncryptionByDefaultResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableEbsEncryptionByDefaultResult, SdkError>;
 
   /**
    * @see {@link DisableFastLaunchCommand}
@@ -6606,10 +5502,7 @@ export interface EC2Service {
   disableFastLaunch(
     args: DisableFastLaunchRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableFastLaunchResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableFastLaunchResult, SdkError>;
 
   /**
    * @see {@link DisableFastSnapshotRestoresCommand}
@@ -6617,10 +5510,7 @@ export interface EC2Service {
   disableFastSnapshotRestores(
     args: DisableFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableFastSnapshotRestoresResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableFastSnapshotRestoresResult, SdkError>;
 
   /**
    * @see {@link DisableImageCommand}
@@ -6628,10 +5518,7 @@ export interface EC2Service {
   disableImage(
     args: DisableImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableImageResult, SdkError>;
 
   /**
    * @see {@link DisableImageBlockPublicAccessCommand}
@@ -6639,10 +5526,7 @@ export interface EC2Service {
   disableImageBlockPublicAccess(
     args: DisableImageBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableImageBlockPublicAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableImageBlockPublicAccessResult, SdkError>;
 
   /**
    * @see {@link DisableImageDeprecationCommand}
@@ -6650,10 +5534,7 @@ export interface EC2Service {
   disableImageDeprecation(
     args: DisableImageDeprecationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableImageDeprecationResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableImageDeprecationResult, SdkError>;
 
   /**
    * @see {@link DisableIpamOrganizationAdminAccountCommand}
@@ -6661,10 +5542,7 @@ export interface EC2Service {
   disableIpamOrganizationAdminAccount(
     args: DisableIpamOrganizationAdminAccountRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableIpamOrganizationAdminAccountResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableIpamOrganizationAdminAccountResult, SdkError>;
 
   /**
    * @see {@link DisableSerialConsoleAccessCommand}
@@ -6672,10 +5550,7 @@ export interface EC2Service {
   disableSerialConsoleAccess(
     args: DisableSerialConsoleAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableSerialConsoleAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableSerialConsoleAccessResult, SdkError>;
 
   /**
    * @see {@link DisableSnapshotBlockPublicAccessCommand}
@@ -6683,10 +5558,7 @@ export interface EC2Service {
   disableSnapshotBlockPublicAccess(
     args: DisableSnapshotBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableSnapshotBlockPublicAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableSnapshotBlockPublicAccessResult, SdkError>;
 
   /**
    * @see {@link DisableTransitGatewayRouteTablePropagationCommand}
@@ -6694,10 +5566,7 @@ export interface EC2Service {
   disableTransitGatewayRouteTablePropagation(
     args: DisableTransitGatewayRouteTablePropagationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableTransitGatewayRouteTablePropagationResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableTransitGatewayRouteTablePropagationResult, SdkError>;
 
   /**
    * @see {@link DisableVgwRoutePropagationCommand}
@@ -6705,10 +5574,7 @@ export interface EC2Service {
   disableVgwRoutePropagation(
     args: DisableVgwRoutePropagationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DisableVpcClassicLinkCommand}
@@ -6716,10 +5582,7 @@ export interface EC2Service {
   disableVpcClassicLink(
     args: DisableVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableVpcClassicLinkResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableVpcClassicLinkResult, SdkError>;
 
   /**
    * @see {@link DisableVpcClassicLinkDnsSupportCommand}
@@ -6727,10 +5590,7 @@ export interface EC2Service {
   disableVpcClassicLinkDnsSupport(
     args: DisableVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisableVpcClassicLinkDnsSupportResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisableVpcClassicLinkDnsSupportResult, SdkError>;
 
   /**
    * @see {@link DisassociateAddressCommand}
@@ -6738,10 +5598,7 @@ export interface EC2Service {
   disassociateAddress(
     args: DisassociateAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DisassociateClientVpnTargetNetworkCommand}
@@ -6749,10 +5606,7 @@ export interface EC2Service {
   disassociateClientVpnTargetNetwork(
     args: DisassociateClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateClientVpnTargetNetworkResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateClientVpnTargetNetworkResult, SdkError>;
 
   /**
    * @see {@link DisassociateEnclaveCertificateIamRoleCommand}
@@ -6760,10 +5614,7 @@ export interface EC2Service {
   disassociateEnclaveCertificateIamRole(
     args: DisassociateEnclaveCertificateIamRoleRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateEnclaveCertificateIamRoleResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateEnclaveCertificateIamRoleResult, SdkError>;
 
   /**
    * @see {@link DisassociateIamInstanceProfileCommand}
@@ -6771,10 +5622,7 @@ export interface EC2Service {
   disassociateIamInstanceProfile(
     args: DisassociateIamInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateIamInstanceProfileResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateIamInstanceProfileResult, SdkError>;
 
   /**
    * @see {@link DisassociateInstanceEventWindowCommand}
@@ -6782,10 +5630,7 @@ export interface EC2Service {
   disassociateInstanceEventWindow(
     args: DisassociateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateInstanceEventWindowResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateInstanceEventWindowResult, SdkError>;
 
   /**
    * @see {@link DisassociateIpamByoasnCommand}
@@ -6793,10 +5638,7 @@ export interface EC2Service {
   disassociateIpamByoasn(
     args: DisassociateIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateIpamByoasnResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateIpamByoasnResult, SdkError>;
 
   /**
    * @see {@link DisassociateIpamResourceDiscoveryCommand}
@@ -6804,10 +5646,7 @@ export interface EC2Service {
   disassociateIpamResourceDiscovery(
     args: DisassociateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateIpamResourceDiscoveryResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateIpamResourceDiscoveryResult, SdkError>;
 
   /**
    * @see {@link DisassociateNatGatewayAddressCommand}
@@ -6815,10 +5654,7 @@ export interface EC2Service {
   disassociateNatGatewayAddress(
     args: DisassociateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateNatGatewayAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateNatGatewayAddressResult, SdkError>;
 
   /**
    * @see {@link DisassociateRouteTableCommand}
@@ -6826,10 +5662,7 @@ export interface EC2Service {
   disassociateRouteTable(
     args: DisassociateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link DisassociateSubnetCidrBlockCommand}
@@ -6837,10 +5670,7 @@ export interface EC2Service {
   disassociateSubnetCidrBlock(
     args: DisassociateSubnetCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateSubnetCidrBlockResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateSubnetCidrBlockResult, SdkError>;
 
   /**
    * @see {@link DisassociateTransitGatewayMulticastDomainCommand}
@@ -6848,10 +5678,7 @@ export interface EC2Service {
   disassociateTransitGatewayMulticastDomain(
     args: DisassociateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateTransitGatewayMulticastDomainResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateTransitGatewayMulticastDomainResult, SdkError>;
 
   /**
    * @see {@link DisassociateTransitGatewayPolicyTableCommand}
@@ -6859,10 +5686,7 @@ export interface EC2Service {
   disassociateTransitGatewayPolicyTable(
     args: DisassociateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateTransitGatewayPolicyTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateTransitGatewayPolicyTableResult, SdkError>;
 
   /**
    * @see {@link DisassociateTransitGatewayRouteTableCommand}
@@ -6870,10 +5694,7 @@ export interface EC2Service {
   disassociateTransitGatewayRouteTable(
     args: DisassociateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateTransitGatewayRouteTableResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateTransitGatewayRouteTableResult, SdkError>;
 
   /**
    * @see {@link DisassociateTrunkInterfaceCommand}
@@ -6881,10 +5702,7 @@ export interface EC2Service {
   disassociateTrunkInterface(
     args: DisassociateTrunkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateTrunkInterfaceResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateTrunkInterfaceResult, SdkError>;
 
   /**
    * @see {@link DisassociateVpcCidrBlockCommand}
@@ -6892,10 +5710,7 @@ export interface EC2Service {
   disassociateVpcCidrBlock(
     args: DisassociateVpcCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  DisassociateVpcCidrBlockResult,
-    | SdkError
-  >
+  ): Effect.Effect<DisassociateVpcCidrBlockResult, SdkError>;
 
   /**
    * @see {@link EnableAddressTransferCommand}
@@ -6903,10 +5718,7 @@ export interface EC2Service {
   enableAddressTransfer(
     args: EnableAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableAddressTransferResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableAddressTransferResult, SdkError>;
 
   /**
    * @see {@link EnableAwsNetworkPerformanceMetricSubscriptionCommand}
@@ -6915,9 +5727,9 @@ export interface EC2Service {
     args: EnableAwsNetworkPerformanceMetricSubscriptionRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  EnableAwsNetworkPerformanceMetricSubscriptionResult,
-    | SdkError
-  >
+    EnableAwsNetworkPerformanceMetricSubscriptionResult,
+    SdkError
+  >;
 
   /**
    * @see {@link EnableEbsEncryptionByDefaultCommand}
@@ -6925,10 +5737,7 @@ export interface EC2Service {
   enableEbsEncryptionByDefault(
     args: EnableEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableEbsEncryptionByDefaultResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableEbsEncryptionByDefaultResult, SdkError>;
 
   /**
    * @see {@link EnableFastLaunchCommand}
@@ -6936,10 +5745,7 @@ export interface EC2Service {
   enableFastLaunch(
     args: EnableFastLaunchRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableFastLaunchResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableFastLaunchResult, SdkError>;
 
   /**
    * @see {@link EnableFastSnapshotRestoresCommand}
@@ -6947,10 +5753,7 @@ export interface EC2Service {
   enableFastSnapshotRestores(
     args: EnableFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableFastSnapshotRestoresResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableFastSnapshotRestoresResult, SdkError>;
 
   /**
    * @see {@link EnableImageCommand}
@@ -6958,10 +5761,7 @@ export interface EC2Service {
   enableImage(
     args: EnableImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableImageResult, SdkError>;
 
   /**
    * @see {@link EnableImageBlockPublicAccessCommand}
@@ -6969,10 +5769,7 @@ export interface EC2Service {
   enableImageBlockPublicAccess(
     args: EnableImageBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableImageBlockPublicAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableImageBlockPublicAccessResult, SdkError>;
 
   /**
    * @see {@link EnableImageDeprecationCommand}
@@ -6980,10 +5777,7 @@ export interface EC2Service {
   enableImageDeprecation(
     args: EnableImageDeprecationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableImageDeprecationResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableImageDeprecationResult, SdkError>;
 
   /**
    * @see {@link EnableIpamOrganizationAdminAccountCommand}
@@ -6991,10 +5785,7 @@ export interface EC2Service {
   enableIpamOrganizationAdminAccount(
     args: EnableIpamOrganizationAdminAccountRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableIpamOrganizationAdminAccountResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableIpamOrganizationAdminAccountResult, SdkError>;
 
   /**
    * @see {@link EnableReachabilityAnalyzerOrganizationSharingCommand}
@@ -7003,9 +5794,9 @@ export interface EC2Service {
     args: EnableReachabilityAnalyzerOrganizationSharingRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  EnableReachabilityAnalyzerOrganizationSharingResult,
-    | SdkError
-  >
+    EnableReachabilityAnalyzerOrganizationSharingResult,
+    SdkError
+  >;
 
   /**
    * @see {@link EnableSerialConsoleAccessCommand}
@@ -7013,10 +5804,7 @@ export interface EC2Service {
   enableSerialConsoleAccess(
     args: EnableSerialConsoleAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableSerialConsoleAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableSerialConsoleAccessResult, SdkError>;
 
   /**
    * @see {@link EnableSnapshotBlockPublicAccessCommand}
@@ -7024,10 +5812,7 @@ export interface EC2Service {
   enableSnapshotBlockPublicAccess(
     args: EnableSnapshotBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableSnapshotBlockPublicAccessResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableSnapshotBlockPublicAccessResult, SdkError>;
 
   /**
    * @see {@link EnableTransitGatewayRouteTablePropagationCommand}
@@ -7035,10 +5820,7 @@ export interface EC2Service {
   enableTransitGatewayRouteTablePropagation(
     args: EnableTransitGatewayRouteTablePropagationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableTransitGatewayRouteTablePropagationResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableTransitGatewayRouteTablePropagationResult, SdkError>;
 
   /**
    * @see {@link EnableVgwRoutePropagationCommand}
@@ -7046,10 +5828,7 @@ export interface EC2Service {
   enableVgwRoutePropagation(
     args: EnableVgwRoutePropagationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link EnableVolumeIOCommand}
@@ -7057,10 +5836,7 @@ export interface EC2Service {
   enableVolumeIO(
     args: EnableVolumeIORequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link EnableVpcClassicLinkCommand}
@@ -7068,10 +5844,7 @@ export interface EC2Service {
   enableVpcClassicLink(
     args: EnableVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableVpcClassicLinkResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableVpcClassicLinkResult, SdkError>;
 
   /**
    * @see {@link EnableVpcClassicLinkDnsSupportCommand}
@@ -7079,10 +5852,7 @@ export interface EC2Service {
   enableVpcClassicLinkDnsSupport(
     args: EnableVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  EnableVpcClassicLinkDnsSupportResult,
-    | SdkError
-  >
+  ): Effect.Effect<EnableVpcClassicLinkDnsSupportResult, SdkError>;
 
   /**
    * @see {@link ExportClientVpnClientCertificateRevocationListCommand}
@@ -7091,9 +5861,9 @@ export interface EC2Service {
     args: ExportClientVpnClientCertificateRevocationListRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  ExportClientVpnClientCertificateRevocationListResult,
-    | SdkError
-  >
+    ExportClientVpnClientCertificateRevocationListResult,
+    SdkError
+  >;
 
   /**
    * @see {@link ExportClientVpnClientConfigurationCommand}
@@ -7101,10 +5871,7 @@ export interface EC2Service {
   exportClientVpnClientConfiguration(
     args: ExportClientVpnClientConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ExportClientVpnClientConfigurationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ExportClientVpnClientConfigurationResult, SdkError>;
 
   /**
    * @see {@link ExportImageCommand}
@@ -7112,10 +5879,7 @@ export interface EC2Service {
   exportImage(
     args: ExportImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ExportImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<ExportImageResult, SdkError>;
 
   /**
    * @see {@link ExportTransitGatewayRoutesCommand}
@@ -7123,10 +5887,7 @@ export interface EC2Service {
   exportTransitGatewayRoutes(
     args: ExportTransitGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ExportTransitGatewayRoutesResult,
-    | SdkError
-  >
+  ): Effect.Effect<ExportTransitGatewayRoutesResult, SdkError>;
 
   /**
    * @see {@link GetAssociatedEnclaveCertificateIamRolesCommand}
@@ -7134,10 +5895,7 @@ export interface EC2Service {
   getAssociatedEnclaveCertificateIamRoles(
     args: GetAssociatedEnclaveCertificateIamRolesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetAssociatedEnclaveCertificateIamRolesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetAssociatedEnclaveCertificateIamRolesResult, SdkError>;
 
   /**
    * @see {@link GetAssociatedIpv6PoolCidrsCommand}
@@ -7145,10 +5903,7 @@ export interface EC2Service {
   getAssociatedIpv6PoolCidrs(
     args: GetAssociatedIpv6PoolCidrsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetAssociatedIpv6PoolCidrsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetAssociatedIpv6PoolCidrsResult, SdkError>;
 
   /**
    * @see {@link GetAwsNetworkPerformanceDataCommand}
@@ -7156,10 +5911,7 @@ export interface EC2Service {
   getAwsNetworkPerformanceData(
     args: GetAwsNetworkPerformanceDataRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetAwsNetworkPerformanceDataResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetAwsNetworkPerformanceDataResult, SdkError>;
 
   /**
    * @see {@link GetCapacityReservationUsageCommand}
@@ -7167,10 +5919,7 @@ export interface EC2Service {
   getCapacityReservationUsage(
     args: GetCapacityReservationUsageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetCapacityReservationUsageResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetCapacityReservationUsageResult, SdkError>;
 
   /**
    * @see {@link GetCoipPoolUsageCommand}
@@ -7178,10 +5927,7 @@ export interface EC2Service {
   getCoipPoolUsage(
     args: GetCoipPoolUsageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetCoipPoolUsageResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetCoipPoolUsageResult, SdkError>;
 
   /**
    * @see {@link GetConsoleOutputCommand}
@@ -7189,10 +5935,7 @@ export interface EC2Service {
   getConsoleOutput(
     args: GetConsoleOutputRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetConsoleOutputResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetConsoleOutputResult, SdkError>;
 
   /**
    * @see {@link GetConsoleScreenshotCommand}
@@ -7200,10 +5943,7 @@ export interface EC2Service {
   getConsoleScreenshot(
     args: GetConsoleScreenshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetConsoleScreenshotResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetConsoleScreenshotResult, SdkError>;
 
   /**
    * @see {@link GetDefaultCreditSpecificationCommand}
@@ -7211,10 +5951,7 @@ export interface EC2Service {
   getDefaultCreditSpecification(
     args: GetDefaultCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetDefaultCreditSpecificationResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetDefaultCreditSpecificationResult, SdkError>;
 
   /**
    * @see {@link GetEbsDefaultKmsKeyIdCommand}
@@ -7222,10 +5959,7 @@ export interface EC2Service {
   getEbsDefaultKmsKeyId(
     args: GetEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetEbsDefaultKmsKeyIdResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetEbsDefaultKmsKeyIdResult, SdkError>;
 
   /**
    * @see {@link GetEbsEncryptionByDefaultCommand}
@@ -7233,10 +5967,7 @@ export interface EC2Service {
   getEbsEncryptionByDefault(
     args: GetEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetEbsEncryptionByDefaultResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetEbsEncryptionByDefaultResult, SdkError>;
 
   /**
    * @see {@link GetFlowLogsIntegrationTemplateCommand}
@@ -7244,10 +5975,7 @@ export interface EC2Service {
   getFlowLogsIntegrationTemplate(
     args: GetFlowLogsIntegrationTemplateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetFlowLogsIntegrationTemplateResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetFlowLogsIntegrationTemplateResult, SdkError>;
 
   /**
    * @see {@link GetGroupsForCapacityReservationCommand}
@@ -7255,10 +5983,7 @@ export interface EC2Service {
   getGroupsForCapacityReservation(
     args: GetGroupsForCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetGroupsForCapacityReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetGroupsForCapacityReservationResult, SdkError>;
 
   /**
    * @see {@link GetHostReservationPurchasePreviewCommand}
@@ -7266,10 +5991,7 @@ export interface EC2Service {
   getHostReservationPurchasePreview(
     args: GetHostReservationPurchasePreviewRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetHostReservationPurchasePreviewResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetHostReservationPurchasePreviewResult, SdkError>;
 
   /**
    * @see {@link GetImageBlockPublicAccessStateCommand}
@@ -7277,10 +5999,7 @@ export interface EC2Service {
   getImageBlockPublicAccessState(
     args: GetImageBlockPublicAccessStateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetImageBlockPublicAccessStateResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetImageBlockPublicAccessStateResult, SdkError>;
 
   /**
    * @see {@link GetInstanceMetadataDefaultsCommand}
@@ -7288,10 +6007,7 @@ export interface EC2Service {
   getInstanceMetadataDefaults(
     args: GetInstanceMetadataDefaultsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetInstanceMetadataDefaultsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetInstanceMetadataDefaultsResult, SdkError>;
 
   /**
    * @see {@link GetInstanceTypesFromInstanceRequirementsCommand}
@@ -7299,10 +6015,7 @@ export interface EC2Service {
   getInstanceTypesFromInstanceRequirements(
     args: GetInstanceTypesFromInstanceRequirementsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetInstanceTypesFromInstanceRequirementsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetInstanceTypesFromInstanceRequirementsResult, SdkError>;
 
   /**
    * @see {@link GetInstanceUefiDataCommand}
@@ -7310,10 +6023,7 @@ export interface EC2Service {
   getInstanceUefiData(
     args: GetInstanceUefiDataRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetInstanceUefiDataResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetInstanceUefiDataResult, SdkError>;
 
   /**
    * @see {@link GetIpamAddressHistoryCommand}
@@ -7321,10 +6031,7 @@ export interface EC2Service {
   getIpamAddressHistory(
     args: GetIpamAddressHistoryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamAddressHistoryResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamAddressHistoryResult, SdkError>;
 
   /**
    * @see {@link GetIpamDiscoveredAccountsCommand}
@@ -7332,10 +6039,7 @@ export interface EC2Service {
   getIpamDiscoveredAccounts(
     args: GetIpamDiscoveredAccountsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamDiscoveredAccountsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamDiscoveredAccountsResult, SdkError>;
 
   /**
    * @see {@link GetIpamDiscoveredPublicAddressesCommand}
@@ -7343,10 +6047,7 @@ export interface EC2Service {
   getIpamDiscoveredPublicAddresses(
     args: GetIpamDiscoveredPublicAddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamDiscoveredPublicAddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamDiscoveredPublicAddressesResult, SdkError>;
 
   /**
    * @see {@link GetIpamDiscoveredResourceCidrsCommand}
@@ -7354,10 +6055,7 @@ export interface EC2Service {
   getIpamDiscoveredResourceCidrs(
     args: GetIpamDiscoveredResourceCidrsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamDiscoveredResourceCidrsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamDiscoveredResourceCidrsResult, SdkError>;
 
   /**
    * @see {@link GetIpamPoolAllocationsCommand}
@@ -7365,10 +6063,7 @@ export interface EC2Service {
   getIpamPoolAllocations(
     args: GetIpamPoolAllocationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamPoolAllocationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamPoolAllocationsResult, SdkError>;
 
   /**
    * @see {@link GetIpamPoolCidrsCommand}
@@ -7376,10 +6071,7 @@ export interface EC2Service {
   getIpamPoolCidrs(
     args: GetIpamPoolCidrsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamPoolCidrsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamPoolCidrsResult, SdkError>;
 
   /**
    * @see {@link GetIpamResourceCidrsCommand}
@@ -7387,10 +6079,7 @@ export interface EC2Service {
   getIpamResourceCidrs(
     args: GetIpamResourceCidrsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetIpamResourceCidrsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetIpamResourceCidrsResult, SdkError>;
 
   /**
    * @see {@link GetLaunchTemplateDataCommand}
@@ -7398,10 +6087,7 @@ export interface EC2Service {
   getLaunchTemplateData(
     args: GetLaunchTemplateDataRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetLaunchTemplateDataResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetLaunchTemplateDataResult, SdkError>;
 
   /**
    * @see {@link GetManagedPrefixListAssociationsCommand}
@@ -7409,10 +6095,7 @@ export interface EC2Service {
   getManagedPrefixListAssociations(
     args: GetManagedPrefixListAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetManagedPrefixListAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetManagedPrefixListAssociationsResult, SdkError>;
 
   /**
    * @see {@link GetManagedPrefixListEntriesCommand}
@@ -7420,10 +6103,7 @@ export interface EC2Service {
   getManagedPrefixListEntries(
     args: GetManagedPrefixListEntriesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetManagedPrefixListEntriesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetManagedPrefixListEntriesResult, SdkError>;
 
   /**
    * @see {@link GetNetworkInsightsAccessScopeAnalysisFindingsCommand}
@@ -7432,9 +6112,9 @@ export interface EC2Service {
     args: GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  GetNetworkInsightsAccessScopeAnalysisFindingsResult,
-    | SdkError
-  >
+    GetNetworkInsightsAccessScopeAnalysisFindingsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link GetNetworkInsightsAccessScopeContentCommand}
@@ -7442,10 +6122,7 @@ export interface EC2Service {
   getNetworkInsightsAccessScopeContent(
     args: GetNetworkInsightsAccessScopeContentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetNetworkInsightsAccessScopeContentResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetNetworkInsightsAccessScopeContentResult, SdkError>;
 
   /**
    * @see {@link GetPasswordDataCommand}
@@ -7453,10 +6130,7 @@ export interface EC2Service {
   getPasswordData(
     args: GetPasswordDataRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetPasswordDataResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetPasswordDataResult, SdkError>;
 
   /**
    * @see {@link GetReservedInstancesExchangeQuoteCommand}
@@ -7464,10 +6138,7 @@ export interface EC2Service {
   getReservedInstancesExchangeQuote(
     args: GetReservedInstancesExchangeQuoteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetReservedInstancesExchangeQuoteResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetReservedInstancesExchangeQuoteResult, SdkError>;
 
   /**
    * @see {@link GetSecurityGroupsForVpcCommand}
@@ -7475,10 +6146,7 @@ export interface EC2Service {
   getSecurityGroupsForVpc(
     args: GetSecurityGroupsForVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetSecurityGroupsForVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetSecurityGroupsForVpcResult, SdkError>;
 
   /**
    * @see {@link GetSerialConsoleAccessStatusCommand}
@@ -7486,10 +6154,7 @@ export interface EC2Service {
   getSerialConsoleAccessStatus(
     args: GetSerialConsoleAccessStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetSerialConsoleAccessStatusResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetSerialConsoleAccessStatusResult, SdkError>;
 
   /**
    * @see {@link GetSnapshotBlockPublicAccessStateCommand}
@@ -7497,10 +6162,7 @@ export interface EC2Service {
   getSnapshotBlockPublicAccessState(
     args: GetSnapshotBlockPublicAccessStateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetSnapshotBlockPublicAccessStateResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetSnapshotBlockPublicAccessStateResult, SdkError>;
 
   /**
    * @see {@link GetSpotPlacementScoresCommand}
@@ -7508,10 +6170,7 @@ export interface EC2Service {
   getSpotPlacementScores(
     args: GetSpotPlacementScoresRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetSpotPlacementScoresResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetSpotPlacementScoresResult, SdkError>;
 
   /**
    * @see {@link GetSubnetCidrReservationsCommand}
@@ -7519,10 +6178,7 @@ export interface EC2Service {
   getSubnetCidrReservations(
     args: GetSubnetCidrReservationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetSubnetCidrReservationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetSubnetCidrReservationsResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayAttachmentPropagationsCommand}
@@ -7530,10 +6186,7 @@ export interface EC2Service {
   getTransitGatewayAttachmentPropagations(
     args: GetTransitGatewayAttachmentPropagationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayAttachmentPropagationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayAttachmentPropagationsResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayMulticastDomainAssociationsCommand}
@@ -7542,9 +6195,9 @@ export interface EC2Service {
     args: GetTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  GetTransitGatewayMulticastDomainAssociationsResult,
-    | SdkError
-  >
+    GetTransitGatewayMulticastDomainAssociationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link GetTransitGatewayPolicyTableAssociationsCommand}
@@ -7552,10 +6205,7 @@ export interface EC2Service {
   getTransitGatewayPolicyTableAssociations(
     args: GetTransitGatewayPolicyTableAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayPolicyTableAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayPolicyTableAssociationsResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayPolicyTableEntriesCommand}
@@ -7563,10 +6213,7 @@ export interface EC2Service {
   getTransitGatewayPolicyTableEntries(
     args: GetTransitGatewayPolicyTableEntriesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayPolicyTableEntriesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayPolicyTableEntriesResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayPrefixListReferencesCommand}
@@ -7574,10 +6221,7 @@ export interface EC2Service {
   getTransitGatewayPrefixListReferences(
     args: GetTransitGatewayPrefixListReferencesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayPrefixListReferencesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayPrefixListReferencesResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayRouteTableAssociationsCommand}
@@ -7585,10 +6229,7 @@ export interface EC2Service {
   getTransitGatewayRouteTableAssociations(
     args: GetTransitGatewayRouteTableAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayRouteTableAssociationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayRouteTableAssociationsResult, SdkError>;
 
   /**
    * @see {@link GetTransitGatewayRouteTablePropagationsCommand}
@@ -7596,10 +6237,7 @@ export interface EC2Service {
   getTransitGatewayRouteTablePropagations(
     args: GetTransitGatewayRouteTablePropagationsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetTransitGatewayRouteTablePropagationsResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetTransitGatewayRouteTablePropagationsResult, SdkError>;
 
   /**
    * @see {@link GetVerifiedAccessEndpointPolicyCommand}
@@ -7607,10 +6245,7 @@ export interface EC2Service {
   getVerifiedAccessEndpointPolicy(
     args: GetVerifiedAccessEndpointPolicyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetVerifiedAccessEndpointPolicyResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetVerifiedAccessEndpointPolicyResult, SdkError>;
 
   /**
    * @see {@link GetVerifiedAccessGroupPolicyCommand}
@@ -7618,10 +6253,7 @@ export interface EC2Service {
   getVerifiedAccessGroupPolicy(
     args: GetVerifiedAccessGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetVerifiedAccessGroupPolicyResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetVerifiedAccessGroupPolicyResult, SdkError>;
 
   /**
    * @see {@link GetVpnConnectionDeviceSampleConfigurationCommand}
@@ -7629,10 +6261,7 @@ export interface EC2Service {
   getVpnConnectionDeviceSampleConfiguration(
     args: GetVpnConnectionDeviceSampleConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetVpnConnectionDeviceSampleConfigurationResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetVpnConnectionDeviceSampleConfigurationResult, SdkError>;
 
   /**
    * @see {@link GetVpnConnectionDeviceTypesCommand}
@@ -7640,10 +6269,7 @@ export interface EC2Service {
   getVpnConnectionDeviceTypes(
     args: GetVpnConnectionDeviceTypesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetVpnConnectionDeviceTypesResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetVpnConnectionDeviceTypesResult, SdkError>;
 
   /**
    * @see {@link GetVpnTunnelReplacementStatusCommand}
@@ -7651,10 +6277,7 @@ export interface EC2Service {
   getVpnTunnelReplacementStatus(
     args: GetVpnTunnelReplacementStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  GetVpnTunnelReplacementStatusResult,
-    | SdkError
-  >
+  ): Effect.Effect<GetVpnTunnelReplacementStatusResult, SdkError>;
 
   /**
    * @see {@link ImportClientVpnClientCertificateRevocationListCommand}
@@ -7663,9 +6286,9 @@ export interface EC2Service {
     args: ImportClientVpnClientCertificateRevocationListRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  ImportClientVpnClientCertificateRevocationListResult,
-    | SdkError
-  >
+    ImportClientVpnClientCertificateRevocationListResult,
+    SdkError
+  >;
 
   /**
    * @see {@link ImportImageCommand}
@@ -7673,10 +6296,7 @@ export interface EC2Service {
   importImage(
     args: ImportImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImportImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<ImportImageResult, SdkError>;
 
   /**
    * @see {@link ImportInstanceCommand}
@@ -7684,10 +6304,7 @@ export interface EC2Service {
   importInstance(
     args: ImportInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImportInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<ImportInstanceResult, SdkError>;
 
   /**
    * @see {@link ImportKeyPairCommand}
@@ -7695,10 +6312,7 @@ export interface EC2Service {
   importKeyPair(
     args: ImportKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImportKeyPairResult,
-    | SdkError
-  >
+  ): Effect.Effect<ImportKeyPairResult, SdkError>;
 
   /**
    * @see {@link ImportSnapshotCommand}
@@ -7706,10 +6320,7 @@ export interface EC2Service {
   importSnapshot(
     args: ImportSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImportSnapshotResult,
-    | SdkError
-  >
+  ): Effect.Effect<ImportSnapshotResult, SdkError>;
 
   /**
    * @see {@link ImportVolumeCommand}
@@ -7717,10 +6328,7 @@ export interface EC2Service {
   importVolume(
     args: ImportVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ImportVolumeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ImportVolumeResult, SdkError>;
 
   /**
    * @see {@link ListImagesInRecycleBinCommand}
@@ -7728,10 +6336,7 @@ export interface EC2Service {
   listImagesInRecycleBin(
     args: ListImagesInRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ListImagesInRecycleBinResult,
-    | SdkError
-  >
+  ): Effect.Effect<ListImagesInRecycleBinResult, SdkError>;
 
   /**
    * @see {@link ListSnapshotsInRecycleBinCommand}
@@ -7739,10 +6344,7 @@ export interface EC2Service {
   listSnapshotsInRecycleBin(
     args: ListSnapshotsInRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ListSnapshotsInRecycleBinResult,
-    | SdkError
-  >
+  ): Effect.Effect<ListSnapshotsInRecycleBinResult, SdkError>;
 
   /**
    * @see {@link LockSnapshotCommand}
@@ -7750,10 +6352,7 @@ export interface EC2Service {
   lockSnapshot(
     args: LockSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  LockSnapshotResult,
-    | SdkError
-  >
+  ): Effect.Effect<LockSnapshotResult, SdkError>;
 
   /**
    * @see {@link ModifyAddressAttributeCommand}
@@ -7761,10 +6360,7 @@ export interface EC2Service {
   modifyAddressAttribute(
     args: ModifyAddressAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyAddressAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyAddressAttributeResult, SdkError>;
 
   /**
    * @see {@link ModifyAvailabilityZoneGroupCommand}
@@ -7772,10 +6368,7 @@ export interface EC2Service {
   modifyAvailabilityZoneGroup(
     args: ModifyAvailabilityZoneGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyAvailabilityZoneGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyAvailabilityZoneGroupResult, SdkError>;
 
   /**
    * @see {@link ModifyCapacityReservationCommand}
@@ -7783,10 +6376,7 @@ export interface EC2Service {
   modifyCapacityReservation(
     args: ModifyCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyCapacityReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyCapacityReservationResult, SdkError>;
 
   /**
    * @see {@link ModifyCapacityReservationFleetCommand}
@@ -7794,10 +6384,7 @@ export interface EC2Service {
   modifyCapacityReservationFleet(
     args: ModifyCapacityReservationFleetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyCapacityReservationFleetResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyCapacityReservationFleetResult, SdkError>;
 
   /**
    * @see {@link ModifyClientVpnEndpointCommand}
@@ -7805,10 +6392,7 @@ export interface EC2Service {
   modifyClientVpnEndpoint(
     args: ModifyClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyClientVpnEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyClientVpnEndpointResult, SdkError>;
 
   /**
    * @see {@link ModifyDefaultCreditSpecificationCommand}
@@ -7816,10 +6400,7 @@ export interface EC2Service {
   modifyDefaultCreditSpecification(
     args: ModifyDefaultCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyDefaultCreditSpecificationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyDefaultCreditSpecificationResult, SdkError>;
 
   /**
    * @see {@link ModifyEbsDefaultKmsKeyIdCommand}
@@ -7827,10 +6408,7 @@ export interface EC2Service {
   modifyEbsDefaultKmsKeyId(
     args: ModifyEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyEbsDefaultKmsKeyIdResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyEbsDefaultKmsKeyIdResult, SdkError>;
 
   /**
    * @see {@link ModifyFleetCommand}
@@ -7838,10 +6416,7 @@ export interface EC2Service {
   modifyFleet(
     args: ModifyFleetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyFleetResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyFleetResult, SdkError>;
 
   /**
    * @see {@link ModifyFpgaImageAttributeCommand}
@@ -7849,10 +6424,7 @@ export interface EC2Service {
   modifyFpgaImageAttribute(
     args: ModifyFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyFpgaImageAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyFpgaImageAttributeResult, SdkError>;
 
   /**
    * @see {@link ModifyHostsCommand}
@@ -7860,10 +6432,7 @@ export interface EC2Service {
   modifyHosts(
     args: ModifyHostsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyHostsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyHostsResult, SdkError>;
 
   /**
    * @see {@link ModifyIdFormatCommand}
@@ -7871,10 +6440,7 @@ export interface EC2Service {
   modifyIdFormat(
     args: ModifyIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyIdentityIdFormatCommand}
@@ -7882,10 +6448,7 @@ export interface EC2Service {
   modifyIdentityIdFormat(
     args: ModifyIdentityIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyImageAttributeCommand}
@@ -7893,10 +6456,7 @@ export interface EC2Service {
   modifyImageAttribute(
     args: ModifyImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyInstanceAttributeCommand}
@@ -7904,10 +6464,7 @@ export interface EC2Service {
   modifyInstanceAttribute(
     args: ModifyInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyInstanceCapacityReservationAttributesCommand}
@@ -7915,10 +6472,7 @@ export interface EC2Service {
   modifyInstanceCapacityReservationAttributes(
     args: ModifyInstanceCapacityReservationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceCapacityReservationAttributesResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceCapacityReservationAttributesResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceCreditSpecificationCommand}
@@ -7926,10 +6480,7 @@ export interface EC2Service {
   modifyInstanceCreditSpecification(
     args: ModifyInstanceCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceCreditSpecificationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceCreditSpecificationResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceEventStartTimeCommand}
@@ -7937,10 +6488,7 @@ export interface EC2Service {
   modifyInstanceEventStartTime(
     args: ModifyInstanceEventStartTimeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceEventStartTimeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceEventStartTimeResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceEventWindowCommand}
@@ -7948,10 +6496,7 @@ export interface EC2Service {
   modifyInstanceEventWindow(
     args: ModifyInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceEventWindowResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceEventWindowResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceMaintenanceOptionsCommand}
@@ -7959,10 +6504,7 @@ export interface EC2Service {
   modifyInstanceMaintenanceOptions(
     args: ModifyInstanceMaintenanceOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceMaintenanceOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceMaintenanceOptionsResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceMetadataDefaultsCommand}
@@ -7970,10 +6512,7 @@ export interface EC2Service {
   modifyInstanceMetadataDefaults(
     args: ModifyInstanceMetadataDefaultsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceMetadataDefaultsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceMetadataDefaultsResult, SdkError>;
 
   /**
    * @see {@link ModifyInstanceMetadataOptionsCommand}
@@ -7981,10 +6520,7 @@ export interface EC2Service {
   modifyInstanceMetadataOptions(
     args: ModifyInstanceMetadataOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstanceMetadataOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstanceMetadataOptionsResult, SdkError>;
 
   /**
    * @see {@link ModifyInstancePlacementCommand}
@@ -7992,10 +6528,7 @@ export interface EC2Service {
   modifyInstancePlacement(
     args: ModifyInstancePlacementRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyInstancePlacementResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyInstancePlacementResult, SdkError>;
 
   /**
    * @see {@link ModifyIpamCommand}
@@ -8003,10 +6536,7 @@ export interface EC2Service {
   modifyIpam(
     args: ModifyIpamRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyIpamResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyIpamResult, SdkError>;
 
   /**
    * @see {@link ModifyIpamPoolCommand}
@@ -8014,10 +6544,7 @@ export interface EC2Service {
   modifyIpamPool(
     args: ModifyIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyIpamPoolResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyIpamPoolResult, SdkError>;
 
   /**
    * @see {@link ModifyIpamResourceCidrCommand}
@@ -8025,10 +6552,7 @@ export interface EC2Service {
   modifyIpamResourceCidr(
     args: ModifyIpamResourceCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyIpamResourceCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyIpamResourceCidrResult, SdkError>;
 
   /**
    * @see {@link ModifyIpamResourceDiscoveryCommand}
@@ -8036,10 +6560,7 @@ export interface EC2Service {
   modifyIpamResourceDiscovery(
     args: ModifyIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyIpamResourceDiscoveryResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyIpamResourceDiscoveryResult, SdkError>;
 
   /**
    * @see {@link ModifyIpamScopeCommand}
@@ -8047,10 +6568,7 @@ export interface EC2Service {
   modifyIpamScope(
     args: ModifyIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyIpamScopeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyIpamScopeResult, SdkError>;
 
   /**
    * @see {@link ModifyLaunchTemplateCommand}
@@ -8058,10 +6576,7 @@ export interface EC2Service {
   modifyLaunchTemplate(
     args: ModifyLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyLaunchTemplateResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyLaunchTemplateResult, SdkError>;
 
   /**
    * @see {@link ModifyLocalGatewayRouteCommand}
@@ -8069,10 +6584,7 @@ export interface EC2Service {
   modifyLocalGatewayRoute(
     args: ModifyLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyLocalGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyLocalGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link ModifyManagedPrefixListCommand}
@@ -8080,10 +6592,7 @@ export interface EC2Service {
   modifyManagedPrefixList(
     args: ModifyManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyManagedPrefixListResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyManagedPrefixListResult, SdkError>;
 
   /**
    * @see {@link ModifyNetworkInterfaceAttributeCommand}
@@ -8091,10 +6600,7 @@ export interface EC2Service {
   modifyNetworkInterfaceAttribute(
     args: ModifyNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyPrivateDnsNameOptionsCommand}
@@ -8102,10 +6608,7 @@ export interface EC2Service {
   modifyPrivateDnsNameOptions(
     args: ModifyPrivateDnsNameOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyPrivateDnsNameOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyPrivateDnsNameOptionsResult, SdkError>;
 
   /**
    * @see {@link ModifyReservedInstancesCommand}
@@ -8113,10 +6616,7 @@ export interface EC2Service {
   modifyReservedInstances(
     args: ModifyReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyReservedInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyReservedInstancesResult, SdkError>;
 
   /**
    * @see {@link ModifySecurityGroupRulesCommand}
@@ -8124,10 +6624,7 @@ export interface EC2Service {
   modifySecurityGroupRules(
     args: ModifySecurityGroupRulesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifySecurityGroupRulesResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifySecurityGroupRulesResult, SdkError>;
 
   /**
    * @see {@link ModifySnapshotAttributeCommand}
@@ -8135,10 +6632,7 @@ export interface EC2Service {
   modifySnapshotAttribute(
     args: ModifySnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifySnapshotTierCommand}
@@ -8146,10 +6640,7 @@ export interface EC2Service {
   modifySnapshotTier(
     args: ModifySnapshotTierRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifySnapshotTierResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifySnapshotTierResult, SdkError>;
 
   /**
    * @see {@link ModifySpotFleetRequestCommand}
@@ -8157,10 +6648,7 @@ export interface EC2Service {
   modifySpotFleetRequest(
     args: ModifySpotFleetRequestRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifySpotFleetRequestResponse,
-    | SdkError
-  >
+  ): Effect.Effect<ModifySpotFleetRequestResponse, SdkError>;
 
   /**
    * @see {@link ModifySubnetAttributeCommand}
@@ -8168,10 +6656,7 @@ export interface EC2Service {
   modifySubnetAttribute(
     args: ModifySubnetAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyTrafficMirrorFilterNetworkServicesCommand}
@@ -8179,10 +6664,7 @@ export interface EC2Service {
   modifyTrafficMirrorFilterNetworkServices(
     args: ModifyTrafficMirrorFilterNetworkServicesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTrafficMirrorFilterNetworkServicesResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTrafficMirrorFilterNetworkServicesResult, SdkError>;
 
   /**
    * @see {@link ModifyTrafficMirrorFilterRuleCommand}
@@ -8190,10 +6672,7 @@ export interface EC2Service {
   modifyTrafficMirrorFilterRule(
     args: ModifyTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTrafficMirrorFilterRuleResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTrafficMirrorFilterRuleResult, SdkError>;
 
   /**
    * @see {@link ModifyTrafficMirrorSessionCommand}
@@ -8201,10 +6680,7 @@ export interface EC2Service {
   modifyTrafficMirrorSession(
     args: ModifyTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTrafficMirrorSessionResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTrafficMirrorSessionResult, SdkError>;
 
   /**
    * @see {@link ModifyTransitGatewayCommand}
@@ -8212,10 +6688,7 @@ export interface EC2Service {
   modifyTransitGateway(
     args: ModifyTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTransitGatewayResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTransitGatewayResult, SdkError>;
 
   /**
    * @see {@link ModifyTransitGatewayPrefixListReferenceCommand}
@@ -8223,10 +6696,7 @@ export interface EC2Service {
   modifyTransitGatewayPrefixListReference(
     args: ModifyTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTransitGatewayPrefixListReferenceResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTransitGatewayPrefixListReferenceResult, SdkError>;
 
   /**
    * @see {@link ModifyTransitGatewayVpcAttachmentCommand}
@@ -8234,10 +6704,7 @@ export interface EC2Service {
   modifyTransitGatewayVpcAttachment(
     args: ModifyTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyTransitGatewayVpcAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyTransitGatewayVpcAttachmentResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessEndpointCommand}
@@ -8245,10 +6712,7 @@ export interface EC2Service {
   modifyVerifiedAccessEndpoint(
     args: ModifyVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessEndpointResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessEndpointPolicyCommand}
@@ -8256,10 +6720,7 @@ export interface EC2Service {
   modifyVerifiedAccessEndpointPolicy(
     args: ModifyVerifiedAccessEndpointPolicyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessEndpointPolicyResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessEndpointPolicyResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessGroupCommand}
@@ -8267,10 +6728,7 @@ export interface EC2Service {
   modifyVerifiedAccessGroup(
     args: ModifyVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessGroupResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessGroupResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessGroupPolicyCommand}
@@ -8278,10 +6736,7 @@ export interface EC2Service {
   modifyVerifiedAccessGroupPolicy(
     args: ModifyVerifiedAccessGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessGroupPolicyResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessGroupPolicyResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessInstanceCommand}
@@ -8289,10 +6744,7 @@ export interface EC2Service {
   modifyVerifiedAccessInstance(
     args: ModifyVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessInstanceResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessInstanceResult, SdkError>;
 
   /**
    * @see {@link ModifyVerifiedAccessInstanceLoggingConfigurationCommand}
@@ -8301,9 +6753,9 @@ export interface EC2Service {
     args: ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  ModifyVerifiedAccessInstanceLoggingConfigurationResult,
-    | SdkError
-  >
+    ModifyVerifiedAccessInstanceLoggingConfigurationResult,
+    SdkError
+  >;
 
   /**
    * @see {@link ModifyVerifiedAccessTrustProviderCommand}
@@ -8311,10 +6763,7 @@ export interface EC2Service {
   modifyVerifiedAccessTrustProvider(
     args: ModifyVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVerifiedAccessTrustProviderResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVerifiedAccessTrustProviderResult, SdkError>;
 
   /**
    * @see {@link ModifyVolumeCommand}
@@ -8322,10 +6771,7 @@ export interface EC2Service {
   modifyVolume(
     args: ModifyVolumeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVolumeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVolumeResult, SdkError>;
 
   /**
    * @see {@link ModifyVolumeAttributeCommand}
@@ -8333,10 +6779,7 @@ export interface EC2Service {
   modifyVolumeAttribute(
     args: ModifyVolumeAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyVpcAttributeCommand}
@@ -8344,10 +6787,7 @@ export interface EC2Service {
   modifyVpcAttribute(
     args: ModifyVpcAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ModifyVpcEndpointCommand}
@@ -8355,10 +6795,7 @@ export interface EC2Service {
   modifyVpcEndpoint(
     args: ModifyVpcEndpointRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcEndpointResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcEndpointResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcEndpointConnectionNotificationCommand}
@@ -8366,10 +6803,7 @@ export interface EC2Service {
   modifyVpcEndpointConnectionNotification(
     args: ModifyVpcEndpointConnectionNotificationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcEndpointConnectionNotificationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcEndpointConnectionNotificationResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcEndpointServiceConfigurationCommand}
@@ -8377,10 +6811,7 @@ export interface EC2Service {
   modifyVpcEndpointServiceConfiguration(
     args: ModifyVpcEndpointServiceConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcEndpointServiceConfigurationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcEndpointServiceConfigurationResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcEndpointServicePayerResponsibilityCommand}
@@ -8388,10 +6819,7 @@ export interface EC2Service {
   modifyVpcEndpointServicePayerResponsibility(
     args: ModifyVpcEndpointServicePayerResponsibilityRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcEndpointServicePayerResponsibilityResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcEndpointServicePayerResponsibilityResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcEndpointServicePermissionsCommand}
@@ -8399,10 +6827,7 @@ export interface EC2Service {
   modifyVpcEndpointServicePermissions(
     args: ModifyVpcEndpointServicePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcEndpointServicePermissionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcEndpointServicePermissionsResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcPeeringConnectionOptionsCommand}
@@ -8410,10 +6835,7 @@ export interface EC2Service {
   modifyVpcPeeringConnectionOptions(
     args: ModifyVpcPeeringConnectionOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcPeeringConnectionOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcPeeringConnectionOptionsResult, SdkError>;
 
   /**
    * @see {@link ModifyVpcTenancyCommand}
@@ -8421,10 +6843,7 @@ export interface EC2Service {
   modifyVpcTenancy(
     args: ModifyVpcTenancyRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpcTenancyResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpcTenancyResult, SdkError>;
 
   /**
    * @see {@link ModifyVpnConnectionCommand}
@@ -8432,10 +6851,7 @@ export interface EC2Service {
   modifyVpnConnection(
     args: ModifyVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpnConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpnConnectionResult, SdkError>;
 
   /**
    * @see {@link ModifyVpnConnectionOptionsCommand}
@@ -8443,10 +6859,7 @@ export interface EC2Service {
   modifyVpnConnectionOptions(
     args: ModifyVpnConnectionOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpnConnectionOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpnConnectionOptionsResult, SdkError>;
 
   /**
    * @see {@link ModifyVpnTunnelCertificateCommand}
@@ -8454,10 +6867,7 @@ export interface EC2Service {
   modifyVpnTunnelCertificate(
     args: ModifyVpnTunnelCertificateRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpnTunnelCertificateResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpnTunnelCertificateResult, SdkError>;
 
   /**
    * @see {@link ModifyVpnTunnelOptionsCommand}
@@ -8465,10 +6875,7 @@ export interface EC2Service {
   modifyVpnTunnelOptions(
     args: ModifyVpnTunnelOptionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ModifyVpnTunnelOptionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ModifyVpnTunnelOptionsResult, SdkError>;
 
   /**
    * @see {@link MonitorInstancesCommand}
@@ -8476,10 +6883,7 @@ export interface EC2Service {
   monitorInstances(
     args: MonitorInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  MonitorInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<MonitorInstancesResult, SdkError>;
 
   /**
    * @see {@link MoveAddressToVpcCommand}
@@ -8487,10 +6891,7 @@ export interface EC2Service {
   moveAddressToVpc(
     args: MoveAddressToVpcRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  MoveAddressToVpcResult,
-    | SdkError
-  >
+  ): Effect.Effect<MoveAddressToVpcResult, SdkError>;
 
   /**
    * @see {@link MoveByoipCidrToIpamCommand}
@@ -8498,10 +6899,7 @@ export interface EC2Service {
   moveByoipCidrToIpam(
     args: MoveByoipCidrToIpamRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  MoveByoipCidrToIpamResult,
-    | SdkError
-  >
+  ): Effect.Effect<MoveByoipCidrToIpamResult, SdkError>;
 
   /**
    * @see {@link ProvisionByoipCidrCommand}
@@ -8509,10 +6907,7 @@ export interface EC2Service {
   provisionByoipCidr(
     args: ProvisionByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ProvisionByoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<ProvisionByoipCidrResult, SdkError>;
 
   /**
    * @see {@link ProvisionIpamByoasnCommand}
@@ -8520,10 +6915,7 @@ export interface EC2Service {
   provisionIpamByoasn(
     args: ProvisionIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ProvisionIpamByoasnResult,
-    | SdkError
-  >
+  ): Effect.Effect<ProvisionIpamByoasnResult, SdkError>;
 
   /**
    * @see {@link ProvisionIpamPoolCidrCommand}
@@ -8531,10 +6923,7 @@ export interface EC2Service {
   provisionIpamPoolCidr(
     args: ProvisionIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ProvisionIpamPoolCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<ProvisionIpamPoolCidrResult, SdkError>;
 
   /**
    * @see {@link ProvisionPublicIpv4PoolCidrCommand}
@@ -8542,10 +6931,7 @@ export interface EC2Service {
   provisionPublicIpv4PoolCidr(
     args: ProvisionPublicIpv4PoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ProvisionPublicIpv4PoolCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<ProvisionPublicIpv4PoolCidrResult, SdkError>;
 
   /**
    * @see {@link PurchaseCapacityBlockCommand}
@@ -8553,10 +6939,7 @@ export interface EC2Service {
   purchaseCapacityBlock(
     args: PurchaseCapacityBlockRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  PurchaseCapacityBlockResult,
-    | SdkError
-  >
+  ): Effect.Effect<PurchaseCapacityBlockResult, SdkError>;
 
   /**
    * @see {@link PurchaseHostReservationCommand}
@@ -8564,10 +6947,7 @@ export interface EC2Service {
   purchaseHostReservation(
     args: PurchaseHostReservationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  PurchaseHostReservationResult,
-    | SdkError
-  >
+  ): Effect.Effect<PurchaseHostReservationResult, SdkError>;
 
   /**
    * @see {@link PurchaseReservedInstancesOfferingCommand}
@@ -8575,10 +6955,7 @@ export interface EC2Service {
   purchaseReservedInstancesOffering(
     args: PurchaseReservedInstancesOfferingRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  PurchaseReservedInstancesOfferingResult,
-    | SdkError
-  >
+  ): Effect.Effect<PurchaseReservedInstancesOfferingResult, SdkError>;
 
   /**
    * @see {@link PurchaseScheduledInstancesCommand}
@@ -8586,10 +6963,7 @@ export interface EC2Service {
   purchaseScheduledInstances(
     args: PurchaseScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  PurchaseScheduledInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<PurchaseScheduledInstancesResult, SdkError>;
 
   /**
    * @see {@link RebootInstancesCommand}
@@ -8597,10 +6971,7 @@ export interface EC2Service {
   rebootInstances(
     args: RebootInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link RegisterImageCommand}
@@ -8608,10 +6979,7 @@ export interface EC2Service {
   registerImage(
     args: RegisterImageRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RegisterImageResult,
-    | SdkError
-  >
+  ): Effect.Effect<RegisterImageResult, SdkError>;
 
   /**
    * @see {@link RegisterInstanceEventNotificationAttributesCommand}
@@ -8619,10 +6987,7 @@ export interface EC2Service {
   registerInstanceEventNotificationAttributes(
     args: RegisterInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RegisterInstanceEventNotificationAttributesResult,
-    | SdkError
-  >
+  ): Effect.Effect<RegisterInstanceEventNotificationAttributesResult, SdkError>;
 
   /**
    * @see {@link RegisterTransitGatewayMulticastGroupMembersCommand}
@@ -8630,10 +6995,7 @@ export interface EC2Service {
   registerTransitGatewayMulticastGroupMembers(
     args: RegisterTransitGatewayMulticastGroupMembersRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RegisterTransitGatewayMulticastGroupMembersResult,
-    | SdkError
-  >
+  ): Effect.Effect<RegisterTransitGatewayMulticastGroupMembersResult, SdkError>;
 
   /**
    * @see {@link RegisterTransitGatewayMulticastGroupSourcesCommand}
@@ -8641,10 +7003,7 @@ export interface EC2Service {
   registerTransitGatewayMulticastGroupSources(
     args: RegisterTransitGatewayMulticastGroupSourcesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RegisterTransitGatewayMulticastGroupSourcesResult,
-    | SdkError
-  >
+  ): Effect.Effect<RegisterTransitGatewayMulticastGroupSourcesResult, SdkError>;
 
   /**
    * @see {@link RejectTransitGatewayMulticastDomainAssociationsCommand}
@@ -8653,9 +7012,9 @@ export interface EC2Service {
     args: RejectTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  RejectTransitGatewayMulticastDomainAssociationsResult,
-    | SdkError
-  >
+    RejectTransitGatewayMulticastDomainAssociationsResult,
+    SdkError
+  >;
 
   /**
    * @see {@link RejectTransitGatewayPeeringAttachmentCommand}
@@ -8663,10 +7022,7 @@ export interface EC2Service {
   rejectTransitGatewayPeeringAttachment(
     args: RejectTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RejectTransitGatewayPeeringAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<RejectTransitGatewayPeeringAttachmentResult, SdkError>;
 
   /**
    * @see {@link RejectTransitGatewayVpcAttachmentCommand}
@@ -8674,10 +7030,7 @@ export interface EC2Service {
   rejectTransitGatewayVpcAttachment(
     args: RejectTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RejectTransitGatewayVpcAttachmentResult,
-    | SdkError
-  >
+  ): Effect.Effect<RejectTransitGatewayVpcAttachmentResult, SdkError>;
 
   /**
    * @see {@link RejectVpcEndpointConnectionsCommand}
@@ -8685,10 +7038,7 @@ export interface EC2Service {
   rejectVpcEndpointConnections(
     args: RejectVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RejectVpcEndpointConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<RejectVpcEndpointConnectionsResult, SdkError>;
 
   /**
    * @see {@link RejectVpcPeeringConnectionCommand}
@@ -8696,10 +7046,7 @@ export interface EC2Service {
   rejectVpcPeeringConnection(
     args: RejectVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RejectVpcPeeringConnectionResult,
-    | SdkError
-  >
+  ): Effect.Effect<RejectVpcPeeringConnectionResult, SdkError>;
 
   /**
    * @see {@link ReleaseAddressCommand}
@@ -8707,10 +7054,7 @@ export interface EC2Service {
   releaseAddress(
     args: ReleaseAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ReleaseHostsCommand}
@@ -8718,10 +7062,7 @@ export interface EC2Service {
   releaseHosts(
     args: ReleaseHostsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReleaseHostsResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReleaseHostsResult, SdkError>;
 
   /**
    * @see {@link ReleaseIpamPoolAllocationCommand}
@@ -8729,10 +7070,7 @@ export interface EC2Service {
   releaseIpamPoolAllocation(
     args: ReleaseIpamPoolAllocationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReleaseIpamPoolAllocationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReleaseIpamPoolAllocationResult, SdkError>;
 
   /**
    * @see {@link ReplaceIamInstanceProfileAssociationCommand}
@@ -8740,10 +7078,7 @@ export interface EC2Service {
   replaceIamInstanceProfileAssociation(
     args: ReplaceIamInstanceProfileAssociationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReplaceIamInstanceProfileAssociationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReplaceIamInstanceProfileAssociationResult, SdkError>;
 
   /**
    * @see {@link ReplaceNetworkAclAssociationCommand}
@@ -8751,10 +7086,7 @@ export interface EC2Service {
   replaceNetworkAclAssociation(
     args: ReplaceNetworkAclAssociationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReplaceNetworkAclAssociationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReplaceNetworkAclAssociationResult, SdkError>;
 
   /**
    * @see {@link ReplaceNetworkAclEntryCommand}
@@ -8762,10 +7094,7 @@ export interface EC2Service {
   replaceNetworkAclEntry(
     args: ReplaceNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ReplaceRouteCommand}
@@ -8773,10 +7102,7 @@ export interface EC2Service {
   replaceRoute(
     args: ReplaceRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ReplaceRouteTableAssociationCommand}
@@ -8784,10 +7110,7 @@ export interface EC2Service {
   replaceRouteTableAssociation(
     args: ReplaceRouteTableAssociationRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReplaceRouteTableAssociationResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReplaceRouteTableAssociationResult, SdkError>;
 
   /**
    * @see {@link ReplaceTransitGatewayRouteCommand}
@@ -8795,10 +7118,7 @@ export interface EC2Service {
   replaceTransitGatewayRoute(
     args: ReplaceTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReplaceTransitGatewayRouteResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReplaceTransitGatewayRouteResult, SdkError>;
 
   /**
    * @see {@link ReplaceVpnTunnelCommand}
@@ -8806,10 +7126,7 @@ export interface EC2Service {
   replaceVpnTunnel(
     args: ReplaceVpnTunnelRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ReplaceVpnTunnelResult,
-    | SdkError
-  >
+  ): Effect.Effect<ReplaceVpnTunnelResult, SdkError>;
 
   /**
    * @see {@link ReportInstanceStatusCommand}
@@ -8817,10 +7134,7 @@ export interface EC2Service {
   reportInstanceStatus(
     args: ReportInstanceStatusRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link RequestSpotFleetCommand}
@@ -8828,10 +7142,7 @@ export interface EC2Service {
   requestSpotFleet(
     args: RequestSpotFleetRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RequestSpotFleetResponse,
-    | SdkError
-  >
+  ): Effect.Effect<RequestSpotFleetResponse, SdkError>;
 
   /**
    * @see {@link RequestSpotInstancesCommand}
@@ -8839,10 +7150,7 @@ export interface EC2Service {
   requestSpotInstances(
     args: RequestSpotInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RequestSpotInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<RequestSpotInstancesResult, SdkError>;
 
   /**
    * @see {@link ResetAddressAttributeCommand}
@@ -8850,10 +7158,7 @@ export interface EC2Service {
   resetAddressAttribute(
     args: ResetAddressAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ResetAddressAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ResetAddressAttributeResult, SdkError>;
 
   /**
    * @see {@link ResetEbsDefaultKmsKeyIdCommand}
@@ -8861,10 +7166,7 @@ export interface EC2Service {
   resetEbsDefaultKmsKeyId(
     args: ResetEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ResetEbsDefaultKmsKeyIdResult,
-    | SdkError
-  >
+  ): Effect.Effect<ResetEbsDefaultKmsKeyIdResult, SdkError>;
 
   /**
    * @see {@link ResetFpgaImageAttributeCommand}
@@ -8872,10 +7174,7 @@ export interface EC2Service {
   resetFpgaImageAttribute(
     args: ResetFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  ResetFpgaImageAttributeResult,
-    | SdkError
-  >
+  ): Effect.Effect<ResetFpgaImageAttributeResult, SdkError>;
 
   /**
    * @see {@link ResetImageAttributeCommand}
@@ -8883,10 +7182,7 @@ export interface EC2Service {
   resetImageAttribute(
     args: ResetImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ResetInstanceAttributeCommand}
@@ -8894,10 +7190,7 @@ export interface EC2Service {
   resetInstanceAttribute(
     args: ResetInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ResetNetworkInterfaceAttributeCommand}
@@ -8905,10 +7198,7 @@ export interface EC2Service {
   resetNetworkInterfaceAttribute(
     args: ResetNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link ResetSnapshotAttributeCommand}
@@ -8916,10 +7206,7 @@ export interface EC2Service {
   resetSnapshotAttribute(
     args: ResetSnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link RestoreAddressToClassicCommand}
@@ -8927,10 +7214,7 @@ export interface EC2Service {
   restoreAddressToClassic(
     args: RestoreAddressToClassicRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RestoreAddressToClassicResult,
-    | SdkError
-  >
+  ): Effect.Effect<RestoreAddressToClassicResult, SdkError>;
 
   /**
    * @see {@link RestoreImageFromRecycleBinCommand}
@@ -8938,10 +7222,7 @@ export interface EC2Service {
   restoreImageFromRecycleBin(
     args: RestoreImageFromRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RestoreImageFromRecycleBinResult,
-    | SdkError
-  >
+  ): Effect.Effect<RestoreImageFromRecycleBinResult, SdkError>;
 
   /**
    * @see {@link RestoreManagedPrefixListVersionCommand}
@@ -8949,10 +7230,7 @@ export interface EC2Service {
   restoreManagedPrefixListVersion(
     args: RestoreManagedPrefixListVersionRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RestoreManagedPrefixListVersionResult,
-    | SdkError
-  >
+  ): Effect.Effect<RestoreManagedPrefixListVersionResult, SdkError>;
 
   /**
    * @see {@link RestoreSnapshotFromRecycleBinCommand}
@@ -8960,10 +7238,7 @@ export interface EC2Service {
   restoreSnapshotFromRecycleBin(
     args: RestoreSnapshotFromRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RestoreSnapshotFromRecycleBinResult,
-    | SdkError
-  >
+  ): Effect.Effect<RestoreSnapshotFromRecycleBinResult, SdkError>;
 
   /**
    * @see {@link RestoreSnapshotTierCommand}
@@ -8971,10 +7246,7 @@ export interface EC2Service {
   restoreSnapshotTier(
     args: RestoreSnapshotTierRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RestoreSnapshotTierResult,
-    | SdkError
-  >
+  ): Effect.Effect<RestoreSnapshotTierResult, SdkError>;
 
   /**
    * @see {@link RevokeClientVpnIngressCommand}
@@ -8982,10 +7254,7 @@ export interface EC2Service {
   revokeClientVpnIngress(
     args: RevokeClientVpnIngressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RevokeClientVpnIngressResult,
-    | SdkError
-  >
+  ): Effect.Effect<RevokeClientVpnIngressResult, SdkError>;
 
   /**
    * @see {@link RevokeSecurityGroupEgressCommand}
@@ -8993,10 +7262,7 @@ export interface EC2Service {
   revokeSecurityGroupEgress(
     args: RevokeSecurityGroupEgressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RevokeSecurityGroupEgressResult,
-    | SdkError
-  >
+  ): Effect.Effect<RevokeSecurityGroupEgressResult, SdkError>;
 
   /**
    * @see {@link RevokeSecurityGroupIngressCommand}
@@ -9004,10 +7270,7 @@ export interface EC2Service {
   revokeSecurityGroupIngress(
     args: RevokeSecurityGroupIngressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RevokeSecurityGroupIngressResult,
-    | SdkError
-  >
+  ): Effect.Effect<RevokeSecurityGroupIngressResult, SdkError>;
 
   /**
    * @see {@link RunInstancesCommand}
@@ -9015,10 +7278,7 @@ export interface EC2Service {
   runInstances(
     args: RunInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  Reservation,
-    | SdkError
-  >
+  ): Effect.Effect<Reservation, SdkError>;
 
   /**
    * @see {@link RunScheduledInstancesCommand}
@@ -9026,10 +7286,7 @@ export interface EC2Service {
   runScheduledInstances(
     args: RunScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  RunScheduledInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<RunScheduledInstancesResult, SdkError>;
 
   /**
    * @see {@link SearchLocalGatewayRoutesCommand}
@@ -9037,10 +7294,7 @@ export interface EC2Service {
   searchLocalGatewayRoutes(
     args: SearchLocalGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  SearchLocalGatewayRoutesResult,
-    | SdkError
-  >
+  ): Effect.Effect<SearchLocalGatewayRoutesResult, SdkError>;
 
   /**
    * @see {@link SearchTransitGatewayMulticastGroupsCommand}
@@ -9048,10 +7302,7 @@ export interface EC2Service {
   searchTransitGatewayMulticastGroups(
     args: SearchTransitGatewayMulticastGroupsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  SearchTransitGatewayMulticastGroupsResult,
-    | SdkError
-  >
+  ): Effect.Effect<SearchTransitGatewayMulticastGroupsResult, SdkError>;
 
   /**
    * @see {@link SearchTransitGatewayRoutesCommand}
@@ -9059,10 +7310,7 @@ export interface EC2Service {
   searchTransitGatewayRoutes(
     args: SearchTransitGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  SearchTransitGatewayRoutesResult,
-    | SdkError
-  >
+  ): Effect.Effect<SearchTransitGatewayRoutesResult, SdkError>;
 
   /**
    * @see {@link SendDiagnosticInterruptCommand}
@@ -9070,10 +7318,7 @@ export interface EC2Service {
   sendDiagnosticInterrupt(
     args: SendDiagnosticInterruptRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link StartInstancesCommand}
@@ -9081,10 +7326,7 @@ export interface EC2Service {
   startInstances(
     args: StartInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  StartInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<StartInstancesResult, SdkError>;
 
   /**
    * @see {@link StartNetworkInsightsAccessScopeAnalysisCommand}
@@ -9092,10 +7334,7 @@ export interface EC2Service {
   startNetworkInsightsAccessScopeAnalysis(
     args: StartNetworkInsightsAccessScopeAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  StartNetworkInsightsAccessScopeAnalysisResult,
-    | SdkError
-  >
+  ): Effect.Effect<StartNetworkInsightsAccessScopeAnalysisResult, SdkError>;
 
   /**
    * @see {@link StartNetworkInsightsAnalysisCommand}
@@ -9103,10 +7342,7 @@ export interface EC2Service {
   startNetworkInsightsAnalysis(
     args: StartNetworkInsightsAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  StartNetworkInsightsAnalysisResult,
-    | SdkError
-  >
+  ): Effect.Effect<StartNetworkInsightsAnalysisResult, SdkError>;
 
   /**
    * @see {@link StartVpcEndpointServicePrivateDnsVerificationCommand}
@@ -9115,9 +7351,9 @@ export interface EC2Service {
     args: StartVpcEndpointServicePrivateDnsVerificationRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-  StartVpcEndpointServicePrivateDnsVerificationResult,
-    | SdkError
-  >
+    StartVpcEndpointServicePrivateDnsVerificationResult,
+    SdkError
+  >;
 
   /**
    * @see {@link StopInstancesCommand}
@@ -9125,10 +7361,7 @@ export interface EC2Service {
   stopInstances(
     args: StopInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  StopInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<StopInstancesResult, SdkError>;
 
   /**
    * @see {@link TerminateClientVpnConnectionsCommand}
@@ -9136,10 +7369,7 @@ export interface EC2Service {
   terminateClientVpnConnections(
     args: TerminateClientVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  TerminateClientVpnConnectionsResult,
-    | SdkError
-  >
+  ): Effect.Effect<TerminateClientVpnConnectionsResult, SdkError>;
 
   /**
    * @see {@link TerminateInstancesCommand}
@@ -9147,10 +7377,7 @@ export interface EC2Service {
   terminateInstances(
     args: TerminateInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  TerminateInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<TerminateInstancesResult, SdkError>;
 
   /**
    * @see {@link UnassignIpv6AddressesCommand}
@@ -9158,10 +7385,7 @@ export interface EC2Service {
   unassignIpv6Addresses(
     args: UnassignIpv6AddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UnassignIpv6AddressesResult,
-    | SdkError
-  >
+  ): Effect.Effect<UnassignIpv6AddressesResult, SdkError>;
 
   /**
    * @see {@link UnassignPrivateIpAddressesCommand}
@@ -9169,10 +7393,7 @@ export interface EC2Service {
   unassignPrivateIpAddresses(
     args: UnassignPrivateIpAddressesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  void,
-    | SdkError
-  >
+  ): Effect.Effect<void, SdkError>;
 
   /**
    * @see {@link UnassignPrivateNatGatewayAddressCommand}
@@ -9180,10 +7401,7 @@ export interface EC2Service {
   unassignPrivateNatGatewayAddress(
     args: UnassignPrivateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UnassignPrivateNatGatewayAddressResult,
-    | SdkError
-  >
+  ): Effect.Effect<UnassignPrivateNatGatewayAddressResult, SdkError>;
 
   /**
    * @see {@link UnlockSnapshotCommand}
@@ -9191,10 +7409,7 @@ export interface EC2Service {
   unlockSnapshot(
     args: UnlockSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UnlockSnapshotResult,
-    | SdkError
-  >
+  ): Effect.Effect<UnlockSnapshotResult, SdkError>;
 
   /**
    * @see {@link UnmonitorInstancesCommand}
@@ -9202,10 +7417,7 @@ export interface EC2Service {
   unmonitorInstances(
     args: UnmonitorInstancesRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UnmonitorInstancesResult,
-    | SdkError
-  >
+  ): Effect.Effect<UnmonitorInstancesResult, SdkError>;
 
   /**
    * @see {@link UpdateSecurityGroupRuleDescriptionsEgressCommand}
@@ -9213,10 +7425,7 @@ export interface EC2Service {
   updateSecurityGroupRuleDescriptionsEgress(
     args: UpdateSecurityGroupRuleDescriptionsEgressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UpdateSecurityGroupRuleDescriptionsEgressResult,
-    | SdkError
-  >
+  ): Effect.Effect<UpdateSecurityGroupRuleDescriptionsEgressResult, SdkError>;
 
   /**
    * @see {@link UpdateSecurityGroupRuleDescriptionsIngressCommand}
@@ -9224,10 +7433,7 @@ export interface EC2Service {
   updateSecurityGroupRuleDescriptionsIngress(
     args: UpdateSecurityGroupRuleDescriptionsIngressRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  UpdateSecurityGroupRuleDescriptionsIngressResult,
-    | SdkError
-  >
+  ): Effect.Effect<UpdateSecurityGroupRuleDescriptionsIngressResult, SdkError>;
 
   /**
    * @see {@link WithdrawByoipCidrCommand}
@@ -9235,10 +7441,7 @@ export interface EC2Service {
   withdrawByoipCidr(
     args: WithdrawByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ): Effect.Effect<
-  WithdrawByoipCidrResult,
-    | SdkError
-  >
+  ): Effect.Effect<WithdrawByoipCidrResult, SdkError>;
 }
 
 /**
@@ -9296,10 +7499,7 @@ export const makeEC2Service = Effect.gen(function* (_) {
  * @since 1.0.0
  * @category layers
  */
-export const BaseEC2ServiceLayer = Layer.effect(
-  EC2Service,
-  makeEC2Service,
-);
+export const BaseEC2ServiceLayer = Layer.effect(EC2Service, makeEC2Service);
 
 /**
  * @since 1.0.0

--- a/packages/client-ec2/src/EC2Service.ts
+++ b/packages/client-ec2/src/EC2Service.ts
@@ -2,8937 +2,9244 @@
  * @since 1.0.0
  */
 import {
-  EC2ServiceException,
+  EC2ServiceException as SdkEC2ServiceException,
   AcceptAddressTransferCommand,
-  type AcceptAddressTransferCommandInput,
-  type AcceptAddressTransferCommandOutput,
   AcceptReservedInstancesExchangeQuoteCommand,
-  type AcceptReservedInstancesExchangeQuoteCommandInput,
-  type AcceptReservedInstancesExchangeQuoteCommandOutput,
   AcceptTransitGatewayMulticastDomainAssociationsCommand,
-  type AcceptTransitGatewayMulticastDomainAssociationsCommandInput,
-  type AcceptTransitGatewayMulticastDomainAssociationsCommandOutput,
   AcceptTransitGatewayPeeringAttachmentCommand,
-  type AcceptTransitGatewayPeeringAttachmentCommandInput,
-  type AcceptTransitGatewayPeeringAttachmentCommandOutput,
   AcceptTransitGatewayVpcAttachmentCommand,
-  type AcceptTransitGatewayVpcAttachmentCommandInput,
-  type AcceptTransitGatewayVpcAttachmentCommandOutput,
   AcceptVpcEndpointConnectionsCommand,
-  type AcceptVpcEndpointConnectionsCommandInput,
-  type AcceptVpcEndpointConnectionsCommandOutput,
   AcceptVpcPeeringConnectionCommand,
-  type AcceptVpcPeeringConnectionCommandInput,
-  type AcceptVpcPeeringConnectionCommandOutput,
   AdvertiseByoipCidrCommand,
-  type AdvertiseByoipCidrCommandInput,
-  type AdvertiseByoipCidrCommandOutput,
   AllocateAddressCommand,
-  type AllocateAddressCommandInput,
-  type AllocateAddressCommandOutput,
   AllocateHostsCommand,
-  type AllocateHostsCommandInput,
-  type AllocateHostsCommandOutput,
   AllocateIpamPoolCidrCommand,
-  type AllocateIpamPoolCidrCommandInput,
-  type AllocateIpamPoolCidrCommandOutput,
   ApplySecurityGroupsToClientVpnTargetNetworkCommand,
-  type ApplySecurityGroupsToClientVpnTargetNetworkCommandInput,
-  type ApplySecurityGroupsToClientVpnTargetNetworkCommandOutput,
   AssignIpv6AddressesCommand,
-  type AssignIpv6AddressesCommandInput,
-  type AssignIpv6AddressesCommandOutput,
   AssignPrivateIpAddressesCommand,
-  type AssignPrivateIpAddressesCommandInput,
-  type AssignPrivateIpAddressesCommandOutput,
   AssignPrivateNatGatewayAddressCommand,
-  type AssignPrivateNatGatewayAddressCommandInput,
-  type AssignPrivateNatGatewayAddressCommandOutput,
   AssociateAddressCommand,
-  type AssociateAddressCommandInput,
-  type AssociateAddressCommandOutput,
   AssociateClientVpnTargetNetworkCommand,
-  type AssociateClientVpnTargetNetworkCommandInput,
-  type AssociateClientVpnTargetNetworkCommandOutput,
   AssociateDhcpOptionsCommand,
-  type AssociateDhcpOptionsCommandInput,
-  type AssociateDhcpOptionsCommandOutput,
   AssociateEnclaveCertificateIamRoleCommand,
-  type AssociateEnclaveCertificateIamRoleCommandInput,
-  type AssociateEnclaveCertificateIamRoleCommandOutput,
   AssociateIamInstanceProfileCommand,
-  type AssociateIamInstanceProfileCommandInput,
-  type AssociateIamInstanceProfileCommandOutput,
   AssociateInstanceEventWindowCommand,
-  type AssociateInstanceEventWindowCommandInput,
-  type AssociateInstanceEventWindowCommandOutput,
   AssociateIpamByoasnCommand,
-  type AssociateIpamByoasnCommandInput,
-  type AssociateIpamByoasnCommandOutput,
   AssociateIpamResourceDiscoveryCommand,
-  type AssociateIpamResourceDiscoveryCommandInput,
-  type AssociateIpamResourceDiscoveryCommandOutput,
   AssociateNatGatewayAddressCommand,
-  type AssociateNatGatewayAddressCommandInput,
-  type AssociateNatGatewayAddressCommandOutput,
   AssociateRouteTableCommand,
-  type AssociateRouteTableCommandInput,
-  type AssociateRouteTableCommandOutput,
   AssociateSubnetCidrBlockCommand,
-  type AssociateSubnetCidrBlockCommandInput,
-  type AssociateSubnetCidrBlockCommandOutput,
   AssociateTransitGatewayMulticastDomainCommand,
-  type AssociateTransitGatewayMulticastDomainCommandInput,
-  type AssociateTransitGatewayMulticastDomainCommandOutput,
   AssociateTransitGatewayPolicyTableCommand,
-  type AssociateTransitGatewayPolicyTableCommandInput,
-  type AssociateTransitGatewayPolicyTableCommandOutput,
   AssociateTransitGatewayRouteTableCommand,
-  type AssociateTransitGatewayRouteTableCommandInput,
-  type AssociateTransitGatewayRouteTableCommandOutput,
   AssociateTrunkInterfaceCommand,
-  type AssociateTrunkInterfaceCommandInput,
-  type AssociateTrunkInterfaceCommandOutput,
   AssociateVpcCidrBlockCommand,
-  type AssociateVpcCidrBlockCommandInput,
-  type AssociateVpcCidrBlockCommandOutput,
   AttachClassicLinkVpcCommand,
-  type AttachClassicLinkVpcCommandInput,
-  type AttachClassicLinkVpcCommandOutput,
   AttachInternetGatewayCommand,
-  type AttachInternetGatewayCommandInput,
-  type AttachInternetGatewayCommandOutput,
   AttachNetworkInterfaceCommand,
-  type AttachNetworkInterfaceCommandInput,
-  type AttachNetworkInterfaceCommandOutput,
   AttachVerifiedAccessTrustProviderCommand,
-  type AttachVerifiedAccessTrustProviderCommandInput,
-  type AttachVerifiedAccessTrustProviderCommandOutput,
   AttachVolumeCommand,
-  type AttachVolumeCommandInput,
-  type AttachVolumeCommandOutput,
   AttachVpnGatewayCommand,
-  type AttachVpnGatewayCommandInput,
-  type AttachVpnGatewayCommandOutput,
   AuthorizeClientVpnIngressCommand,
-  type AuthorizeClientVpnIngressCommandInput,
-  type AuthorizeClientVpnIngressCommandOutput,
   AuthorizeSecurityGroupEgressCommand,
-  type AuthorizeSecurityGroupEgressCommandInput,
-  type AuthorizeSecurityGroupEgressCommandOutput,
   AuthorizeSecurityGroupIngressCommand,
-  type AuthorizeSecurityGroupIngressCommandInput,
-  type AuthorizeSecurityGroupIngressCommandOutput,
   BundleInstanceCommand,
-  type BundleInstanceCommandInput,
-  type BundleInstanceCommandOutput,
   CancelBundleTaskCommand,
-  type CancelBundleTaskCommandInput,
-  type CancelBundleTaskCommandOutput,
   CancelCapacityReservationCommand,
-  type CancelCapacityReservationCommandInput,
-  type CancelCapacityReservationCommandOutput,
   CancelCapacityReservationFleetsCommand,
-  type CancelCapacityReservationFleetsCommandInput,
-  type CancelCapacityReservationFleetsCommandOutput,
   CancelConversionTaskCommand,
-  type CancelConversionTaskCommandInput,
-  type CancelConversionTaskCommandOutput,
   CancelExportTaskCommand,
-  type CancelExportTaskCommandInput,
-  type CancelExportTaskCommandOutput,
   CancelImageLaunchPermissionCommand,
-  type CancelImageLaunchPermissionCommandInput,
-  type CancelImageLaunchPermissionCommandOutput,
   CancelImportTaskCommand,
-  type CancelImportTaskCommandInput,
-  type CancelImportTaskCommandOutput,
   CancelReservedInstancesListingCommand,
-  type CancelReservedInstancesListingCommandInput,
-  type CancelReservedInstancesListingCommandOutput,
   CancelSpotFleetRequestsCommand,
-  type CancelSpotFleetRequestsCommandInput,
-  type CancelSpotFleetRequestsCommandOutput,
   CancelSpotInstanceRequestsCommand,
-  type CancelSpotInstanceRequestsCommandInput,
-  type CancelSpotInstanceRequestsCommandOutput,
   ConfirmProductInstanceCommand,
-  type ConfirmProductInstanceCommandInput,
-  type ConfirmProductInstanceCommandOutput,
   CopyFpgaImageCommand,
-  type CopyFpgaImageCommandInput,
-  type CopyFpgaImageCommandOutput,
   CopyImageCommand,
-  type CopyImageCommandInput,
-  type CopyImageCommandOutput,
   CopySnapshotCommand,
-  type CopySnapshotCommandInput,
-  type CopySnapshotCommandOutput,
   CreateCapacityReservationCommand,
-  type CreateCapacityReservationCommandInput,
-  type CreateCapacityReservationCommandOutput,
   CreateCapacityReservationFleetCommand,
-  type CreateCapacityReservationFleetCommandInput,
-  type CreateCapacityReservationFleetCommandOutput,
   CreateCarrierGatewayCommand,
-  type CreateCarrierGatewayCommandInput,
-  type CreateCarrierGatewayCommandOutput,
   CreateClientVpnEndpointCommand,
-  type CreateClientVpnEndpointCommandInput,
-  type CreateClientVpnEndpointCommandOutput,
   CreateClientVpnRouteCommand,
-  type CreateClientVpnRouteCommandInput,
-  type CreateClientVpnRouteCommandOutput,
   CreateCoipCidrCommand,
-  type CreateCoipCidrCommandInput,
-  type CreateCoipCidrCommandOutput,
   CreateCoipPoolCommand,
-  type CreateCoipPoolCommandInput,
-  type CreateCoipPoolCommandOutput,
   CreateCustomerGatewayCommand,
-  type CreateCustomerGatewayCommandInput,
-  type CreateCustomerGatewayCommandOutput,
   CreateDefaultSubnetCommand,
-  type CreateDefaultSubnetCommandInput,
-  type CreateDefaultSubnetCommandOutput,
   CreateDefaultVpcCommand,
-  type CreateDefaultVpcCommandInput,
-  type CreateDefaultVpcCommandOutput,
   CreateDhcpOptionsCommand,
-  type CreateDhcpOptionsCommandInput,
-  type CreateDhcpOptionsCommandOutput,
   CreateEgressOnlyInternetGatewayCommand,
-  type CreateEgressOnlyInternetGatewayCommandInput,
-  type CreateEgressOnlyInternetGatewayCommandOutput,
   CreateFleetCommand,
-  type CreateFleetCommandInput,
-  type CreateFleetCommandOutput,
   CreateFlowLogsCommand,
-  type CreateFlowLogsCommandInput,
-  type CreateFlowLogsCommandOutput,
   CreateFpgaImageCommand,
-  type CreateFpgaImageCommandInput,
-  type CreateFpgaImageCommandOutput,
   CreateImageCommand,
-  type CreateImageCommandInput,
-  type CreateImageCommandOutput,
   CreateInstanceConnectEndpointCommand,
-  type CreateInstanceConnectEndpointCommandInput,
-  type CreateInstanceConnectEndpointCommandOutput,
   CreateInstanceEventWindowCommand,
-  type CreateInstanceEventWindowCommandInput,
-  type CreateInstanceEventWindowCommandOutput,
   CreateInstanceExportTaskCommand,
-  type CreateInstanceExportTaskCommandInput,
-  type CreateInstanceExportTaskCommandOutput,
   CreateInternetGatewayCommand,
-  type CreateInternetGatewayCommandInput,
-  type CreateInternetGatewayCommandOutput,
   CreateIpamCommand,
-  type CreateIpamCommandInput,
-  type CreateIpamCommandOutput,
   CreateIpamPoolCommand,
-  type CreateIpamPoolCommandInput,
-  type CreateIpamPoolCommandOutput,
   CreateIpamResourceDiscoveryCommand,
-  type CreateIpamResourceDiscoveryCommandInput,
-  type CreateIpamResourceDiscoveryCommandOutput,
   CreateIpamScopeCommand,
-  type CreateIpamScopeCommandInput,
-  type CreateIpamScopeCommandOutput,
   CreateKeyPairCommand,
-  type CreateKeyPairCommandInput,
-  type CreateKeyPairCommandOutput,
   CreateLaunchTemplateCommand,
-  type CreateLaunchTemplateCommandInput,
-  type CreateLaunchTemplateCommandOutput,
   CreateLaunchTemplateVersionCommand,
-  type CreateLaunchTemplateVersionCommandInput,
-  type CreateLaunchTemplateVersionCommandOutput,
   CreateLocalGatewayRouteCommand,
-  type CreateLocalGatewayRouteCommandInput,
-  type CreateLocalGatewayRouteCommandOutput,
   CreateLocalGatewayRouteTableCommand,
-  type CreateLocalGatewayRouteTableCommandInput,
-  type CreateLocalGatewayRouteTableCommandOutput,
   CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-  type CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
-  type CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandOutput,
   CreateLocalGatewayRouteTableVpcAssociationCommand,
-  type CreateLocalGatewayRouteTableVpcAssociationCommandInput,
-  type CreateLocalGatewayRouteTableVpcAssociationCommandOutput,
   CreateManagedPrefixListCommand,
-  type CreateManagedPrefixListCommandInput,
-  type CreateManagedPrefixListCommandOutput,
   CreateNatGatewayCommand,
-  type CreateNatGatewayCommandInput,
-  type CreateNatGatewayCommandOutput,
   CreateNetworkAclCommand,
-  type CreateNetworkAclCommandInput,
-  type CreateNetworkAclCommandOutput,
   CreateNetworkAclEntryCommand,
-  type CreateNetworkAclEntryCommandInput,
-  type CreateNetworkAclEntryCommandOutput,
   CreateNetworkInsightsAccessScopeCommand,
-  type CreateNetworkInsightsAccessScopeCommandInput,
-  type CreateNetworkInsightsAccessScopeCommandOutput,
   CreateNetworkInsightsPathCommand,
-  type CreateNetworkInsightsPathCommandInput,
-  type CreateNetworkInsightsPathCommandOutput,
   CreateNetworkInterfaceCommand,
-  type CreateNetworkInterfaceCommandInput,
-  type CreateNetworkInterfaceCommandOutput,
   CreateNetworkInterfacePermissionCommand,
-  type CreateNetworkInterfacePermissionCommandInput,
-  type CreateNetworkInterfacePermissionCommandOutput,
   CreatePlacementGroupCommand,
-  type CreatePlacementGroupCommandInput,
-  type CreatePlacementGroupCommandOutput,
   CreatePublicIpv4PoolCommand,
-  type CreatePublicIpv4PoolCommandInput,
-  type CreatePublicIpv4PoolCommandOutput,
   CreateReplaceRootVolumeTaskCommand,
-  type CreateReplaceRootVolumeTaskCommandInput,
-  type CreateReplaceRootVolumeTaskCommandOutput,
   CreateReservedInstancesListingCommand,
-  type CreateReservedInstancesListingCommandInput,
-  type CreateReservedInstancesListingCommandOutput,
   CreateRestoreImageTaskCommand,
-  type CreateRestoreImageTaskCommandInput,
-  type CreateRestoreImageTaskCommandOutput,
   CreateRouteCommand,
-  type CreateRouteCommandInput,
-  type CreateRouteCommandOutput,
   CreateRouteTableCommand,
-  type CreateRouteTableCommandInput,
-  type CreateRouteTableCommandOutput,
   CreateSecurityGroupCommand,
-  type CreateSecurityGroupCommandInput,
-  type CreateSecurityGroupCommandOutput,
   CreateSnapshotCommand,
-  type CreateSnapshotCommandInput,
-  type CreateSnapshotCommandOutput,
   CreateSnapshotsCommand,
-  type CreateSnapshotsCommandInput,
-  type CreateSnapshotsCommandOutput,
   CreateSpotDatafeedSubscriptionCommand,
-  type CreateSpotDatafeedSubscriptionCommandInput,
-  type CreateSpotDatafeedSubscriptionCommandOutput,
   CreateStoreImageTaskCommand,
-  type CreateStoreImageTaskCommandInput,
-  type CreateStoreImageTaskCommandOutput,
   CreateSubnetCommand,
-  type CreateSubnetCommandInput,
-  type CreateSubnetCommandOutput,
   CreateSubnetCidrReservationCommand,
-  type CreateSubnetCidrReservationCommandInput,
-  type CreateSubnetCidrReservationCommandOutput,
   CreateTagsCommand,
-  type CreateTagsCommandInput,
-  type CreateTagsCommandOutput,
   CreateTrafficMirrorFilterCommand,
-  type CreateTrafficMirrorFilterCommandInput,
-  type CreateTrafficMirrorFilterCommandOutput,
   CreateTrafficMirrorFilterRuleCommand,
-  type CreateTrafficMirrorFilterRuleCommandInput,
-  type CreateTrafficMirrorFilterRuleCommandOutput,
   CreateTrafficMirrorSessionCommand,
-  type CreateTrafficMirrorSessionCommandInput,
-  type CreateTrafficMirrorSessionCommandOutput,
   CreateTrafficMirrorTargetCommand,
-  type CreateTrafficMirrorTargetCommandInput,
-  type CreateTrafficMirrorTargetCommandOutput,
   CreateTransitGatewayCommand,
-  type CreateTransitGatewayCommandInput,
-  type CreateTransitGatewayCommandOutput,
   CreateTransitGatewayConnectCommand,
-  type CreateTransitGatewayConnectCommandInput,
-  type CreateTransitGatewayConnectCommandOutput,
   CreateTransitGatewayConnectPeerCommand,
-  type CreateTransitGatewayConnectPeerCommandInput,
-  type CreateTransitGatewayConnectPeerCommandOutput,
   CreateTransitGatewayMulticastDomainCommand,
-  type CreateTransitGatewayMulticastDomainCommandInput,
-  type CreateTransitGatewayMulticastDomainCommandOutput,
   CreateTransitGatewayPeeringAttachmentCommand,
-  type CreateTransitGatewayPeeringAttachmentCommandInput,
-  type CreateTransitGatewayPeeringAttachmentCommandOutput,
   CreateTransitGatewayPolicyTableCommand,
-  type CreateTransitGatewayPolicyTableCommandInput,
-  type CreateTransitGatewayPolicyTableCommandOutput,
   CreateTransitGatewayPrefixListReferenceCommand,
-  type CreateTransitGatewayPrefixListReferenceCommandInput,
-  type CreateTransitGatewayPrefixListReferenceCommandOutput,
   CreateTransitGatewayRouteCommand,
-  type CreateTransitGatewayRouteCommandInput,
-  type CreateTransitGatewayRouteCommandOutput,
   CreateTransitGatewayRouteTableCommand,
-  type CreateTransitGatewayRouteTableCommandInput,
-  type CreateTransitGatewayRouteTableCommandOutput,
   CreateTransitGatewayRouteTableAnnouncementCommand,
-  type CreateTransitGatewayRouteTableAnnouncementCommandInput,
-  type CreateTransitGatewayRouteTableAnnouncementCommandOutput,
   CreateTransitGatewayVpcAttachmentCommand,
-  type CreateTransitGatewayVpcAttachmentCommandInput,
-  type CreateTransitGatewayVpcAttachmentCommandOutput,
   CreateVerifiedAccessEndpointCommand,
-  type CreateVerifiedAccessEndpointCommandInput,
-  type CreateVerifiedAccessEndpointCommandOutput,
   CreateVerifiedAccessGroupCommand,
-  type CreateVerifiedAccessGroupCommandInput,
-  type CreateVerifiedAccessGroupCommandOutput,
   CreateVerifiedAccessInstanceCommand,
-  type CreateVerifiedAccessInstanceCommandInput,
-  type CreateVerifiedAccessInstanceCommandOutput,
   CreateVerifiedAccessTrustProviderCommand,
-  type CreateVerifiedAccessTrustProviderCommandInput,
-  type CreateVerifiedAccessTrustProviderCommandOutput,
   CreateVolumeCommand,
-  type CreateVolumeCommandInput,
-  type CreateVolumeCommandOutput,
   CreateVpcCommand,
-  type CreateVpcCommandInput,
-  type CreateVpcCommandOutput,
   CreateVpcEndpointCommand,
-  type CreateVpcEndpointCommandInput,
-  type CreateVpcEndpointCommandOutput,
   CreateVpcEndpointConnectionNotificationCommand,
-  type CreateVpcEndpointConnectionNotificationCommandInput,
-  type CreateVpcEndpointConnectionNotificationCommandOutput,
   CreateVpcEndpointServiceConfigurationCommand,
-  type CreateVpcEndpointServiceConfigurationCommandInput,
-  type CreateVpcEndpointServiceConfigurationCommandOutput,
   CreateVpcPeeringConnectionCommand,
-  type CreateVpcPeeringConnectionCommandInput,
-  type CreateVpcPeeringConnectionCommandOutput,
   CreateVpnConnectionCommand,
-  type CreateVpnConnectionCommandInput,
-  type CreateVpnConnectionCommandOutput,
   CreateVpnConnectionRouteCommand,
-  type CreateVpnConnectionRouteCommandInput,
-  type CreateVpnConnectionRouteCommandOutput,
   CreateVpnGatewayCommand,
-  type CreateVpnGatewayCommandInput,
-  type CreateVpnGatewayCommandOutput,
   DeleteCarrierGatewayCommand,
-  type DeleteCarrierGatewayCommandInput,
-  type DeleteCarrierGatewayCommandOutput,
   DeleteClientVpnEndpointCommand,
-  type DeleteClientVpnEndpointCommandInput,
-  type DeleteClientVpnEndpointCommandOutput,
   DeleteClientVpnRouteCommand,
-  type DeleteClientVpnRouteCommandInput,
-  type DeleteClientVpnRouteCommandOutput,
   DeleteCoipCidrCommand,
-  type DeleteCoipCidrCommandInput,
-  type DeleteCoipCidrCommandOutput,
   DeleteCoipPoolCommand,
-  type DeleteCoipPoolCommandInput,
-  type DeleteCoipPoolCommandOutput,
   DeleteCustomerGatewayCommand,
-  type DeleteCustomerGatewayCommandInput,
-  type DeleteCustomerGatewayCommandOutput,
   DeleteDhcpOptionsCommand,
-  type DeleteDhcpOptionsCommandInput,
-  type DeleteDhcpOptionsCommandOutput,
   DeleteEgressOnlyInternetGatewayCommand,
-  type DeleteEgressOnlyInternetGatewayCommandInput,
-  type DeleteEgressOnlyInternetGatewayCommandOutput,
   DeleteFleetsCommand,
-  type DeleteFleetsCommandInput,
-  type DeleteFleetsCommandOutput,
   DeleteFlowLogsCommand,
-  type DeleteFlowLogsCommandInput,
-  type DeleteFlowLogsCommandOutput,
   DeleteFpgaImageCommand,
-  type DeleteFpgaImageCommandInput,
-  type DeleteFpgaImageCommandOutput,
   DeleteInstanceConnectEndpointCommand,
-  type DeleteInstanceConnectEndpointCommandInput,
-  type DeleteInstanceConnectEndpointCommandOutput,
   DeleteInstanceEventWindowCommand,
-  type DeleteInstanceEventWindowCommandInput,
-  type DeleteInstanceEventWindowCommandOutput,
   DeleteInternetGatewayCommand,
-  type DeleteInternetGatewayCommandInput,
-  type DeleteInternetGatewayCommandOutput,
   DeleteIpamCommand,
-  type DeleteIpamCommandInput,
-  type DeleteIpamCommandOutput,
   DeleteIpamPoolCommand,
-  type DeleteIpamPoolCommandInput,
-  type DeleteIpamPoolCommandOutput,
   DeleteIpamResourceDiscoveryCommand,
-  type DeleteIpamResourceDiscoveryCommandInput,
-  type DeleteIpamResourceDiscoveryCommandOutput,
   DeleteIpamScopeCommand,
-  type DeleteIpamScopeCommandInput,
-  type DeleteIpamScopeCommandOutput,
   DeleteKeyPairCommand,
-  type DeleteKeyPairCommandInput,
-  type DeleteKeyPairCommandOutput,
   DeleteLaunchTemplateCommand,
-  type DeleteLaunchTemplateCommandInput,
-  type DeleteLaunchTemplateCommandOutput,
   DeleteLaunchTemplateVersionsCommand,
-  type DeleteLaunchTemplateVersionsCommandInput,
-  type DeleteLaunchTemplateVersionsCommandOutput,
   DeleteLocalGatewayRouteCommand,
-  type DeleteLocalGatewayRouteCommandInput,
-  type DeleteLocalGatewayRouteCommandOutput,
   DeleteLocalGatewayRouteTableCommand,
-  type DeleteLocalGatewayRouteTableCommandInput,
-  type DeleteLocalGatewayRouteTableCommandOutput,
   DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-  type DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
-  type DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandOutput,
   DeleteLocalGatewayRouteTableVpcAssociationCommand,
-  type DeleteLocalGatewayRouteTableVpcAssociationCommandInput,
-  type DeleteLocalGatewayRouteTableVpcAssociationCommandOutput,
   DeleteManagedPrefixListCommand,
-  type DeleteManagedPrefixListCommandInput,
-  type DeleteManagedPrefixListCommandOutput,
   DeleteNatGatewayCommand,
-  type DeleteNatGatewayCommandInput,
-  type DeleteNatGatewayCommandOutput,
   DeleteNetworkAclCommand,
-  type DeleteNetworkAclCommandInput,
-  type DeleteNetworkAclCommandOutput,
   DeleteNetworkAclEntryCommand,
-  type DeleteNetworkAclEntryCommandInput,
-  type DeleteNetworkAclEntryCommandOutput,
   DeleteNetworkInsightsAccessScopeCommand,
-  type DeleteNetworkInsightsAccessScopeCommandInput,
-  type DeleteNetworkInsightsAccessScopeCommandOutput,
   DeleteNetworkInsightsAccessScopeAnalysisCommand,
-  type DeleteNetworkInsightsAccessScopeAnalysisCommandInput,
-  type DeleteNetworkInsightsAccessScopeAnalysisCommandOutput,
   DeleteNetworkInsightsAnalysisCommand,
-  type DeleteNetworkInsightsAnalysisCommandInput,
-  type DeleteNetworkInsightsAnalysisCommandOutput,
   DeleteNetworkInsightsPathCommand,
-  type DeleteNetworkInsightsPathCommandInput,
-  type DeleteNetworkInsightsPathCommandOutput,
   DeleteNetworkInterfaceCommand,
-  type DeleteNetworkInterfaceCommandInput,
-  type DeleteNetworkInterfaceCommandOutput,
   DeleteNetworkInterfacePermissionCommand,
-  type DeleteNetworkInterfacePermissionCommandInput,
-  type DeleteNetworkInterfacePermissionCommandOutput,
   DeletePlacementGroupCommand,
-  type DeletePlacementGroupCommandInput,
-  type DeletePlacementGroupCommandOutput,
   DeletePublicIpv4PoolCommand,
-  type DeletePublicIpv4PoolCommandInput,
-  type DeletePublicIpv4PoolCommandOutput,
   DeleteQueuedReservedInstancesCommand,
-  type DeleteQueuedReservedInstancesCommandInput,
-  type DeleteQueuedReservedInstancesCommandOutput,
   DeleteRouteCommand,
-  type DeleteRouteCommandInput,
-  type DeleteRouteCommandOutput,
   DeleteRouteTableCommand,
-  type DeleteRouteTableCommandInput,
-  type DeleteRouteTableCommandOutput,
   DeleteSecurityGroupCommand,
-  type DeleteSecurityGroupCommandInput,
-  type DeleteSecurityGroupCommandOutput,
   DeleteSnapshotCommand,
-  type DeleteSnapshotCommandInput,
-  type DeleteSnapshotCommandOutput,
   DeleteSpotDatafeedSubscriptionCommand,
-  type DeleteSpotDatafeedSubscriptionCommandInput,
-  type DeleteSpotDatafeedSubscriptionCommandOutput,
   DeleteSubnetCommand,
-  type DeleteSubnetCommandInput,
-  type DeleteSubnetCommandOutput,
   DeleteSubnetCidrReservationCommand,
-  type DeleteSubnetCidrReservationCommandInput,
-  type DeleteSubnetCidrReservationCommandOutput,
   DeleteTagsCommand,
-  type DeleteTagsCommandInput,
-  type DeleteTagsCommandOutput,
   DeleteTrafficMirrorFilterCommand,
-  type DeleteTrafficMirrorFilterCommandInput,
-  type DeleteTrafficMirrorFilterCommandOutput,
   DeleteTrafficMirrorFilterRuleCommand,
-  type DeleteTrafficMirrorFilterRuleCommandInput,
-  type DeleteTrafficMirrorFilterRuleCommandOutput,
   DeleteTrafficMirrorSessionCommand,
-  type DeleteTrafficMirrorSessionCommandInput,
-  type DeleteTrafficMirrorSessionCommandOutput,
   DeleteTrafficMirrorTargetCommand,
-  type DeleteTrafficMirrorTargetCommandInput,
-  type DeleteTrafficMirrorTargetCommandOutput,
   DeleteTransitGatewayCommand,
-  type DeleteTransitGatewayCommandInput,
-  type DeleteTransitGatewayCommandOutput,
   DeleteTransitGatewayConnectCommand,
-  type DeleteTransitGatewayConnectCommandInput,
-  type DeleteTransitGatewayConnectCommandOutput,
   DeleteTransitGatewayConnectPeerCommand,
-  type DeleteTransitGatewayConnectPeerCommandInput,
-  type DeleteTransitGatewayConnectPeerCommandOutput,
   DeleteTransitGatewayMulticastDomainCommand,
-  type DeleteTransitGatewayMulticastDomainCommandInput,
-  type DeleteTransitGatewayMulticastDomainCommandOutput,
   DeleteTransitGatewayPeeringAttachmentCommand,
-  type DeleteTransitGatewayPeeringAttachmentCommandInput,
-  type DeleteTransitGatewayPeeringAttachmentCommandOutput,
   DeleteTransitGatewayPolicyTableCommand,
-  type DeleteTransitGatewayPolicyTableCommandInput,
-  type DeleteTransitGatewayPolicyTableCommandOutput,
   DeleteTransitGatewayPrefixListReferenceCommand,
-  type DeleteTransitGatewayPrefixListReferenceCommandInput,
-  type DeleteTransitGatewayPrefixListReferenceCommandOutput,
   DeleteTransitGatewayRouteCommand,
-  type DeleteTransitGatewayRouteCommandInput,
-  type DeleteTransitGatewayRouteCommandOutput,
   DeleteTransitGatewayRouteTableCommand,
-  type DeleteTransitGatewayRouteTableCommandInput,
-  type DeleteTransitGatewayRouteTableCommandOutput,
   DeleteTransitGatewayRouteTableAnnouncementCommand,
-  type DeleteTransitGatewayRouteTableAnnouncementCommandInput,
-  type DeleteTransitGatewayRouteTableAnnouncementCommandOutput,
   DeleteTransitGatewayVpcAttachmentCommand,
-  type DeleteTransitGatewayVpcAttachmentCommandInput,
-  type DeleteTransitGatewayVpcAttachmentCommandOutput,
   DeleteVerifiedAccessEndpointCommand,
-  type DeleteVerifiedAccessEndpointCommandInput,
-  type DeleteVerifiedAccessEndpointCommandOutput,
   DeleteVerifiedAccessGroupCommand,
-  type DeleteVerifiedAccessGroupCommandInput,
-  type DeleteVerifiedAccessGroupCommandOutput,
   DeleteVerifiedAccessInstanceCommand,
-  type DeleteVerifiedAccessInstanceCommandInput,
-  type DeleteVerifiedAccessInstanceCommandOutput,
   DeleteVerifiedAccessTrustProviderCommand,
-  type DeleteVerifiedAccessTrustProviderCommandInput,
-  type DeleteVerifiedAccessTrustProviderCommandOutput,
   DeleteVolumeCommand,
-  type DeleteVolumeCommandInput,
-  type DeleteVolumeCommandOutput,
   DeleteVpcCommand,
-  type DeleteVpcCommandInput,
-  type DeleteVpcCommandOutput,
   DeleteVpcEndpointConnectionNotificationsCommand,
-  type DeleteVpcEndpointConnectionNotificationsCommandInput,
-  type DeleteVpcEndpointConnectionNotificationsCommandOutput,
-  DeleteVpcEndpointsCommand,
-  type DeleteVpcEndpointsCommandInput,
-  type DeleteVpcEndpointsCommandOutput,
   DeleteVpcEndpointServiceConfigurationsCommand,
-  type DeleteVpcEndpointServiceConfigurationsCommandInput,
-  type DeleteVpcEndpointServiceConfigurationsCommandOutput,
+  DeleteVpcEndpointsCommand,
   DeleteVpcPeeringConnectionCommand,
-  type DeleteVpcPeeringConnectionCommandInput,
-  type DeleteVpcPeeringConnectionCommandOutput,
   DeleteVpnConnectionCommand,
-  type DeleteVpnConnectionCommandInput,
-  type DeleteVpnConnectionCommandOutput,
   DeleteVpnConnectionRouteCommand,
-  type DeleteVpnConnectionRouteCommandInput,
-  type DeleteVpnConnectionRouteCommandOutput,
   DeleteVpnGatewayCommand,
-  type DeleteVpnGatewayCommandInput,
-  type DeleteVpnGatewayCommandOutput,
   DeprovisionByoipCidrCommand,
-  type DeprovisionByoipCidrCommandInput,
-  type DeprovisionByoipCidrCommandOutput,
   DeprovisionIpamByoasnCommand,
-  type DeprovisionIpamByoasnCommandInput,
-  type DeprovisionIpamByoasnCommandOutput,
   DeprovisionIpamPoolCidrCommand,
-  type DeprovisionIpamPoolCidrCommandInput,
-  type DeprovisionIpamPoolCidrCommandOutput,
   DeprovisionPublicIpv4PoolCidrCommand,
-  type DeprovisionPublicIpv4PoolCidrCommandInput,
-  type DeprovisionPublicIpv4PoolCidrCommandOutput,
   DeregisterImageCommand,
-  type DeregisterImageCommandInput,
-  type DeregisterImageCommandOutput,
   DeregisterInstanceEventNotificationAttributesCommand,
-  type DeregisterInstanceEventNotificationAttributesCommandInput,
-  type DeregisterInstanceEventNotificationAttributesCommandOutput,
   DeregisterTransitGatewayMulticastGroupMembersCommand,
-  type DeregisterTransitGatewayMulticastGroupMembersCommandInput,
-  type DeregisterTransitGatewayMulticastGroupMembersCommandOutput,
   DeregisterTransitGatewayMulticastGroupSourcesCommand,
-  type DeregisterTransitGatewayMulticastGroupSourcesCommandInput,
-  type DeregisterTransitGatewayMulticastGroupSourcesCommandOutput,
   DescribeAccountAttributesCommand,
-  type DescribeAccountAttributesCommandInput,
-  type DescribeAccountAttributesCommandOutput,
-  DescribeAddressesCommand,
-  type DescribeAddressesCommandInput,
-  type DescribeAddressesCommandOutput,
-  DescribeAddressesAttributeCommand,
-  type DescribeAddressesAttributeCommandInput,
-  type DescribeAddressesAttributeCommandOutput,
   DescribeAddressTransfersCommand,
-  type DescribeAddressTransfersCommandInput,
-  type DescribeAddressTransfersCommandOutput,
+  DescribeAddressesCommand,
+  DescribeAddressesAttributeCommand,
   DescribeAggregateIdFormatCommand,
-  type DescribeAggregateIdFormatCommandInput,
-  type DescribeAggregateIdFormatCommandOutput,
   DescribeAvailabilityZonesCommand,
-  type DescribeAvailabilityZonesCommandInput,
-  type DescribeAvailabilityZonesCommandOutput,
   DescribeAwsNetworkPerformanceMetricSubscriptionsCommand,
-  type DescribeAwsNetworkPerformanceMetricSubscriptionsCommandInput,
-  type DescribeAwsNetworkPerformanceMetricSubscriptionsCommandOutput,
   DescribeBundleTasksCommand,
-  type DescribeBundleTasksCommandInput,
-  type DescribeBundleTasksCommandOutput,
   DescribeByoipCidrsCommand,
-  type DescribeByoipCidrsCommandInput,
-  type DescribeByoipCidrsCommandOutput,
   DescribeCapacityBlockOfferingsCommand,
-  type DescribeCapacityBlockOfferingsCommandInput,
-  type DescribeCapacityBlockOfferingsCommandOutput,
   DescribeCapacityReservationFleetsCommand,
-  type DescribeCapacityReservationFleetsCommandInput,
-  type DescribeCapacityReservationFleetsCommandOutput,
   DescribeCapacityReservationsCommand,
-  type DescribeCapacityReservationsCommandInput,
-  type DescribeCapacityReservationsCommandOutput,
   DescribeCarrierGatewaysCommand,
-  type DescribeCarrierGatewaysCommandInput,
-  type DescribeCarrierGatewaysCommandOutput,
   DescribeClassicLinkInstancesCommand,
-  type DescribeClassicLinkInstancesCommandInput,
-  type DescribeClassicLinkInstancesCommandOutput,
   DescribeClientVpnAuthorizationRulesCommand,
-  type DescribeClientVpnAuthorizationRulesCommandInput,
-  type DescribeClientVpnAuthorizationRulesCommandOutput,
   DescribeClientVpnConnectionsCommand,
-  type DescribeClientVpnConnectionsCommandInput,
-  type DescribeClientVpnConnectionsCommandOutput,
   DescribeClientVpnEndpointsCommand,
-  type DescribeClientVpnEndpointsCommandInput,
-  type DescribeClientVpnEndpointsCommandOutput,
   DescribeClientVpnRoutesCommand,
-  type DescribeClientVpnRoutesCommandInput,
-  type DescribeClientVpnRoutesCommandOutput,
   DescribeClientVpnTargetNetworksCommand,
-  type DescribeClientVpnTargetNetworksCommandInput,
-  type DescribeClientVpnTargetNetworksCommandOutput,
   DescribeCoipPoolsCommand,
-  type DescribeCoipPoolsCommandInput,
-  type DescribeCoipPoolsCommandOutput,
   DescribeConversionTasksCommand,
-  type DescribeConversionTasksCommandInput,
-  type DescribeConversionTasksCommandOutput,
   DescribeCustomerGatewaysCommand,
-  type DescribeCustomerGatewaysCommandInput,
-  type DescribeCustomerGatewaysCommandOutput,
   DescribeDhcpOptionsCommand,
-  type DescribeDhcpOptionsCommandInput,
-  type DescribeDhcpOptionsCommandOutput,
   DescribeEgressOnlyInternetGatewaysCommand,
-  type DescribeEgressOnlyInternetGatewaysCommandInput,
-  type DescribeEgressOnlyInternetGatewaysCommandOutput,
   DescribeElasticGpusCommand,
-  type DescribeElasticGpusCommandInput,
-  type DescribeElasticGpusCommandOutput,
   DescribeExportImageTasksCommand,
-  type DescribeExportImageTasksCommandInput,
-  type DescribeExportImageTasksCommandOutput,
   DescribeExportTasksCommand,
-  type DescribeExportTasksCommandInput,
-  type DescribeExportTasksCommandOutput,
   DescribeFastLaunchImagesCommand,
-  type DescribeFastLaunchImagesCommandInput,
-  type DescribeFastLaunchImagesCommandOutput,
   DescribeFastSnapshotRestoresCommand,
-  type DescribeFastSnapshotRestoresCommandInput,
-  type DescribeFastSnapshotRestoresCommandOutput,
   DescribeFleetHistoryCommand,
-  type DescribeFleetHistoryCommandInput,
-  type DescribeFleetHistoryCommandOutput,
   DescribeFleetInstancesCommand,
-  type DescribeFleetInstancesCommandInput,
-  type DescribeFleetInstancesCommandOutput,
   DescribeFleetsCommand,
-  type DescribeFleetsCommandInput,
-  type DescribeFleetsCommandOutput,
   DescribeFlowLogsCommand,
-  type DescribeFlowLogsCommandInput,
-  type DescribeFlowLogsCommandOutput,
   DescribeFpgaImageAttributeCommand,
-  type DescribeFpgaImageAttributeCommandInput,
-  type DescribeFpgaImageAttributeCommandOutput,
   DescribeFpgaImagesCommand,
-  type DescribeFpgaImagesCommandInput,
-  type DescribeFpgaImagesCommandOutput,
   DescribeHostReservationOfferingsCommand,
-  type DescribeHostReservationOfferingsCommandInput,
-  type DescribeHostReservationOfferingsCommandOutput,
   DescribeHostReservationsCommand,
-  type DescribeHostReservationsCommandInput,
-  type DescribeHostReservationsCommandOutput,
   DescribeHostsCommand,
-  type DescribeHostsCommandInput,
-  type DescribeHostsCommandOutput,
   DescribeIamInstanceProfileAssociationsCommand,
-  type DescribeIamInstanceProfileAssociationsCommandInput,
-  type DescribeIamInstanceProfileAssociationsCommandOutput,
-  DescribeIdentityIdFormatCommand,
-  type DescribeIdentityIdFormatCommandInput,
-  type DescribeIdentityIdFormatCommandOutput,
   DescribeIdFormatCommand,
-  type DescribeIdFormatCommandInput,
-  type DescribeIdFormatCommandOutput,
+  DescribeIdentityIdFormatCommand,
   DescribeImageAttributeCommand,
-  type DescribeImageAttributeCommandInput,
-  type DescribeImageAttributeCommandOutput,
   DescribeImagesCommand,
-  type DescribeImagesCommandInput,
-  type DescribeImagesCommandOutput,
   DescribeImportImageTasksCommand,
-  type DescribeImportImageTasksCommandInput,
-  type DescribeImportImageTasksCommandOutput,
   DescribeImportSnapshotTasksCommand,
-  type DescribeImportSnapshotTasksCommandInput,
-  type DescribeImportSnapshotTasksCommandOutput,
   DescribeInstanceAttributeCommand,
-  type DescribeInstanceAttributeCommandInput,
-  type DescribeInstanceAttributeCommandOutput,
   DescribeInstanceConnectEndpointsCommand,
-  type DescribeInstanceConnectEndpointsCommandInput,
-  type DescribeInstanceConnectEndpointsCommandOutput,
   DescribeInstanceCreditSpecificationsCommand,
-  type DescribeInstanceCreditSpecificationsCommandInput,
-  type DescribeInstanceCreditSpecificationsCommandOutput,
   DescribeInstanceEventNotificationAttributesCommand,
-  type DescribeInstanceEventNotificationAttributesCommandInput,
-  type DescribeInstanceEventNotificationAttributesCommandOutput,
   DescribeInstanceEventWindowsCommand,
-  type DescribeInstanceEventWindowsCommandInput,
-  type DescribeInstanceEventWindowsCommandOutput,
-  DescribeInstancesCommand,
-  type DescribeInstancesCommandInput,
-  type DescribeInstancesCommandOutput,
   DescribeInstanceStatusCommand,
-  type DescribeInstanceStatusCommandInput,
-  type DescribeInstanceStatusCommandOutput,
   DescribeInstanceTopologyCommand,
-  type DescribeInstanceTopologyCommandInput,
-  type DescribeInstanceTopologyCommandOutput,
   DescribeInstanceTypeOfferingsCommand,
-  type DescribeInstanceTypeOfferingsCommandInput,
-  type DescribeInstanceTypeOfferingsCommandOutput,
   DescribeInstanceTypesCommand,
-  type DescribeInstanceTypesCommandInput,
-  type DescribeInstanceTypesCommandOutput,
+  DescribeInstancesCommand,
   DescribeInternetGatewaysCommand,
-  type DescribeInternetGatewaysCommandInput,
-  type DescribeInternetGatewaysCommandOutput,
   DescribeIpamByoasnCommand,
-  type DescribeIpamByoasnCommandInput,
-  type DescribeIpamByoasnCommandOutput,
   DescribeIpamPoolsCommand,
-  type DescribeIpamPoolsCommandInput,
-  type DescribeIpamPoolsCommandOutput,
   DescribeIpamResourceDiscoveriesCommand,
-  type DescribeIpamResourceDiscoveriesCommandInput,
-  type DescribeIpamResourceDiscoveriesCommandOutput,
   DescribeIpamResourceDiscoveryAssociationsCommand,
-  type DescribeIpamResourceDiscoveryAssociationsCommandInput,
-  type DescribeIpamResourceDiscoveryAssociationsCommandOutput,
-  DescribeIpamsCommand,
-  type DescribeIpamsCommandInput,
-  type DescribeIpamsCommandOutput,
   DescribeIpamScopesCommand,
-  type DescribeIpamScopesCommandInput,
-  type DescribeIpamScopesCommandOutput,
+  DescribeIpamsCommand,
   DescribeIpv6PoolsCommand,
-  type DescribeIpv6PoolsCommandInput,
-  type DescribeIpv6PoolsCommandOutput,
   DescribeKeyPairsCommand,
-  type DescribeKeyPairsCommandInput,
-  type DescribeKeyPairsCommandOutput,
-  DescribeLaunchTemplatesCommand,
-  type DescribeLaunchTemplatesCommandInput,
-  type DescribeLaunchTemplatesCommandOutput,
   DescribeLaunchTemplateVersionsCommand,
-  type DescribeLaunchTemplateVersionsCommandInput,
-  type DescribeLaunchTemplateVersionsCommandOutput,
-  DescribeLocalGatewayRouteTablesCommand,
-  type DescribeLocalGatewayRouteTablesCommandInput,
-  type DescribeLocalGatewayRouteTablesCommandOutput,
+  DescribeLaunchTemplatesCommand,
   DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
-  type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandInput,
-  type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput,
   DescribeLocalGatewayRouteTableVpcAssociationsCommand,
-  type DescribeLocalGatewayRouteTableVpcAssociationsCommandInput,
-  type DescribeLocalGatewayRouteTableVpcAssociationsCommandOutput,
-  DescribeLocalGatewaysCommand,
-  type DescribeLocalGatewaysCommandInput,
-  type DescribeLocalGatewaysCommandOutput,
+  DescribeLocalGatewayRouteTablesCommand,
   DescribeLocalGatewayVirtualInterfaceGroupsCommand,
-  type DescribeLocalGatewayVirtualInterfaceGroupsCommandInput,
-  type DescribeLocalGatewayVirtualInterfaceGroupsCommandOutput,
   DescribeLocalGatewayVirtualInterfacesCommand,
-  type DescribeLocalGatewayVirtualInterfacesCommandInput,
-  type DescribeLocalGatewayVirtualInterfacesCommandOutput,
+  DescribeLocalGatewaysCommand,
   DescribeLockedSnapshotsCommand,
-  type DescribeLockedSnapshotsCommandInput,
-  type DescribeLockedSnapshotsCommandOutput,
+  DescribeMacHostsCommand,
   DescribeManagedPrefixListsCommand,
-  type DescribeManagedPrefixListsCommandInput,
-  type DescribeManagedPrefixListsCommandOutput,
   DescribeMovingAddressesCommand,
-  type DescribeMovingAddressesCommandInput,
-  type DescribeMovingAddressesCommandOutput,
   DescribeNatGatewaysCommand,
-  type DescribeNatGatewaysCommandInput,
-  type DescribeNatGatewaysCommandOutput,
   DescribeNetworkAclsCommand,
-  type DescribeNetworkAclsCommandInput,
-  type DescribeNetworkAclsCommandOutput,
   DescribeNetworkInsightsAccessScopeAnalysesCommand,
-  type DescribeNetworkInsightsAccessScopeAnalysesCommandInput,
-  type DescribeNetworkInsightsAccessScopeAnalysesCommandOutput,
   DescribeNetworkInsightsAccessScopesCommand,
-  type DescribeNetworkInsightsAccessScopesCommandInput,
-  type DescribeNetworkInsightsAccessScopesCommandOutput,
   DescribeNetworkInsightsAnalysesCommand,
-  type DescribeNetworkInsightsAnalysesCommandInput,
-  type DescribeNetworkInsightsAnalysesCommandOutput,
   DescribeNetworkInsightsPathsCommand,
-  type DescribeNetworkInsightsPathsCommandInput,
-  type DescribeNetworkInsightsPathsCommandOutput,
   DescribeNetworkInterfaceAttributeCommand,
-  type DescribeNetworkInterfaceAttributeCommandInput,
-  type DescribeNetworkInterfaceAttributeCommandOutput,
   DescribeNetworkInterfacePermissionsCommand,
-  type DescribeNetworkInterfacePermissionsCommandInput,
-  type DescribeNetworkInterfacePermissionsCommandOutput,
   DescribeNetworkInterfacesCommand,
-  type DescribeNetworkInterfacesCommandInput,
-  type DescribeNetworkInterfacesCommandOutput,
   DescribePlacementGroupsCommand,
-  type DescribePlacementGroupsCommandInput,
-  type DescribePlacementGroupsCommandOutput,
   DescribePrefixListsCommand,
-  type DescribePrefixListsCommandInput,
-  type DescribePrefixListsCommandOutput,
   DescribePrincipalIdFormatCommand,
-  type DescribePrincipalIdFormatCommandInput,
-  type DescribePrincipalIdFormatCommandOutput,
   DescribePublicIpv4PoolsCommand,
-  type DescribePublicIpv4PoolsCommandInput,
-  type DescribePublicIpv4PoolsCommandOutput,
   DescribeRegionsCommand,
-  type DescribeRegionsCommandInput,
-  type DescribeRegionsCommandOutput,
   DescribeReplaceRootVolumeTasksCommand,
-  type DescribeReplaceRootVolumeTasksCommandInput,
-  type DescribeReplaceRootVolumeTasksCommandOutput,
   DescribeReservedInstancesCommand,
-  type DescribeReservedInstancesCommandInput,
-  type DescribeReservedInstancesCommandOutput,
   DescribeReservedInstancesListingsCommand,
-  type DescribeReservedInstancesListingsCommandInput,
-  type DescribeReservedInstancesListingsCommandOutput,
   DescribeReservedInstancesModificationsCommand,
-  type DescribeReservedInstancesModificationsCommandInput,
-  type DescribeReservedInstancesModificationsCommandOutput,
   DescribeReservedInstancesOfferingsCommand,
-  type DescribeReservedInstancesOfferingsCommandInput,
-  type DescribeReservedInstancesOfferingsCommandOutput,
   DescribeRouteTablesCommand,
-  type DescribeRouteTablesCommandInput,
-  type DescribeRouteTablesCommandOutput,
   DescribeScheduledInstanceAvailabilityCommand,
-  type DescribeScheduledInstanceAvailabilityCommandInput,
-  type DescribeScheduledInstanceAvailabilityCommandOutput,
   DescribeScheduledInstancesCommand,
-  type DescribeScheduledInstancesCommandInput,
-  type DescribeScheduledInstancesCommandOutput,
   DescribeSecurityGroupReferencesCommand,
-  type DescribeSecurityGroupReferencesCommandInput,
-  type DescribeSecurityGroupReferencesCommandOutput,
   DescribeSecurityGroupRulesCommand,
-  type DescribeSecurityGroupRulesCommandInput,
-  type DescribeSecurityGroupRulesCommandOutput,
   DescribeSecurityGroupsCommand,
-  type DescribeSecurityGroupsCommandInput,
-  type DescribeSecurityGroupsCommandOutput,
   DescribeSnapshotAttributeCommand,
-  type DescribeSnapshotAttributeCommandInput,
-  type DescribeSnapshotAttributeCommandOutput,
-  DescribeSnapshotsCommand,
-  type DescribeSnapshotsCommandInput,
-  type DescribeSnapshotsCommandOutput,
   DescribeSnapshotTierStatusCommand,
-  type DescribeSnapshotTierStatusCommandInput,
-  type DescribeSnapshotTierStatusCommandOutput,
+  DescribeSnapshotsCommand,
   DescribeSpotDatafeedSubscriptionCommand,
-  type DescribeSpotDatafeedSubscriptionCommandInput,
-  type DescribeSpotDatafeedSubscriptionCommandOutput,
   DescribeSpotFleetInstancesCommand,
-  type DescribeSpotFleetInstancesCommandInput,
-  type DescribeSpotFleetInstancesCommandOutput,
   DescribeSpotFleetRequestHistoryCommand,
-  type DescribeSpotFleetRequestHistoryCommandInput,
-  type DescribeSpotFleetRequestHistoryCommandOutput,
   DescribeSpotFleetRequestsCommand,
-  type DescribeSpotFleetRequestsCommandInput,
-  type DescribeSpotFleetRequestsCommandOutput,
   DescribeSpotInstanceRequestsCommand,
-  type DescribeSpotInstanceRequestsCommandInput,
-  type DescribeSpotInstanceRequestsCommandOutput,
   DescribeSpotPriceHistoryCommand,
-  type DescribeSpotPriceHistoryCommandInput,
-  type DescribeSpotPriceHistoryCommandOutput,
   DescribeStaleSecurityGroupsCommand,
-  type DescribeStaleSecurityGroupsCommandInput,
-  type DescribeStaleSecurityGroupsCommandOutput,
   DescribeStoreImageTasksCommand,
-  type DescribeStoreImageTasksCommandInput,
-  type DescribeStoreImageTasksCommandOutput,
   DescribeSubnetsCommand,
-  type DescribeSubnetsCommandInput,
-  type DescribeSubnetsCommandOutput,
   DescribeTagsCommand,
-  type DescribeTagsCommandInput,
-  type DescribeTagsCommandOutput,
   DescribeTrafficMirrorFiltersCommand,
-  type DescribeTrafficMirrorFiltersCommandInput,
-  type DescribeTrafficMirrorFiltersCommandOutput,
   DescribeTrafficMirrorSessionsCommand,
-  type DescribeTrafficMirrorSessionsCommandInput,
-  type DescribeTrafficMirrorSessionsCommandOutput,
   DescribeTrafficMirrorTargetsCommand,
-  type DescribeTrafficMirrorTargetsCommandInput,
-  type DescribeTrafficMirrorTargetsCommandOutput,
   DescribeTransitGatewayAttachmentsCommand,
-  type DescribeTransitGatewayAttachmentsCommandInput,
-  type DescribeTransitGatewayAttachmentsCommandOutput,
   DescribeTransitGatewayConnectPeersCommand,
-  type DescribeTransitGatewayConnectPeersCommandInput,
-  type DescribeTransitGatewayConnectPeersCommandOutput,
   DescribeTransitGatewayConnectsCommand,
-  type DescribeTransitGatewayConnectsCommandInput,
-  type DescribeTransitGatewayConnectsCommandOutput,
   DescribeTransitGatewayMulticastDomainsCommand,
-  type DescribeTransitGatewayMulticastDomainsCommandInput,
-  type DescribeTransitGatewayMulticastDomainsCommandOutput,
   DescribeTransitGatewayPeeringAttachmentsCommand,
-  type DescribeTransitGatewayPeeringAttachmentsCommandInput,
-  type DescribeTransitGatewayPeeringAttachmentsCommandOutput,
   DescribeTransitGatewayPolicyTablesCommand,
-  type DescribeTransitGatewayPolicyTablesCommandInput,
-  type DescribeTransitGatewayPolicyTablesCommandOutput,
   DescribeTransitGatewayRouteTableAnnouncementsCommand,
-  type DescribeTransitGatewayRouteTableAnnouncementsCommandInput,
-  type DescribeTransitGatewayRouteTableAnnouncementsCommandOutput,
   DescribeTransitGatewayRouteTablesCommand,
-  type DescribeTransitGatewayRouteTablesCommandInput,
-  type DescribeTransitGatewayRouteTablesCommandOutput,
-  DescribeTransitGatewaysCommand,
-  type DescribeTransitGatewaysCommandInput,
-  type DescribeTransitGatewaysCommandOutput,
   DescribeTransitGatewayVpcAttachmentsCommand,
-  type DescribeTransitGatewayVpcAttachmentsCommandInput,
-  type DescribeTransitGatewayVpcAttachmentsCommandOutput,
+  DescribeTransitGatewaysCommand,
   DescribeTrunkInterfaceAssociationsCommand,
-  type DescribeTrunkInterfaceAssociationsCommandInput,
-  type DescribeTrunkInterfaceAssociationsCommandOutput,
   DescribeVerifiedAccessEndpointsCommand,
-  type DescribeVerifiedAccessEndpointsCommandInput,
-  type DescribeVerifiedAccessEndpointsCommandOutput,
   DescribeVerifiedAccessGroupsCommand,
-  type DescribeVerifiedAccessGroupsCommandInput,
-  type DescribeVerifiedAccessGroupsCommandOutput,
   DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
-  type DescribeVerifiedAccessInstanceLoggingConfigurationsCommandInput,
-  type DescribeVerifiedAccessInstanceLoggingConfigurationsCommandOutput,
   DescribeVerifiedAccessInstancesCommand,
-  type DescribeVerifiedAccessInstancesCommandInput,
-  type DescribeVerifiedAccessInstancesCommandOutput,
   DescribeVerifiedAccessTrustProvidersCommand,
-  type DescribeVerifiedAccessTrustProvidersCommandInput,
-  type DescribeVerifiedAccessTrustProvidersCommandOutput,
   DescribeVolumeAttributeCommand,
-  type DescribeVolumeAttributeCommandInput,
-  type DescribeVolumeAttributeCommandOutput,
-  DescribeVolumesCommand,
-  type DescribeVolumesCommandInput,
-  type DescribeVolumesCommandOutput,
-  DescribeVolumesModificationsCommand,
-  type DescribeVolumesModificationsCommandInput,
-  type DescribeVolumesModificationsCommandOutput,
   DescribeVolumeStatusCommand,
-  type DescribeVolumeStatusCommandInput,
-  type DescribeVolumeStatusCommandOutput,
+  DescribeVolumesCommand,
+  DescribeVolumesModificationsCommand,
   DescribeVpcAttributeCommand,
-  type DescribeVpcAttributeCommandInput,
-  type DescribeVpcAttributeCommandOutput,
   DescribeVpcClassicLinkCommand,
-  type DescribeVpcClassicLinkCommandInput,
-  type DescribeVpcClassicLinkCommandOutput,
   DescribeVpcClassicLinkDnsSupportCommand,
-  type DescribeVpcClassicLinkDnsSupportCommandInput,
-  type DescribeVpcClassicLinkDnsSupportCommandOutput,
   DescribeVpcEndpointConnectionNotificationsCommand,
-  type DescribeVpcEndpointConnectionNotificationsCommandInput,
-  type DescribeVpcEndpointConnectionNotificationsCommandOutput,
   DescribeVpcEndpointConnectionsCommand,
-  type DescribeVpcEndpointConnectionsCommandInput,
-  type DescribeVpcEndpointConnectionsCommandOutput,
-  DescribeVpcEndpointsCommand,
-  type DescribeVpcEndpointsCommandInput,
-  type DescribeVpcEndpointsCommandOutput,
   DescribeVpcEndpointServiceConfigurationsCommand,
-  type DescribeVpcEndpointServiceConfigurationsCommandInput,
-  type DescribeVpcEndpointServiceConfigurationsCommandOutput,
   DescribeVpcEndpointServicePermissionsCommand,
-  type DescribeVpcEndpointServicePermissionsCommandInput,
-  type DescribeVpcEndpointServicePermissionsCommandOutput,
   DescribeVpcEndpointServicesCommand,
-  type DescribeVpcEndpointServicesCommandInput,
-  type DescribeVpcEndpointServicesCommandOutput,
+  DescribeVpcEndpointsCommand,
   DescribeVpcPeeringConnectionsCommand,
-  type DescribeVpcPeeringConnectionsCommandInput,
-  type DescribeVpcPeeringConnectionsCommandOutput,
   DescribeVpcsCommand,
-  type DescribeVpcsCommandInput,
-  type DescribeVpcsCommandOutput,
   DescribeVpnConnectionsCommand,
-  type DescribeVpnConnectionsCommandInput,
-  type DescribeVpnConnectionsCommandOutput,
   DescribeVpnGatewaysCommand,
-  type DescribeVpnGatewaysCommandInput,
-  type DescribeVpnGatewaysCommandOutput,
   DetachClassicLinkVpcCommand,
-  type DetachClassicLinkVpcCommandInput,
-  type DetachClassicLinkVpcCommandOutput,
   DetachInternetGatewayCommand,
-  type DetachInternetGatewayCommandInput,
-  type DetachInternetGatewayCommandOutput,
   DetachNetworkInterfaceCommand,
-  type DetachNetworkInterfaceCommandInput,
-  type DetachNetworkInterfaceCommandOutput,
   DetachVerifiedAccessTrustProviderCommand,
-  type DetachVerifiedAccessTrustProviderCommandInput,
-  type DetachVerifiedAccessTrustProviderCommandOutput,
   DetachVolumeCommand,
-  type DetachVolumeCommandInput,
-  type DetachVolumeCommandOutput,
   DetachVpnGatewayCommand,
-  type DetachVpnGatewayCommandInput,
-  type DetachVpnGatewayCommandOutput,
   DisableAddressTransferCommand,
-  type DisableAddressTransferCommandInput,
-  type DisableAddressTransferCommandOutput,
   DisableAwsNetworkPerformanceMetricSubscriptionCommand,
-  type DisableAwsNetworkPerformanceMetricSubscriptionCommandInput,
-  type DisableAwsNetworkPerformanceMetricSubscriptionCommandOutput,
   DisableEbsEncryptionByDefaultCommand,
-  type DisableEbsEncryptionByDefaultCommandInput,
-  type DisableEbsEncryptionByDefaultCommandOutput,
   DisableFastLaunchCommand,
-  type DisableFastLaunchCommandInput,
-  type DisableFastLaunchCommandOutput,
   DisableFastSnapshotRestoresCommand,
-  type DisableFastSnapshotRestoresCommandInput,
-  type DisableFastSnapshotRestoresCommandOutput,
   DisableImageCommand,
-  type DisableImageCommandInput,
-  type DisableImageCommandOutput,
   DisableImageBlockPublicAccessCommand,
-  type DisableImageBlockPublicAccessCommandInput,
-  type DisableImageBlockPublicAccessCommandOutput,
   DisableImageDeprecationCommand,
-  type DisableImageDeprecationCommandInput,
-  type DisableImageDeprecationCommandOutput,
   DisableIpamOrganizationAdminAccountCommand,
-  type DisableIpamOrganizationAdminAccountCommandInput,
-  type DisableIpamOrganizationAdminAccountCommandOutput,
   DisableSerialConsoleAccessCommand,
-  type DisableSerialConsoleAccessCommandInput,
-  type DisableSerialConsoleAccessCommandOutput,
   DisableSnapshotBlockPublicAccessCommand,
-  type DisableSnapshotBlockPublicAccessCommandInput,
-  type DisableSnapshotBlockPublicAccessCommandOutput,
   DisableTransitGatewayRouteTablePropagationCommand,
-  type DisableTransitGatewayRouteTablePropagationCommandInput,
-  type DisableTransitGatewayRouteTablePropagationCommandOutput,
   DisableVgwRoutePropagationCommand,
-  type DisableVgwRoutePropagationCommandInput,
-  type DisableVgwRoutePropagationCommandOutput,
   DisableVpcClassicLinkCommand,
-  type DisableVpcClassicLinkCommandInput,
-  type DisableVpcClassicLinkCommandOutput,
   DisableVpcClassicLinkDnsSupportCommand,
-  type DisableVpcClassicLinkDnsSupportCommandInput,
-  type DisableVpcClassicLinkDnsSupportCommandOutput,
   DisassociateAddressCommand,
-  type DisassociateAddressCommandInput,
-  type DisassociateAddressCommandOutput,
   DisassociateClientVpnTargetNetworkCommand,
-  type DisassociateClientVpnTargetNetworkCommandInput,
-  type DisassociateClientVpnTargetNetworkCommandOutput,
   DisassociateEnclaveCertificateIamRoleCommand,
-  type DisassociateEnclaveCertificateIamRoleCommandInput,
-  type DisassociateEnclaveCertificateIamRoleCommandOutput,
   DisassociateIamInstanceProfileCommand,
-  type DisassociateIamInstanceProfileCommandInput,
-  type DisassociateIamInstanceProfileCommandOutput,
   DisassociateInstanceEventWindowCommand,
-  type DisassociateInstanceEventWindowCommandInput,
-  type DisassociateInstanceEventWindowCommandOutput,
   DisassociateIpamByoasnCommand,
-  type DisassociateIpamByoasnCommandInput,
-  type DisassociateIpamByoasnCommandOutput,
   DisassociateIpamResourceDiscoveryCommand,
-  type DisassociateIpamResourceDiscoveryCommandInput,
-  type DisassociateIpamResourceDiscoveryCommandOutput,
   DisassociateNatGatewayAddressCommand,
-  type DisassociateNatGatewayAddressCommandInput,
-  type DisassociateNatGatewayAddressCommandOutput,
   DisassociateRouteTableCommand,
-  type DisassociateRouteTableCommandInput,
-  type DisassociateRouteTableCommandOutput,
   DisassociateSubnetCidrBlockCommand,
-  type DisassociateSubnetCidrBlockCommandInput,
-  type DisassociateSubnetCidrBlockCommandOutput,
   DisassociateTransitGatewayMulticastDomainCommand,
-  type DisassociateTransitGatewayMulticastDomainCommandInput,
-  type DisassociateTransitGatewayMulticastDomainCommandOutput,
   DisassociateTransitGatewayPolicyTableCommand,
-  type DisassociateTransitGatewayPolicyTableCommandInput,
-  type DisassociateTransitGatewayPolicyTableCommandOutput,
   DisassociateTransitGatewayRouteTableCommand,
-  type DisassociateTransitGatewayRouteTableCommandInput,
-  type DisassociateTransitGatewayRouteTableCommandOutput,
   DisassociateTrunkInterfaceCommand,
-  type DisassociateTrunkInterfaceCommandInput,
-  type DisassociateTrunkInterfaceCommandOutput,
   DisassociateVpcCidrBlockCommand,
-  type DisassociateVpcCidrBlockCommandInput,
-  type DisassociateVpcCidrBlockCommandOutput,
   EnableAddressTransferCommand,
-  type EnableAddressTransferCommandInput,
-  type EnableAddressTransferCommandOutput,
   EnableAwsNetworkPerformanceMetricSubscriptionCommand,
-  type EnableAwsNetworkPerformanceMetricSubscriptionCommandInput,
-  type EnableAwsNetworkPerformanceMetricSubscriptionCommandOutput,
   EnableEbsEncryptionByDefaultCommand,
-  type EnableEbsEncryptionByDefaultCommandInput,
-  type EnableEbsEncryptionByDefaultCommandOutput,
   EnableFastLaunchCommand,
-  type EnableFastLaunchCommandInput,
-  type EnableFastLaunchCommandOutput,
   EnableFastSnapshotRestoresCommand,
-  type EnableFastSnapshotRestoresCommandInput,
-  type EnableFastSnapshotRestoresCommandOutput,
   EnableImageCommand,
-  type EnableImageCommandInput,
-  type EnableImageCommandOutput,
   EnableImageBlockPublicAccessCommand,
-  type EnableImageBlockPublicAccessCommandInput,
-  type EnableImageBlockPublicAccessCommandOutput,
   EnableImageDeprecationCommand,
-  type EnableImageDeprecationCommandInput,
-  type EnableImageDeprecationCommandOutput,
   EnableIpamOrganizationAdminAccountCommand,
-  type EnableIpamOrganizationAdminAccountCommandInput,
-  type EnableIpamOrganizationAdminAccountCommandOutput,
   EnableReachabilityAnalyzerOrganizationSharingCommand,
-  type EnableReachabilityAnalyzerOrganizationSharingCommandInput,
-  type EnableReachabilityAnalyzerOrganizationSharingCommandOutput,
   EnableSerialConsoleAccessCommand,
-  type EnableSerialConsoleAccessCommandInput,
-  type EnableSerialConsoleAccessCommandOutput,
   EnableSnapshotBlockPublicAccessCommand,
-  type EnableSnapshotBlockPublicAccessCommandInput,
-  type EnableSnapshotBlockPublicAccessCommandOutput,
   EnableTransitGatewayRouteTablePropagationCommand,
-  type EnableTransitGatewayRouteTablePropagationCommandInput,
-  type EnableTransitGatewayRouteTablePropagationCommandOutput,
   EnableVgwRoutePropagationCommand,
-  type EnableVgwRoutePropagationCommandInput,
-  type EnableVgwRoutePropagationCommandOutput,
   EnableVolumeIOCommand,
-  type EnableVolumeIOCommandInput,
-  type EnableVolumeIOCommandOutput,
   EnableVpcClassicLinkCommand,
-  type EnableVpcClassicLinkCommandInput,
-  type EnableVpcClassicLinkCommandOutput,
   EnableVpcClassicLinkDnsSupportCommand,
-  type EnableVpcClassicLinkDnsSupportCommandInput,
-  type EnableVpcClassicLinkDnsSupportCommandOutput,
   ExportClientVpnClientCertificateRevocationListCommand,
-  type ExportClientVpnClientCertificateRevocationListCommandInput,
-  type ExportClientVpnClientCertificateRevocationListCommandOutput,
   ExportClientVpnClientConfigurationCommand,
-  type ExportClientVpnClientConfigurationCommandInput,
-  type ExportClientVpnClientConfigurationCommandOutput,
   ExportImageCommand,
-  type ExportImageCommandInput,
-  type ExportImageCommandOutput,
   ExportTransitGatewayRoutesCommand,
-  type ExportTransitGatewayRoutesCommandInput,
-  type ExportTransitGatewayRoutesCommandOutput,
   GetAssociatedEnclaveCertificateIamRolesCommand,
-  type GetAssociatedEnclaveCertificateIamRolesCommandInput,
-  type GetAssociatedEnclaveCertificateIamRolesCommandOutput,
   GetAssociatedIpv6PoolCidrsCommand,
-  type GetAssociatedIpv6PoolCidrsCommandInput,
-  type GetAssociatedIpv6PoolCidrsCommandOutput,
   GetAwsNetworkPerformanceDataCommand,
-  type GetAwsNetworkPerformanceDataCommandInput,
-  type GetAwsNetworkPerformanceDataCommandOutput,
   GetCapacityReservationUsageCommand,
-  type GetCapacityReservationUsageCommandInput,
-  type GetCapacityReservationUsageCommandOutput,
   GetCoipPoolUsageCommand,
-  type GetCoipPoolUsageCommandInput,
-  type GetCoipPoolUsageCommandOutput,
   GetConsoleOutputCommand,
-  type GetConsoleOutputCommandInput,
-  type GetConsoleOutputCommandOutput,
   GetConsoleScreenshotCommand,
-  type GetConsoleScreenshotCommandInput,
-  type GetConsoleScreenshotCommandOutput,
   GetDefaultCreditSpecificationCommand,
-  type GetDefaultCreditSpecificationCommandInput,
-  type GetDefaultCreditSpecificationCommandOutput,
   GetEbsDefaultKmsKeyIdCommand,
-  type GetEbsDefaultKmsKeyIdCommandInput,
-  type GetEbsDefaultKmsKeyIdCommandOutput,
   GetEbsEncryptionByDefaultCommand,
-  type GetEbsEncryptionByDefaultCommandInput,
-  type GetEbsEncryptionByDefaultCommandOutput,
   GetFlowLogsIntegrationTemplateCommand,
-  type GetFlowLogsIntegrationTemplateCommandInput,
-  type GetFlowLogsIntegrationTemplateCommandOutput,
   GetGroupsForCapacityReservationCommand,
-  type GetGroupsForCapacityReservationCommandInput,
-  type GetGroupsForCapacityReservationCommandOutput,
   GetHostReservationPurchasePreviewCommand,
-  type GetHostReservationPurchasePreviewCommandInput,
-  type GetHostReservationPurchasePreviewCommandOutput,
   GetImageBlockPublicAccessStateCommand,
-  type GetImageBlockPublicAccessStateCommandInput,
-  type GetImageBlockPublicAccessStateCommandOutput,
+  GetInstanceMetadataDefaultsCommand,
   GetInstanceTypesFromInstanceRequirementsCommand,
-  type GetInstanceTypesFromInstanceRequirementsCommandInput,
-  type GetInstanceTypesFromInstanceRequirementsCommandOutput,
   GetInstanceUefiDataCommand,
-  type GetInstanceUefiDataCommandInput,
-  type GetInstanceUefiDataCommandOutput,
   GetIpamAddressHistoryCommand,
-  type GetIpamAddressHistoryCommandInput,
-  type GetIpamAddressHistoryCommandOutput,
   GetIpamDiscoveredAccountsCommand,
-  type GetIpamDiscoveredAccountsCommandInput,
-  type GetIpamDiscoveredAccountsCommandOutput,
   GetIpamDiscoveredPublicAddressesCommand,
-  type GetIpamDiscoveredPublicAddressesCommandInput,
-  type GetIpamDiscoveredPublicAddressesCommandOutput,
   GetIpamDiscoveredResourceCidrsCommand,
-  type GetIpamDiscoveredResourceCidrsCommandInput,
-  type GetIpamDiscoveredResourceCidrsCommandOutput,
   GetIpamPoolAllocationsCommand,
-  type GetIpamPoolAllocationsCommandInput,
-  type GetIpamPoolAllocationsCommandOutput,
   GetIpamPoolCidrsCommand,
-  type GetIpamPoolCidrsCommandInput,
-  type GetIpamPoolCidrsCommandOutput,
   GetIpamResourceCidrsCommand,
-  type GetIpamResourceCidrsCommandInput,
-  type GetIpamResourceCidrsCommandOutput,
   GetLaunchTemplateDataCommand,
-  type GetLaunchTemplateDataCommandInput,
-  type GetLaunchTemplateDataCommandOutput,
   GetManagedPrefixListAssociationsCommand,
-  type GetManagedPrefixListAssociationsCommandInput,
-  type GetManagedPrefixListAssociationsCommandOutput,
   GetManagedPrefixListEntriesCommand,
-  type GetManagedPrefixListEntriesCommandInput,
-  type GetManagedPrefixListEntriesCommandOutput,
   GetNetworkInsightsAccessScopeAnalysisFindingsCommand,
-  type GetNetworkInsightsAccessScopeAnalysisFindingsCommandInput,
-  type GetNetworkInsightsAccessScopeAnalysisFindingsCommandOutput,
   GetNetworkInsightsAccessScopeContentCommand,
-  type GetNetworkInsightsAccessScopeContentCommandInput,
-  type GetNetworkInsightsAccessScopeContentCommandOutput,
   GetPasswordDataCommand,
-  type GetPasswordDataCommandInput,
-  type GetPasswordDataCommandOutput,
   GetReservedInstancesExchangeQuoteCommand,
-  type GetReservedInstancesExchangeQuoteCommandInput,
-  type GetReservedInstancesExchangeQuoteCommandOutput,
   GetSecurityGroupsForVpcCommand,
-  type GetSecurityGroupsForVpcCommandInput,
-  type GetSecurityGroupsForVpcCommandOutput,
   GetSerialConsoleAccessStatusCommand,
-  type GetSerialConsoleAccessStatusCommandInput,
-  type GetSerialConsoleAccessStatusCommandOutput,
   GetSnapshotBlockPublicAccessStateCommand,
-  type GetSnapshotBlockPublicAccessStateCommandInput,
-  type GetSnapshotBlockPublicAccessStateCommandOutput,
   GetSpotPlacementScoresCommand,
-  type GetSpotPlacementScoresCommandInput,
-  type GetSpotPlacementScoresCommandOutput,
   GetSubnetCidrReservationsCommand,
-  type GetSubnetCidrReservationsCommandInput,
-  type GetSubnetCidrReservationsCommandOutput,
   GetTransitGatewayAttachmentPropagationsCommand,
-  type GetTransitGatewayAttachmentPropagationsCommandInput,
-  type GetTransitGatewayAttachmentPropagationsCommandOutput,
   GetTransitGatewayMulticastDomainAssociationsCommand,
-  type GetTransitGatewayMulticastDomainAssociationsCommandInput,
-  type GetTransitGatewayMulticastDomainAssociationsCommandOutput,
   GetTransitGatewayPolicyTableAssociationsCommand,
-  type GetTransitGatewayPolicyTableAssociationsCommandInput,
-  type GetTransitGatewayPolicyTableAssociationsCommandOutput,
   GetTransitGatewayPolicyTableEntriesCommand,
-  type GetTransitGatewayPolicyTableEntriesCommandInput,
-  type GetTransitGatewayPolicyTableEntriesCommandOutput,
   GetTransitGatewayPrefixListReferencesCommand,
-  type GetTransitGatewayPrefixListReferencesCommandInput,
-  type GetTransitGatewayPrefixListReferencesCommandOutput,
   GetTransitGatewayRouteTableAssociationsCommand,
-  type GetTransitGatewayRouteTableAssociationsCommandInput,
-  type GetTransitGatewayRouteTableAssociationsCommandOutput,
   GetTransitGatewayRouteTablePropagationsCommand,
-  type GetTransitGatewayRouteTablePropagationsCommandInput,
-  type GetTransitGatewayRouteTablePropagationsCommandOutput,
   GetVerifiedAccessEndpointPolicyCommand,
-  type GetVerifiedAccessEndpointPolicyCommandInput,
-  type GetVerifiedAccessEndpointPolicyCommandOutput,
   GetVerifiedAccessGroupPolicyCommand,
-  type GetVerifiedAccessGroupPolicyCommandInput,
-  type GetVerifiedAccessGroupPolicyCommandOutput,
   GetVpnConnectionDeviceSampleConfigurationCommand,
-  type GetVpnConnectionDeviceSampleConfigurationCommandInput,
-  type GetVpnConnectionDeviceSampleConfigurationCommandOutput,
   GetVpnConnectionDeviceTypesCommand,
-  type GetVpnConnectionDeviceTypesCommandInput,
-  type GetVpnConnectionDeviceTypesCommandOutput,
   GetVpnTunnelReplacementStatusCommand,
-  type GetVpnTunnelReplacementStatusCommandInput,
-  type GetVpnTunnelReplacementStatusCommandOutput,
   ImportClientVpnClientCertificateRevocationListCommand,
-  type ImportClientVpnClientCertificateRevocationListCommandInput,
-  type ImportClientVpnClientCertificateRevocationListCommandOutput,
   ImportImageCommand,
-  type ImportImageCommandInput,
-  type ImportImageCommandOutput,
   ImportInstanceCommand,
-  type ImportInstanceCommandInput,
-  type ImportInstanceCommandOutput,
   ImportKeyPairCommand,
-  type ImportKeyPairCommandInput,
-  type ImportKeyPairCommandOutput,
   ImportSnapshotCommand,
-  type ImportSnapshotCommandInput,
-  type ImportSnapshotCommandOutput,
   ImportVolumeCommand,
-  type ImportVolumeCommandInput,
-  type ImportVolumeCommandOutput,
   ListImagesInRecycleBinCommand,
-  type ListImagesInRecycleBinCommandInput,
-  type ListImagesInRecycleBinCommandOutput,
   ListSnapshotsInRecycleBinCommand,
-  type ListSnapshotsInRecycleBinCommandInput,
-  type ListSnapshotsInRecycleBinCommandOutput,
   LockSnapshotCommand,
-  type LockSnapshotCommandInput,
-  type LockSnapshotCommandOutput,
   ModifyAddressAttributeCommand,
-  type ModifyAddressAttributeCommandInput,
-  type ModifyAddressAttributeCommandOutput,
   ModifyAvailabilityZoneGroupCommand,
-  type ModifyAvailabilityZoneGroupCommandInput,
-  type ModifyAvailabilityZoneGroupCommandOutput,
   ModifyCapacityReservationCommand,
-  type ModifyCapacityReservationCommandInput,
-  type ModifyCapacityReservationCommandOutput,
   ModifyCapacityReservationFleetCommand,
-  type ModifyCapacityReservationFleetCommandInput,
-  type ModifyCapacityReservationFleetCommandOutput,
   ModifyClientVpnEndpointCommand,
-  type ModifyClientVpnEndpointCommandInput,
-  type ModifyClientVpnEndpointCommandOutput,
   ModifyDefaultCreditSpecificationCommand,
-  type ModifyDefaultCreditSpecificationCommandInput,
-  type ModifyDefaultCreditSpecificationCommandOutput,
   ModifyEbsDefaultKmsKeyIdCommand,
-  type ModifyEbsDefaultKmsKeyIdCommandInput,
-  type ModifyEbsDefaultKmsKeyIdCommandOutput,
   ModifyFleetCommand,
-  type ModifyFleetCommandInput,
-  type ModifyFleetCommandOutput,
   ModifyFpgaImageAttributeCommand,
-  type ModifyFpgaImageAttributeCommandInput,
-  type ModifyFpgaImageAttributeCommandOutput,
   ModifyHostsCommand,
-  type ModifyHostsCommandInput,
-  type ModifyHostsCommandOutput,
-  ModifyIdentityIdFormatCommand,
-  type ModifyIdentityIdFormatCommandInput,
-  type ModifyIdentityIdFormatCommandOutput,
   ModifyIdFormatCommand,
-  type ModifyIdFormatCommandInput,
-  type ModifyIdFormatCommandOutput,
+  ModifyIdentityIdFormatCommand,
   ModifyImageAttributeCommand,
-  type ModifyImageAttributeCommandInput,
-  type ModifyImageAttributeCommandOutput,
   ModifyInstanceAttributeCommand,
-  type ModifyInstanceAttributeCommandInput,
-  type ModifyInstanceAttributeCommandOutput,
   ModifyInstanceCapacityReservationAttributesCommand,
-  type ModifyInstanceCapacityReservationAttributesCommandInput,
-  type ModifyInstanceCapacityReservationAttributesCommandOutput,
   ModifyInstanceCreditSpecificationCommand,
-  type ModifyInstanceCreditSpecificationCommandInput,
-  type ModifyInstanceCreditSpecificationCommandOutput,
   ModifyInstanceEventStartTimeCommand,
-  type ModifyInstanceEventStartTimeCommandInput,
-  type ModifyInstanceEventStartTimeCommandOutput,
   ModifyInstanceEventWindowCommand,
-  type ModifyInstanceEventWindowCommandInput,
-  type ModifyInstanceEventWindowCommandOutput,
   ModifyInstanceMaintenanceOptionsCommand,
-  type ModifyInstanceMaintenanceOptionsCommandInput,
-  type ModifyInstanceMaintenanceOptionsCommandOutput,
+  ModifyInstanceMetadataDefaultsCommand,
   ModifyInstanceMetadataOptionsCommand,
-  type ModifyInstanceMetadataOptionsCommandInput,
-  type ModifyInstanceMetadataOptionsCommandOutput,
   ModifyInstancePlacementCommand,
-  type ModifyInstancePlacementCommandInput,
-  type ModifyInstancePlacementCommandOutput,
   ModifyIpamCommand,
-  type ModifyIpamCommandInput,
-  type ModifyIpamCommandOutput,
   ModifyIpamPoolCommand,
-  type ModifyIpamPoolCommandInput,
-  type ModifyIpamPoolCommandOutput,
   ModifyIpamResourceCidrCommand,
-  type ModifyIpamResourceCidrCommandInput,
-  type ModifyIpamResourceCidrCommandOutput,
   ModifyIpamResourceDiscoveryCommand,
-  type ModifyIpamResourceDiscoveryCommandInput,
-  type ModifyIpamResourceDiscoveryCommandOutput,
   ModifyIpamScopeCommand,
-  type ModifyIpamScopeCommandInput,
-  type ModifyIpamScopeCommandOutput,
   ModifyLaunchTemplateCommand,
-  type ModifyLaunchTemplateCommandInput,
-  type ModifyLaunchTemplateCommandOutput,
   ModifyLocalGatewayRouteCommand,
-  type ModifyLocalGatewayRouteCommandInput,
-  type ModifyLocalGatewayRouteCommandOutput,
   ModifyManagedPrefixListCommand,
-  type ModifyManagedPrefixListCommandInput,
-  type ModifyManagedPrefixListCommandOutput,
   ModifyNetworkInterfaceAttributeCommand,
-  type ModifyNetworkInterfaceAttributeCommandInput,
-  type ModifyNetworkInterfaceAttributeCommandOutput,
   ModifyPrivateDnsNameOptionsCommand,
-  type ModifyPrivateDnsNameOptionsCommandInput,
-  type ModifyPrivateDnsNameOptionsCommandOutput,
   ModifyReservedInstancesCommand,
-  type ModifyReservedInstancesCommandInput,
-  type ModifyReservedInstancesCommandOutput,
   ModifySecurityGroupRulesCommand,
-  type ModifySecurityGroupRulesCommandInput,
-  type ModifySecurityGroupRulesCommandOutput,
   ModifySnapshotAttributeCommand,
-  type ModifySnapshotAttributeCommandInput,
-  type ModifySnapshotAttributeCommandOutput,
   ModifySnapshotTierCommand,
-  type ModifySnapshotTierCommandInput,
-  type ModifySnapshotTierCommandOutput,
   ModifySpotFleetRequestCommand,
-  type ModifySpotFleetRequestCommandInput,
-  type ModifySpotFleetRequestCommandOutput,
   ModifySubnetAttributeCommand,
-  type ModifySubnetAttributeCommandInput,
-  type ModifySubnetAttributeCommandOutput,
   ModifyTrafficMirrorFilterNetworkServicesCommand,
-  type ModifyTrafficMirrorFilterNetworkServicesCommandInput,
-  type ModifyTrafficMirrorFilterNetworkServicesCommandOutput,
   ModifyTrafficMirrorFilterRuleCommand,
-  type ModifyTrafficMirrorFilterRuleCommandInput,
-  type ModifyTrafficMirrorFilterRuleCommandOutput,
   ModifyTrafficMirrorSessionCommand,
-  type ModifyTrafficMirrorSessionCommandInput,
-  type ModifyTrafficMirrorSessionCommandOutput,
   ModifyTransitGatewayCommand,
-  type ModifyTransitGatewayCommandInput,
-  type ModifyTransitGatewayCommandOutput,
   ModifyTransitGatewayPrefixListReferenceCommand,
-  type ModifyTransitGatewayPrefixListReferenceCommandInput,
-  type ModifyTransitGatewayPrefixListReferenceCommandOutput,
   ModifyTransitGatewayVpcAttachmentCommand,
-  type ModifyTransitGatewayVpcAttachmentCommandInput,
-  type ModifyTransitGatewayVpcAttachmentCommandOutput,
   ModifyVerifiedAccessEndpointCommand,
-  type ModifyVerifiedAccessEndpointCommandInput,
-  type ModifyVerifiedAccessEndpointCommandOutput,
   ModifyVerifiedAccessEndpointPolicyCommand,
-  type ModifyVerifiedAccessEndpointPolicyCommandInput,
-  type ModifyVerifiedAccessEndpointPolicyCommandOutput,
   ModifyVerifiedAccessGroupCommand,
-  type ModifyVerifiedAccessGroupCommandInput,
-  type ModifyVerifiedAccessGroupCommandOutput,
   ModifyVerifiedAccessGroupPolicyCommand,
-  type ModifyVerifiedAccessGroupPolicyCommandInput,
-  type ModifyVerifiedAccessGroupPolicyCommandOutput,
   ModifyVerifiedAccessInstanceCommand,
-  type ModifyVerifiedAccessInstanceCommandInput,
-  type ModifyVerifiedAccessInstanceCommandOutput,
   ModifyVerifiedAccessInstanceLoggingConfigurationCommand,
-  type ModifyVerifiedAccessInstanceLoggingConfigurationCommandInput,
-  type ModifyVerifiedAccessInstanceLoggingConfigurationCommandOutput,
   ModifyVerifiedAccessTrustProviderCommand,
-  type ModifyVerifiedAccessTrustProviderCommandInput,
-  type ModifyVerifiedAccessTrustProviderCommandOutput,
   ModifyVolumeCommand,
-  type ModifyVolumeCommandInput,
-  type ModifyVolumeCommandOutput,
   ModifyVolumeAttributeCommand,
-  type ModifyVolumeAttributeCommandInput,
-  type ModifyVolumeAttributeCommandOutput,
   ModifyVpcAttributeCommand,
-  type ModifyVpcAttributeCommandInput,
-  type ModifyVpcAttributeCommandOutput,
   ModifyVpcEndpointCommand,
-  type ModifyVpcEndpointCommandInput,
-  type ModifyVpcEndpointCommandOutput,
   ModifyVpcEndpointConnectionNotificationCommand,
-  type ModifyVpcEndpointConnectionNotificationCommandInput,
-  type ModifyVpcEndpointConnectionNotificationCommandOutput,
   ModifyVpcEndpointServiceConfigurationCommand,
-  type ModifyVpcEndpointServiceConfigurationCommandInput,
-  type ModifyVpcEndpointServiceConfigurationCommandOutput,
   ModifyVpcEndpointServicePayerResponsibilityCommand,
-  type ModifyVpcEndpointServicePayerResponsibilityCommandInput,
-  type ModifyVpcEndpointServicePayerResponsibilityCommandOutput,
   ModifyVpcEndpointServicePermissionsCommand,
-  type ModifyVpcEndpointServicePermissionsCommandInput,
-  type ModifyVpcEndpointServicePermissionsCommandOutput,
   ModifyVpcPeeringConnectionOptionsCommand,
-  type ModifyVpcPeeringConnectionOptionsCommandInput,
-  type ModifyVpcPeeringConnectionOptionsCommandOutput,
   ModifyVpcTenancyCommand,
-  type ModifyVpcTenancyCommandInput,
-  type ModifyVpcTenancyCommandOutput,
   ModifyVpnConnectionCommand,
-  type ModifyVpnConnectionCommandInput,
-  type ModifyVpnConnectionCommandOutput,
   ModifyVpnConnectionOptionsCommand,
-  type ModifyVpnConnectionOptionsCommandInput,
-  type ModifyVpnConnectionOptionsCommandOutput,
   ModifyVpnTunnelCertificateCommand,
-  type ModifyVpnTunnelCertificateCommandInput,
-  type ModifyVpnTunnelCertificateCommandOutput,
   ModifyVpnTunnelOptionsCommand,
-  type ModifyVpnTunnelOptionsCommandInput,
-  type ModifyVpnTunnelOptionsCommandOutput,
   MonitorInstancesCommand,
-  type MonitorInstancesCommandInput,
-  type MonitorInstancesCommandOutput,
   MoveAddressToVpcCommand,
-  type MoveAddressToVpcCommandInput,
-  type MoveAddressToVpcCommandOutput,
   MoveByoipCidrToIpamCommand,
-  type MoveByoipCidrToIpamCommandInput,
-  type MoveByoipCidrToIpamCommandOutput,
   ProvisionByoipCidrCommand,
-  type ProvisionByoipCidrCommandInput,
-  type ProvisionByoipCidrCommandOutput,
   ProvisionIpamByoasnCommand,
-  type ProvisionIpamByoasnCommandInput,
-  type ProvisionIpamByoasnCommandOutput,
   ProvisionIpamPoolCidrCommand,
-  type ProvisionIpamPoolCidrCommandInput,
-  type ProvisionIpamPoolCidrCommandOutput,
   ProvisionPublicIpv4PoolCidrCommand,
-  type ProvisionPublicIpv4PoolCidrCommandInput,
-  type ProvisionPublicIpv4PoolCidrCommandOutput,
   PurchaseCapacityBlockCommand,
-  type PurchaseCapacityBlockCommandInput,
-  type PurchaseCapacityBlockCommandOutput,
   PurchaseHostReservationCommand,
-  type PurchaseHostReservationCommandInput,
-  type PurchaseHostReservationCommandOutput,
   PurchaseReservedInstancesOfferingCommand,
-  type PurchaseReservedInstancesOfferingCommandInput,
-  type PurchaseReservedInstancesOfferingCommandOutput,
   PurchaseScheduledInstancesCommand,
-  type PurchaseScheduledInstancesCommandInput,
-  type PurchaseScheduledInstancesCommandOutput,
   RebootInstancesCommand,
-  type RebootInstancesCommandInput,
-  type RebootInstancesCommandOutput,
   RegisterImageCommand,
-  type RegisterImageCommandInput,
-  type RegisterImageCommandOutput,
   RegisterInstanceEventNotificationAttributesCommand,
-  type RegisterInstanceEventNotificationAttributesCommandInput,
-  type RegisterInstanceEventNotificationAttributesCommandOutput,
   RegisterTransitGatewayMulticastGroupMembersCommand,
-  type RegisterTransitGatewayMulticastGroupMembersCommandInput,
-  type RegisterTransitGatewayMulticastGroupMembersCommandOutput,
   RegisterTransitGatewayMulticastGroupSourcesCommand,
-  type RegisterTransitGatewayMulticastGroupSourcesCommandInput,
-  type RegisterTransitGatewayMulticastGroupSourcesCommandOutput,
   RejectTransitGatewayMulticastDomainAssociationsCommand,
-  type RejectTransitGatewayMulticastDomainAssociationsCommandInput,
-  type RejectTransitGatewayMulticastDomainAssociationsCommandOutput,
   RejectTransitGatewayPeeringAttachmentCommand,
-  type RejectTransitGatewayPeeringAttachmentCommandInput,
-  type RejectTransitGatewayPeeringAttachmentCommandOutput,
   RejectTransitGatewayVpcAttachmentCommand,
-  type RejectTransitGatewayVpcAttachmentCommandInput,
-  type RejectTransitGatewayVpcAttachmentCommandOutput,
   RejectVpcEndpointConnectionsCommand,
-  type RejectVpcEndpointConnectionsCommandInput,
-  type RejectVpcEndpointConnectionsCommandOutput,
   RejectVpcPeeringConnectionCommand,
-  type RejectVpcPeeringConnectionCommandInput,
-  type RejectVpcPeeringConnectionCommandOutput,
   ReleaseAddressCommand,
-  type ReleaseAddressCommandInput,
-  type ReleaseAddressCommandOutput,
   ReleaseHostsCommand,
-  type ReleaseHostsCommandInput,
-  type ReleaseHostsCommandOutput,
   ReleaseIpamPoolAllocationCommand,
-  type ReleaseIpamPoolAllocationCommandInput,
-  type ReleaseIpamPoolAllocationCommandOutput,
   ReplaceIamInstanceProfileAssociationCommand,
-  type ReplaceIamInstanceProfileAssociationCommandInput,
-  type ReplaceIamInstanceProfileAssociationCommandOutput,
   ReplaceNetworkAclAssociationCommand,
-  type ReplaceNetworkAclAssociationCommandInput,
-  type ReplaceNetworkAclAssociationCommandOutput,
   ReplaceNetworkAclEntryCommand,
-  type ReplaceNetworkAclEntryCommandInput,
-  type ReplaceNetworkAclEntryCommandOutput,
   ReplaceRouteCommand,
-  type ReplaceRouteCommandInput,
-  type ReplaceRouteCommandOutput,
   ReplaceRouteTableAssociationCommand,
-  type ReplaceRouteTableAssociationCommandInput,
-  type ReplaceRouteTableAssociationCommandOutput,
   ReplaceTransitGatewayRouteCommand,
-  type ReplaceTransitGatewayRouteCommandInput,
-  type ReplaceTransitGatewayRouteCommandOutput,
   ReplaceVpnTunnelCommand,
-  type ReplaceVpnTunnelCommandInput,
-  type ReplaceVpnTunnelCommandOutput,
   ReportInstanceStatusCommand,
-  type ReportInstanceStatusCommandInput,
-  type ReportInstanceStatusCommandOutput,
   RequestSpotFleetCommand,
-  type RequestSpotFleetCommandInput,
-  type RequestSpotFleetCommandOutput,
   RequestSpotInstancesCommand,
-  type RequestSpotInstancesCommandInput,
-  type RequestSpotInstancesCommandOutput,
   ResetAddressAttributeCommand,
-  type ResetAddressAttributeCommandInput,
-  type ResetAddressAttributeCommandOutput,
   ResetEbsDefaultKmsKeyIdCommand,
-  type ResetEbsDefaultKmsKeyIdCommandInput,
-  type ResetEbsDefaultKmsKeyIdCommandOutput,
   ResetFpgaImageAttributeCommand,
-  type ResetFpgaImageAttributeCommandInput,
-  type ResetFpgaImageAttributeCommandOutput,
   ResetImageAttributeCommand,
-  type ResetImageAttributeCommandInput,
-  type ResetImageAttributeCommandOutput,
   ResetInstanceAttributeCommand,
-  type ResetInstanceAttributeCommandInput,
-  type ResetInstanceAttributeCommandOutput,
   ResetNetworkInterfaceAttributeCommand,
-  type ResetNetworkInterfaceAttributeCommandInput,
-  type ResetNetworkInterfaceAttributeCommandOutput,
   ResetSnapshotAttributeCommand,
-  type ResetSnapshotAttributeCommandInput,
-  type ResetSnapshotAttributeCommandOutput,
   RestoreAddressToClassicCommand,
-  type RestoreAddressToClassicCommandInput,
-  type RestoreAddressToClassicCommandOutput,
   RestoreImageFromRecycleBinCommand,
-  type RestoreImageFromRecycleBinCommandInput,
-  type RestoreImageFromRecycleBinCommandOutput,
   RestoreManagedPrefixListVersionCommand,
-  type RestoreManagedPrefixListVersionCommandInput,
-  type RestoreManagedPrefixListVersionCommandOutput,
   RestoreSnapshotFromRecycleBinCommand,
-  type RestoreSnapshotFromRecycleBinCommandInput,
-  type RestoreSnapshotFromRecycleBinCommandOutput,
   RestoreSnapshotTierCommand,
-  type RestoreSnapshotTierCommandInput,
-  type RestoreSnapshotTierCommandOutput,
   RevokeClientVpnIngressCommand,
-  type RevokeClientVpnIngressCommandInput,
-  type RevokeClientVpnIngressCommandOutput,
   RevokeSecurityGroupEgressCommand,
-  type RevokeSecurityGroupEgressCommandInput,
-  type RevokeSecurityGroupEgressCommandOutput,
   RevokeSecurityGroupIngressCommand,
-  type RevokeSecurityGroupIngressCommandInput,
-  type RevokeSecurityGroupIngressCommandOutput,
   RunInstancesCommand,
-  type RunInstancesCommandInput,
-  type RunInstancesCommandOutput,
   RunScheduledInstancesCommand,
-  type RunScheduledInstancesCommandInput,
-  type RunScheduledInstancesCommandOutput,
   SearchLocalGatewayRoutesCommand,
-  type SearchLocalGatewayRoutesCommandInput,
-  type SearchLocalGatewayRoutesCommandOutput,
   SearchTransitGatewayMulticastGroupsCommand,
-  type SearchTransitGatewayMulticastGroupsCommandInput,
-  type SearchTransitGatewayMulticastGroupsCommandOutput,
   SearchTransitGatewayRoutesCommand,
-  type SearchTransitGatewayRoutesCommandInput,
-  type SearchTransitGatewayRoutesCommandOutput,
   SendDiagnosticInterruptCommand,
-  type SendDiagnosticInterruptCommandInput,
-  type SendDiagnosticInterruptCommandOutput,
   StartInstancesCommand,
-  type StartInstancesCommandInput,
-  type StartInstancesCommandOutput,
   StartNetworkInsightsAccessScopeAnalysisCommand,
-  type StartNetworkInsightsAccessScopeAnalysisCommandInput,
-  type StartNetworkInsightsAccessScopeAnalysisCommandOutput,
   StartNetworkInsightsAnalysisCommand,
-  type StartNetworkInsightsAnalysisCommandInput,
-  type StartNetworkInsightsAnalysisCommandOutput,
   StartVpcEndpointServicePrivateDnsVerificationCommand,
-  type StartVpcEndpointServicePrivateDnsVerificationCommandInput,
-  type StartVpcEndpointServicePrivateDnsVerificationCommandOutput,
   StopInstancesCommand,
-  type StopInstancesCommandInput,
-  type StopInstancesCommandOutput,
   TerminateClientVpnConnectionsCommand,
-  type TerminateClientVpnConnectionsCommandInput,
-  type TerminateClientVpnConnectionsCommandOutput,
   TerminateInstancesCommand,
-  type TerminateInstancesCommandInput,
-  type TerminateInstancesCommandOutput,
   UnassignIpv6AddressesCommand,
-  type UnassignIpv6AddressesCommandInput,
-  type UnassignIpv6AddressesCommandOutput,
   UnassignPrivateIpAddressesCommand,
-  type UnassignPrivateIpAddressesCommandInput,
-  type UnassignPrivateIpAddressesCommandOutput,
   UnassignPrivateNatGatewayAddressCommand,
-  type UnassignPrivateNatGatewayAddressCommandInput,
-  type UnassignPrivateNatGatewayAddressCommandOutput,
   UnlockSnapshotCommand,
-  type UnlockSnapshotCommandInput,
-  type UnlockSnapshotCommandOutput,
   UnmonitorInstancesCommand,
-  type UnmonitorInstancesCommandInput,
-  type UnmonitorInstancesCommandOutput,
   UpdateSecurityGroupRuleDescriptionsEgressCommand,
-  type UpdateSecurityGroupRuleDescriptionsEgressCommandInput,
-  type UpdateSecurityGroupRuleDescriptionsEgressCommandOutput,
   UpdateSecurityGroupRuleDescriptionsIngressCommand,
-  type UpdateSecurityGroupRuleDescriptionsIngressCommandInput,
-  type UpdateSecurityGroupRuleDescriptionsIngressCommandOutput,
   WithdrawByoipCidrCommand,
-  type WithdrawByoipCidrCommandInput,
-  type WithdrawByoipCidrCommandOutput,
+  type AcceptAddressTransferRequest,
+  type AcceptAddressTransferResult,
+  type AcceptReservedInstancesExchangeQuoteRequest,
+  type AcceptReservedInstancesExchangeQuoteResult,
+  type AcceptTransitGatewayMulticastDomainAssociationsRequest,
+  type AcceptTransitGatewayMulticastDomainAssociationsResult,
+  type AcceptTransitGatewayPeeringAttachmentRequest,
+  type AcceptTransitGatewayPeeringAttachmentResult,
+  type AcceptTransitGatewayVpcAttachmentRequest,
+  type AcceptTransitGatewayVpcAttachmentResult,
+  type AcceptVpcEndpointConnectionsRequest,
+  type AcceptVpcEndpointConnectionsResult,
+  type AcceptVpcPeeringConnectionRequest,
+  type AcceptVpcPeeringConnectionResult,
+  type AdvertiseByoipCidrRequest,
+  type AdvertiseByoipCidrResult,
+  type AllocateAddressRequest,
+  type AllocateAddressResult,
+  type AllocateHostsRequest,
+  type AllocateHostsResult,
+  type AllocateIpamPoolCidrRequest,
+  type AllocateIpamPoolCidrResult,
+  type ApplySecurityGroupsToClientVpnTargetNetworkRequest,
+  type ApplySecurityGroupsToClientVpnTargetNetworkResult,
+  type AssignIpv6AddressesRequest,
+  type AssignIpv6AddressesResult,
+  type AssignPrivateIpAddressesRequest,
+  type AssignPrivateIpAddressesResult,
+  type AssignPrivateNatGatewayAddressRequest,
+  type AssignPrivateNatGatewayAddressResult,
+  type AssociateAddressRequest,
+  type AssociateAddressResult,
+  type AssociateClientVpnTargetNetworkRequest,
+  type AssociateClientVpnTargetNetworkResult,
+  type AssociateDhcpOptionsRequest,
+  type AssociateEnclaveCertificateIamRoleRequest,
+  type AssociateEnclaveCertificateIamRoleResult,
+  type AssociateIamInstanceProfileRequest,
+  type AssociateIamInstanceProfileResult,
+  type AssociateInstanceEventWindowRequest,
+  type AssociateInstanceEventWindowResult,
+  type AssociateIpamByoasnRequest,
+  type AssociateIpamByoasnResult,
+  type AssociateIpamResourceDiscoveryRequest,
+  type AssociateIpamResourceDiscoveryResult,
+  type AssociateNatGatewayAddressRequest,
+  type AssociateNatGatewayAddressResult,
+  type AssociateRouteTableRequest,
+  type AssociateRouteTableResult,
+  type AssociateSubnetCidrBlockRequest,
+  type AssociateSubnetCidrBlockResult,
+  type AssociateTransitGatewayMulticastDomainRequest,
+  type AssociateTransitGatewayMulticastDomainResult,
+  type AssociateTransitGatewayPolicyTableRequest,
+  type AssociateTransitGatewayPolicyTableResult,
+  type AssociateTransitGatewayRouteTableRequest,
+  type AssociateTransitGatewayRouteTableResult,
+  type AssociateTrunkInterfaceRequest,
+  type AssociateTrunkInterfaceResult,
+  type AssociateVpcCidrBlockRequest,
+  type AssociateVpcCidrBlockResult,
+  type AttachClassicLinkVpcRequest,
+  type AttachClassicLinkVpcResult,
+  type AttachInternetGatewayRequest,
+  type AttachNetworkInterfaceRequest,
+  type AttachNetworkInterfaceResult,
+  type AttachVerifiedAccessTrustProviderRequest,
+  type AttachVerifiedAccessTrustProviderResult,
+  type AttachVolumeRequest,
+  type VolumeAttachment,
+  type AttachVpnGatewayRequest,
+  type AttachVpnGatewayResult,
+  type AuthorizeClientVpnIngressRequest,
+  type AuthorizeClientVpnIngressResult,
+  type AuthorizeSecurityGroupEgressRequest,
+  type AuthorizeSecurityGroupEgressResult,
+  type AuthorizeSecurityGroupIngressRequest,
+  type AuthorizeSecurityGroupIngressResult,
+  type BundleInstanceRequest,
+  type BundleInstanceResult,
+  type CancelBundleTaskRequest,
+  type CancelBundleTaskResult,
+  type CancelCapacityReservationRequest,
+  type CancelCapacityReservationResult,
+  type CancelCapacityReservationFleetsRequest,
+  type CancelCapacityReservationFleetsResult,
+  type CancelConversionRequest,
+  type CancelExportTaskRequest,
+  type CancelImageLaunchPermissionRequest,
+  type CancelImageLaunchPermissionResult,
+  type CancelImportTaskRequest,
+  type CancelImportTaskResult,
+  type CancelReservedInstancesListingRequest,
+  type CancelReservedInstancesListingResult,
+  type CancelSpotFleetRequestsRequest,
+  type CancelSpotFleetRequestsResponse,
+  type CancelSpotInstanceRequestsRequest,
+  type CancelSpotInstanceRequestsResult,
+  type ConfirmProductInstanceRequest,
+  type ConfirmProductInstanceResult,
+  type CopyFpgaImageRequest,
+  type CopyFpgaImageResult,
+  type CopyImageRequest,
+  type CopyImageResult,
+  type CopySnapshotRequest,
+  type CopySnapshotResult,
+  type CreateCapacityReservationRequest,
+  type CreateCapacityReservationResult,
+  type CreateCapacityReservationFleetRequest,
+  type CreateCapacityReservationFleetResult,
+  type CreateCarrierGatewayRequest,
+  type CreateCarrierGatewayResult,
+  type CreateClientVpnEndpointRequest,
+  type CreateClientVpnEndpointResult,
+  type CreateClientVpnRouteRequest,
+  type CreateClientVpnRouteResult,
+  type CreateCoipCidrRequest,
+  type CreateCoipCidrResult,
+  type CreateCoipPoolRequest,
+  type CreateCoipPoolResult,
+  type CreateCustomerGatewayRequest,
+  type CreateCustomerGatewayResult,
+  type CreateDefaultSubnetRequest,
+  type CreateDefaultSubnetResult,
+  type CreateDefaultVpcRequest,
+  type CreateDefaultVpcResult,
+  type CreateDhcpOptionsRequest,
+  type CreateDhcpOptionsResult,
+  type CreateEgressOnlyInternetGatewayRequest,
+  type CreateEgressOnlyInternetGatewayResult,
+  type CreateFleetRequest,
+  type CreateFleetResult,
+  type CreateFlowLogsRequest,
+  type CreateFlowLogsResult,
+  type CreateFpgaImageRequest,
+  type CreateFpgaImageResult,
+  type CreateImageRequest,
+  type CreateImageResult,
+  type CreateInstanceConnectEndpointRequest,
+  type CreateInstanceConnectEndpointResult,
+  type CreateInstanceEventWindowRequest,
+  type CreateInstanceEventWindowResult,
+  type CreateInstanceExportTaskRequest,
+  type CreateInstanceExportTaskResult,
+  type CreateInternetGatewayRequest,
+  type CreateInternetGatewayResult,
+  type CreateIpamRequest,
+  type CreateIpamResult,
+  type CreateIpamPoolRequest,
+  type CreateIpamPoolResult,
+  type CreateIpamResourceDiscoveryRequest,
+  type CreateIpamResourceDiscoveryResult,
+  type CreateIpamScopeRequest,
+  type CreateIpamScopeResult,
+  type CreateKeyPairRequest,
+  type KeyPair,
+  type CreateLaunchTemplateRequest,
+  type CreateLaunchTemplateResult,
+  type CreateLaunchTemplateVersionRequest,
+  type CreateLaunchTemplateVersionResult,
+  type CreateLocalGatewayRouteRequest,
+  type CreateLocalGatewayRouteResult,
+  type CreateLocalGatewayRouteTableRequest,
+  type CreateLocalGatewayRouteTableResult,
+  type CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
+  type CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+  type CreateLocalGatewayRouteTableVpcAssociationRequest,
+  type CreateLocalGatewayRouteTableVpcAssociationResult,
+  type CreateManagedPrefixListRequest,
+  type CreateManagedPrefixListResult,
+  type CreateNatGatewayRequest,
+  type CreateNatGatewayResult,
+  type CreateNetworkAclRequest,
+  type CreateNetworkAclResult,
+  type CreateNetworkAclEntryRequest,
+  type CreateNetworkInsightsAccessScopeRequest,
+  type CreateNetworkInsightsAccessScopeResult,
+  type CreateNetworkInsightsPathRequest,
+  type CreateNetworkInsightsPathResult,
+  type CreateNetworkInterfaceRequest,
+  type CreateNetworkInterfaceResult,
+  type CreateNetworkInterfacePermissionRequest,
+  type CreateNetworkInterfacePermissionResult,
+  type CreatePlacementGroupRequest,
+  type CreatePlacementGroupResult,
+  type CreatePublicIpv4PoolRequest,
+  type CreatePublicIpv4PoolResult,
+  type CreateReplaceRootVolumeTaskRequest,
+  type CreateReplaceRootVolumeTaskResult,
+  type CreateReservedInstancesListingRequest,
+  type CreateReservedInstancesListingResult,
+  type CreateRestoreImageTaskRequest,
+  type CreateRestoreImageTaskResult,
+  type CreateRouteRequest,
+  type CreateRouteResult,
+  type CreateRouteTableRequest,
+  type CreateRouteTableResult,
+  type CreateSecurityGroupRequest,
+  type CreateSecurityGroupResult,
+  type CreateSnapshotRequest,
+  type Snapshot,
+  type CreateSnapshotsRequest,
+  type CreateSnapshotsResult,
+  type CreateSpotDatafeedSubscriptionRequest,
+  type CreateSpotDatafeedSubscriptionResult,
+  type CreateStoreImageTaskRequest,
+  type CreateStoreImageTaskResult,
+  type CreateSubnetRequest,
+  type CreateSubnetResult,
+  type CreateSubnetCidrReservationRequest,
+  type CreateSubnetCidrReservationResult,
+  type CreateTagsRequest,
+  type CreateTrafficMirrorFilterRequest,
+  type CreateTrafficMirrorFilterResult,
+  type CreateTrafficMirrorFilterRuleRequest,
+  type CreateTrafficMirrorFilterRuleResult,
+  type CreateTrafficMirrorSessionRequest,
+  type CreateTrafficMirrorSessionResult,
+  type CreateTrafficMirrorTargetRequest,
+  type CreateTrafficMirrorTargetResult,
+  type CreateTransitGatewayRequest,
+  type CreateTransitGatewayResult,
+  type CreateTransitGatewayConnectRequest,
+  type CreateTransitGatewayConnectResult,
+  type CreateTransitGatewayConnectPeerRequest,
+  type CreateTransitGatewayConnectPeerResult,
+  type CreateTransitGatewayMulticastDomainRequest,
+  type CreateTransitGatewayMulticastDomainResult,
+  type CreateTransitGatewayPeeringAttachmentRequest,
+  type CreateTransitGatewayPeeringAttachmentResult,
+  type CreateTransitGatewayPolicyTableRequest,
+  type CreateTransitGatewayPolicyTableResult,
+  type CreateTransitGatewayPrefixListReferenceRequest,
+  type CreateTransitGatewayPrefixListReferenceResult,
+  type CreateTransitGatewayRouteRequest,
+  type CreateTransitGatewayRouteResult,
+  type CreateTransitGatewayRouteTableRequest,
+  type CreateTransitGatewayRouteTableResult,
+  type CreateTransitGatewayRouteTableAnnouncementRequest,
+  type CreateTransitGatewayRouteTableAnnouncementResult,
+  type CreateTransitGatewayVpcAttachmentRequest,
+  type CreateTransitGatewayVpcAttachmentResult,
+  type CreateVerifiedAccessEndpointRequest,
+  type CreateVerifiedAccessEndpointResult,
+  type CreateVerifiedAccessGroupRequest,
+  type CreateVerifiedAccessGroupResult,
+  type CreateVerifiedAccessInstanceRequest,
+  type CreateVerifiedAccessInstanceResult,
+  type CreateVerifiedAccessTrustProviderRequest,
+  type CreateVerifiedAccessTrustProviderResult,
+  type CreateVolumeRequest,
+  type Volume,
+  type CreateVpcRequest,
+  type CreateVpcResult,
+  type CreateVpcEndpointRequest,
+  type CreateVpcEndpointResult,
+  type CreateVpcEndpointConnectionNotificationRequest,
+  type CreateVpcEndpointConnectionNotificationResult,
+  type CreateVpcEndpointServiceConfigurationRequest,
+  type CreateVpcEndpointServiceConfigurationResult,
+  type CreateVpcPeeringConnectionRequest,
+  type CreateVpcPeeringConnectionResult,
+  type CreateVpnConnectionRequest,
+  type CreateVpnConnectionResult,
+  type CreateVpnConnectionRouteRequest,
+  type CreateVpnGatewayRequest,
+  type CreateVpnGatewayResult,
+  type DeleteCarrierGatewayRequest,
+  type DeleteCarrierGatewayResult,
+  type DeleteClientVpnEndpointRequest,
+  type DeleteClientVpnEndpointResult,
+  type DeleteClientVpnRouteRequest,
+  type DeleteClientVpnRouteResult,
+  type DeleteCoipCidrRequest,
+  type DeleteCoipCidrResult,
+  type DeleteCoipPoolRequest,
+  type DeleteCoipPoolResult,
+  type DeleteCustomerGatewayRequest,
+  type DeleteDhcpOptionsRequest,
+  type DeleteEgressOnlyInternetGatewayRequest,
+  type DeleteEgressOnlyInternetGatewayResult,
+  type DeleteFleetsRequest,
+  type DeleteFleetsResult,
+  type DeleteFlowLogsRequest,
+  type DeleteFlowLogsResult,
+  type DeleteFpgaImageRequest,
+  type DeleteFpgaImageResult,
+  type DeleteInstanceConnectEndpointRequest,
+  type DeleteInstanceConnectEndpointResult,
+  type DeleteInstanceEventWindowRequest,
+  type DeleteInstanceEventWindowResult,
+  type DeleteInternetGatewayRequest,
+  type DeleteIpamRequest,
+  type DeleteIpamResult,
+  type DeleteIpamPoolRequest,
+  type DeleteIpamPoolResult,
+  type DeleteIpamResourceDiscoveryRequest,
+  type DeleteIpamResourceDiscoveryResult,
+  type DeleteIpamScopeRequest,
+  type DeleteIpamScopeResult,
+  type DeleteKeyPairRequest,
+  type DeleteKeyPairResult,
+  type DeleteLaunchTemplateRequest,
+  type DeleteLaunchTemplateResult,
+  type DeleteLaunchTemplateVersionsRequest,
+  type DeleteLaunchTemplateVersionsResult,
+  type DeleteLocalGatewayRouteRequest,
+  type DeleteLocalGatewayRouteResult,
+  type DeleteLocalGatewayRouteTableRequest,
+  type DeleteLocalGatewayRouteTableResult,
+  type DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
+  type DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+  type DeleteLocalGatewayRouteTableVpcAssociationRequest,
+  type DeleteLocalGatewayRouteTableVpcAssociationResult,
+  type DeleteManagedPrefixListRequest,
+  type DeleteManagedPrefixListResult,
+  type DeleteNatGatewayRequest,
+  type DeleteNatGatewayResult,
+  type DeleteNetworkAclRequest,
+  type DeleteNetworkAclEntryRequest,
+  type DeleteNetworkInsightsAccessScopeRequest,
+  type DeleteNetworkInsightsAccessScopeResult,
+  type DeleteNetworkInsightsAccessScopeAnalysisRequest,
+  type DeleteNetworkInsightsAccessScopeAnalysisResult,
+  type DeleteNetworkInsightsAnalysisRequest,
+  type DeleteNetworkInsightsAnalysisResult,
+  type DeleteNetworkInsightsPathRequest,
+  type DeleteNetworkInsightsPathResult,
+  type DeleteNetworkInterfaceRequest,
+  type DeleteNetworkInterfacePermissionRequest,
+  type DeleteNetworkInterfacePermissionResult,
+  type DeletePlacementGroupRequest,
+  type DeletePublicIpv4PoolRequest,
+  type DeletePublicIpv4PoolResult,
+  type DeleteQueuedReservedInstancesRequest,
+  type DeleteQueuedReservedInstancesResult,
+  type DeleteRouteRequest,
+  type DeleteRouteTableRequest,
+  type DeleteSecurityGroupRequest,
+  type DeleteSnapshotRequest,
+  type DeleteSpotDatafeedSubscriptionRequest,
+  type DeleteSubnetRequest,
+  type DeleteSubnetCidrReservationRequest,
+  type DeleteSubnetCidrReservationResult,
+  type DeleteTagsRequest,
+  type DeleteTrafficMirrorFilterRequest,
+  type DeleteTrafficMirrorFilterResult,
+  type DeleteTrafficMirrorFilterRuleRequest,
+  type DeleteTrafficMirrorFilterRuleResult,
+  type DeleteTrafficMirrorSessionRequest,
+  type DeleteTrafficMirrorSessionResult,
+  type DeleteTrafficMirrorTargetRequest,
+  type DeleteTrafficMirrorTargetResult,
+  type DeleteTransitGatewayRequest,
+  type DeleteTransitGatewayResult,
+  type DeleteTransitGatewayConnectRequest,
+  type DeleteTransitGatewayConnectResult,
+  type DeleteTransitGatewayConnectPeerRequest,
+  type DeleteTransitGatewayConnectPeerResult,
+  type DeleteTransitGatewayMulticastDomainRequest,
+  type DeleteTransitGatewayMulticastDomainResult,
+  type DeleteTransitGatewayPeeringAttachmentRequest,
+  type DeleteTransitGatewayPeeringAttachmentResult,
+  type DeleteTransitGatewayPolicyTableRequest,
+  type DeleteTransitGatewayPolicyTableResult,
+  type DeleteTransitGatewayPrefixListReferenceRequest,
+  type DeleteTransitGatewayPrefixListReferenceResult,
+  type DeleteTransitGatewayRouteRequest,
+  type DeleteTransitGatewayRouteResult,
+  type DeleteTransitGatewayRouteTableRequest,
+  type DeleteTransitGatewayRouteTableResult,
+  type DeleteTransitGatewayRouteTableAnnouncementRequest,
+  type DeleteTransitGatewayRouteTableAnnouncementResult,
+  type DeleteTransitGatewayVpcAttachmentRequest,
+  type DeleteTransitGatewayVpcAttachmentResult,
+  type DeleteVerifiedAccessEndpointRequest,
+  type DeleteVerifiedAccessEndpointResult,
+  type DeleteVerifiedAccessGroupRequest,
+  type DeleteVerifiedAccessGroupResult,
+  type DeleteVerifiedAccessInstanceRequest,
+  type DeleteVerifiedAccessInstanceResult,
+  type DeleteVerifiedAccessTrustProviderRequest,
+  type DeleteVerifiedAccessTrustProviderResult,
+  type DeleteVolumeRequest,
+  type DeleteVpcRequest,
+  type DeleteVpcEndpointConnectionNotificationsRequest,
+  type DeleteVpcEndpointConnectionNotificationsResult,
+  type DeleteVpcEndpointServiceConfigurationsRequest,
+  type DeleteVpcEndpointServiceConfigurationsResult,
+  type DeleteVpcEndpointsRequest,
+  type DeleteVpcEndpointsResult,
+  type DeleteVpcPeeringConnectionRequest,
+  type DeleteVpcPeeringConnectionResult,
+  type DeleteVpnConnectionRequest,
+  type DeleteVpnConnectionRouteRequest,
+  type DeleteVpnGatewayRequest,
+  type DeprovisionByoipCidrRequest,
+  type DeprovisionByoipCidrResult,
+  type DeprovisionIpamByoasnRequest,
+  type DeprovisionIpamByoasnResult,
+  type DeprovisionIpamPoolCidrRequest,
+  type DeprovisionIpamPoolCidrResult,
+  type DeprovisionPublicIpv4PoolCidrRequest,
+  type DeprovisionPublicIpv4PoolCidrResult,
+  type DeregisterImageRequest,
+  type DeregisterInstanceEventNotificationAttributesRequest,
+  type DeregisterInstanceEventNotificationAttributesResult,
+  type DeregisterTransitGatewayMulticastGroupMembersRequest,
+  type DeregisterTransitGatewayMulticastGroupMembersResult,
+  type DeregisterTransitGatewayMulticastGroupSourcesRequest,
+  type DeregisterTransitGatewayMulticastGroupSourcesResult,
+  type DescribeAccountAttributesRequest,
+  type DescribeAccountAttributesResult,
+  type DescribeAddressTransfersRequest,
+  type DescribeAddressTransfersResult,
+  type DescribeAddressesRequest,
+  type DescribeAddressesResult,
+  type DescribeAddressesAttributeRequest,
+  type DescribeAddressesAttributeResult,
+  type DescribeAggregateIdFormatRequest,
+  type DescribeAggregateIdFormatResult,
+  type DescribeAvailabilityZonesRequest,
+  type DescribeAvailabilityZonesResult,
+  type DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
+  type DescribeAwsNetworkPerformanceMetricSubscriptionsResult,
+  type DescribeBundleTasksRequest,
+  type DescribeBundleTasksResult,
+  type DescribeByoipCidrsRequest,
+  type DescribeByoipCidrsResult,
+  type DescribeCapacityBlockOfferingsRequest,
+  type DescribeCapacityBlockOfferingsResult,
+  type DescribeCapacityReservationFleetsRequest,
+  type DescribeCapacityReservationFleetsResult,
+  type DescribeCapacityReservationsRequest,
+  type DescribeCapacityReservationsResult,
+  type DescribeCarrierGatewaysRequest,
+  type DescribeCarrierGatewaysResult,
+  type DescribeClassicLinkInstancesRequest,
+  type DescribeClassicLinkInstancesResult,
+  type DescribeClientVpnAuthorizationRulesRequest,
+  type DescribeClientVpnAuthorizationRulesResult,
+  type DescribeClientVpnConnectionsRequest,
+  type DescribeClientVpnConnectionsResult,
+  type DescribeClientVpnEndpointsRequest,
+  type DescribeClientVpnEndpointsResult,
+  type DescribeClientVpnRoutesRequest,
+  type DescribeClientVpnRoutesResult,
+  type DescribeClientVpnTargetNetworksRequest,
+  type DescribeClientVpnTargetNetworksResult,
+  type DescribeCoipPoolsRequest,
+  type DescribeCoipPoolsResult,
+  type DescribeConversionTasksRequest,
+  type DescribeConversionTasksResult,
+  type DescribeCustomerGatewaysRequest,
+  type DescribeCustomerGatewaysResult,
+  type DescribeDhcpOptionsRequest,
+  type DescribeDhcpOptionsResult,
+  type DescribeEgressOnlyInternetGatewaysRequest,
+  type DescribeEgressOnlyInternetGatewaysResult,
+  type DescribeElasticGpusRequest,
+  type DescribeElasticGpusResult,
+  type DescribeExportImageTasksRequest,
+  type DescribeExportImageTasksResult,
+  type DescribeExportTasksRequest,
+  type DescribeExportTasksResult,
+  type DescribeFastLaunchImagesRequest,
+  type DescribeFastLaunchImagesResult,
+  type DescribeFastSnapshotRestoresRequest,
+  type DescribeFastSnapshotRestoresResult,
+  type DescribeFleetHistoryRequest,
+  type DescribeFleetHistoryResult,
+  type DescribeFleetInstancesRequest,
+  type DescribeFleetInstancesResult,
+  type DescribeFleetsRequest,
+  type DescribeFleetsResult,
+  type DescribeFlowLogsRequest,
+  type DescribeFlowLogsResult,
+  type DescribeFpgaImageAttributeRequest,
+  type DescribeFpgaImageAttributeResult,
+  type DescribeFpgaImagesRequest,
+  type DescribeFpgaImagesResult,
+  type DescribeHostReservationOfferingsRequest,
+  type DescribeHostReservationOfferingsResult,
+  type DescribeHostReservationsRequest,
+  type DescribeHostReservationsResult,
+  type DescribeHostsRequest,
+  type DescribeHostsResult,
+  type DescribeIamInstanceProfileAssociationsRequest,
+  type DescribeIamInstanceProfileAssociationsResult,
+  type DescribeIdFormatRequest,
+  type DescribeIdFormatResult,
+  type DescribeIdentityIdFormatRequest,
+  type DescribeIdentityIdFormatResult,
+  type DescribeImageAttributeRequest,
+  type ImageAttribute,
+  type DescribeImagesRequest,
+  type DescribeImagesResult,
+  type DescribeImportImageTasksRequest,
+  type DescribeImportImageTasksResult,
+  type DescribeImportSnapshotTasksRequest,
+  type DescribeImportSnapshotTasksResult,
+  type DescribeInstanceAttributeRequest,
+  type InstanceAttribute,
+  type DescribeInstanceConnectEndpointsRequest,
+  type DescribeInstanceConnectEndpointsResult,
+  type DescribeInstanceCreditSpecificationsRequest,
+  type DescribeInstanceCreditSpecificationsResult,
+  type DescribeInstanceEventNotificationAttributesRequest,
+  type DescribeInstanceEventNotificationAttributesResult,
+  type DescribeInstanceEventWindowsRequest,
+  type DescribeInstanceEventWindowsResult,
+  type DescribeInstanceStatusRequest,
+  type DescribeInstanceStatusResult,
+  type DescribeInstanceTopologyRequest,
+  type DescribeInstanceTopologyResult,
+  type DescribeInstanceTypeOfferingsRequest,
+  type DescribeInstanceTypeOfferingsResult,
+  type DescribeInstanceTypesRequest,
+  type DescribeInstanceTypesResult,
+  type DescribeInstancesRequest,
+  type DescribeInstancesResult,
+  type DescribeInternetGatewaysRequest,
+  type DescribeInternetGatewaysResult,
+  type DescribeIpamByoasnRequest,
+  type DescribeIpamByoasnResult,
+  type DescribeIpamPoolsRequest,
+  type DescribeIpamPoolsResult,
+  type DescribeIpamResourceDiscoveriesRequest,
+  type DescribeIpamResourceDiscoveriesResult,
+  type DescribeIpamResourceDiscoveryAssociationsRequest,
+  type DescribeIpamResourceDiscoveryAssociationsResult,
+  type DescribeIpamScopesRequest,
+  type DescribeIpamScopesResult,
+  type DescribeIpamsRequest,
+  type DescribeIpamsResult,
+  type DescribeIpv6PoolsRequest,
+  type DescribeIpv6PoolsResult,
+  type DescribeKeyPairsRequest,
+  type DescribeKeyPairsResult,
+  type DescribeLaunchTemplateVersionsRequest,
+  type DescribeLaunchTemplateVersionsResult,
+  type DescribeLaunchTemplatesRequest,
+  type DescribeLaunchTemplatesResult,
+  type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest,
+  type DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult,
+  type DescribeLocalGatewayRouteTableVpcAssociationsRequest,
+  type DescribeLocalGatewayRouteTableVpcAssociationsResult,
+  type DescribeLocalGatewayRouteTablesRequest,
+  type DescribeLocalGatewayRouteTablesResult,
+  type DescribeLocalGatewayVirtualInterfaceGroupsRequest,
+  type DescribeLocalGatewayVirtualInterfaceGroupsResult,
+  type DescribeLocalGatewayVirtualInterfacesRequest,
+  type DescribeLocalGatewayVirtualInterfacesResult,
+  type DescribeLocalGatewaysRequest,
+  type DescribeLocalGatewaysResult,
+  type DescribeLockedSnapshotsRequest,
+  type DescribeLockedSnapshotsResult,
+  type DescribeMacHostsRequest,
+  type DescribeMacHostsResult,
+  type DescribeManagedPrefixListsRequest,
+  type DescribeManagedPrefixListsResult,
+  type DescribeMovingAddressesRequest,
+  type DescribeMovingAddressesResult,
+  type DescribeNatGatewaysRequest,
+  type DescribeNatGatewaysResult,
+  type DescribeNetworkAclsRequest,
+  type DescribeNetworkAclsResult,
+  type DescribeNetworkInsightsAccessScopeAnalysesRequest,
+  type DescribeNetworkInsightsAccessScopeAnalysesResult,
+  type DescribeNetworkInsightsAccessScopesRequest,
+  type DescribeNetworkInsightsAccessScopesResult,
+  type DescribeNetworkInsightsAnalysesRequest,
+  type DescribeNetworkInsightsAnalysesResult,
+  type DescribeNetworkInsightsPathsRequest,
+  type DescribeNetworkInsightsPathsResult,
+  type DescribeNetworkInterfaceAttributeRequest,
+  type DescribeNetworkInterfaceAttributeResult,
+  type DescribeNetworkInterfacePermissionsRequest,
+  type DescribeNetworkInterfacePermissionsResult,
+  type DescribeNetworkInterfacesRequest,
+  type DescribeNetworkInterfacesResult,
+  type DescribePlacementGroupsRequest,
+  type DescribePlacementGroupsResult,
+  type DescribePrefixListsRequest,
+  type DescribePrefixListsResult,
+  type DescribePrincipalIdFormatRequest,
+  type DescribePrincipalIdFormatResult,
+  type DescribePublicIpv4PoolsRequest,
+  type DescribePublicIpv4PoolsResult,
+  type DescribeRegionsRequest,
+  type DescribeRegionsResult,
+  type DescribeReplaceRootVolumeTasksRequest,
+  type DescribeReplaceRootVolumeTasksResult,
+  type DescribeReservedInstancesRequest,
+  type DescribeReservedInstancesResult,
+  type DescribeReservedInstancesListingsRequest,
+  type DescribeReservedInstancesListingsResult,
+  type DescribeReservedInstancesModificationsRequest,
+  type DescribeReservedInstancesModificationsResult,
+  type DescribeReservedInstancesOfferingsRequest,
+  type DescribeReservedInstancesOfferingsResult,
+  type DescribeRouteTablesRequest,
+  type DescribeRouteTablesResult,
+  type DescribeScheduledInstanceAvailabilityRequest,
+  type DescribeScheduledInstanceAvailabilityResult,
+  type DescribeScheduledInstancesRequest,
+  type DescribeScheduledInstancesResult,
+  type DescribeSecurityGroupReferencesRequest,
+  type DescribeSecurityGroupReferencesResult,
+  type DescribeSecurityGroupRulesRequest,
+  type DescribeSecurityGroupRulesResult,
+  type DescribeSecurityGroupsRequest,
+  type DescribeSecurityGroupsResult,
+  type DescribeSnapshotAttributeRequest,
+  type DescribeSnapshotAttributeResult,
+  type DescribeSnapshotTierStatusRequest,
+  type DescribeSnapshotTierStatusResult,
+  type DescribeSnapshotsRequest,
+  type DescribeSnapshotsResult,
+  type DescribeSpotDatafeedSubscriptionRequest,
+  type DescribeSpotDatafeedSubscriptionResult,
+  type DescribeSpotFleetInstancesRequest,
+  type DescribeSpotFleetInstancesResponse,
+  type DescribeSpotFleetRequestHistoryRequest,
+  type DescribeSpotFleetRequestHistoryResponse,
+  type DescribeSpotFleetRequestsRequest,
+  type DescribeSpotFleetRequestsResponse,
+  type DescribeSpotInstanceRequestsRequest,
+  type DescribeSpotInstanceRequestsResult,
+  type DescribeSpotPriceHistoryRequest,
+  type DescribeSpotPriceHistoryResult,
+  type DescribeStaleSecurityGroupsRequest,
+  type DescribeStaleSecurityGroupsResult,
+  type DescribeStoreImageTasksRequest,
+  type DescribeStoreImageTasksResult,
+  type DescribeSubnetsRequest,
+  type DescribeSubnetsResult,
+  type DescribeTagsRequest,
+  type DescribeTagsResult,
+  type DescribeTrafficMirrorFiltersRequest,
+  type DescribeTrafficMirrorFiltersResult,
+  type DescribeTrafficMirrorSessionsRequest,
+  type DescribeTrafficMirrorSessionsResult,
+  type DescribeTrafficMirrorTargetsRequest,
+  type DescribeTrafficMirrorTargetsResult,
+  type DescribeTransitGatewayAttachmentsRequest,
+  type DescribeTransitGatewayAttachmentsResult,
+  type DescribeTransitGatewayConnectPeersRequest,
+  type DescribeTransitGatewayConnectPeersResult,
+  type DescribeTransitGatewayConnectsRequest,
+  type DescribeTransitGatewayConnectsResult,
+  type DescribeTransitGatewayMulticastDomainsRequest,
+  type DescribeTransitGatewayMulticastDomainsResult,
+  type DescribeTransitGatewayPeeringAttachmentsRequest,
+  type DescribeTransitGatewayPeeringAttachmentsResult,
+  type DescribeTransitGatewayPolicyTablesRequest,
+  type DescribeTransitGatewayPolicyTablesResult,
+  type DescribeTransitGatewayRouteTableAnnouncementsRequest,
+  type DescribeTransitGatewayRouteTableAnnouncementsResult,
+  type DescribeTransitGatewayRouteTablesRequest,
+  type DescribeTransitGatewayRouteTablesResult,
+  type DescribeTransitGatewayVpcAttachmentsRequest,
+  type DescribeTransitGatewayVpcAttachmentsResult,
+  type DescribeTransitGatewaysRequest,
+  type DescribeTransitGatewaysResult,
+  type DescribeTrunkInterfaceAssociationsRequest,
+  type DescribeTrunkInterfaceAssociationsResult,
+  type DescribeVerifiedAccessEndpointsRequest,
+  type DescribeVerifiedAccessEndpointsResult,
+  type DescribeVerifiedAccessGroupsRequest,
+  type DescribeVerifiedAccessGroupsResult,
+  type DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
+  type DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
+  type DescribeVerifiedAccessInstancesRequest,
+  type DescribeVerifiedAccessInstancesResult,
+  type DescribeVerifiedAccessTrustProvidersRequest,
+  type DescribeVerifiedAccessTrustProvidersResult,
+  type DescribeVolumeAttributeRequest,
+  type DescribeVolumeAttributeResult,
+  type DescribeVolumeStatusRequest,
+  type DescribeVolumeStatusResult,
+  type DescribeVolumesRequest,
+  type DescribeVolumesResult,
+  type DescribeVolumesModificationsRequest,
+  type DescribeVolumesModificationsResult,
+  type DescribeVpcAttributeRequest,
+  type DescribeVpcAttributeResult,
+  type DescribeVpcClassicLinkRequest,
+  type DescribeVpcClassicLinkResult,
+  type DescribeVpcClassicLinkDnsSupportRequest,
+  type DescribeVpcClassicLinkDnsSupportResult,
+  type DescribeVpcEndpointConnectionNotificationsRequest,
+  type DescribeVpcEndpointConnectionNotificationsResult,
+  type DescribeVpcEndpointConnectionsRequest,
+  type DescribeVpcEndpointConnectionsResult,
+  type DescribeVpcEndpointServiceConfigurationsRequest,
+  type DescribeVpcEndpointServiceConfigurationsResult,
+  type DescribeVpcEndpointServicePermissionsRequest,
+  type DescribeVpcEndpointServicePermissionsResult,
+  type DescribeVpcEndpointServicesRequest,
+  type DescribeVpcEndpointServicesResult,
+  type DescribeVpcEndpointsRequest,
+  type DescribeVpcEndpointsResult,
+  type DescribeVpcPeeringConnectionsRequest,
+  type DescribeVpcPeeringConnectionsResult,
+  type DescribeVpcsRequest,
+  type DescribeVpcsResult,
+  type DescribeVpnConnectionsRequest,
+  type DescribeVpnConnectionsResult,
+  type DescribeVpnGatewaysRequest,
+  type DescribeVpnGatewaysResult,
+  type DetachClassicLinkVpcRequest,
+  type DetachClassicLinkVpcResult,
+  type DetachInternetGatewayRequest,
+  type DetachNetworkInterfaceRequest,
+  type DetachVerifiedAccessTrustProviderRequest,
+  type DetachVerifiedAccessTrustProviderResult,
+  type DetachVolumeRequest,
+  type DetachVpnGatewayRequest,
+  type DisableAddressTransferRequest,
+  type DisableAddressTransferResult,
+  type DisableAwsNetworkPerformanceMetricSubscriptionRequest,
+  type DisableAwsNetworkPerformanceMetricSubscriptionResult,
+  type DisableEbsEncryptionByDefaultRequest,
+  type DisableEbsEncryptionByDefaultResult,
+  type DisableFastLaunchRequest,
+  type DisableFastLaunchResult,
+  type DisableFastSnapshotRestoresRequest,
+  type DisableFastSnapshotRestoresResult,
+  type DisableImageRequest,
+  type DisableImageResult,
+  type DisableImageBlockPublicAccessRequest,
+  type DisableImageBlockPublicAccessResult,
+  type DisableImageDeprecationRequest,
+  type DisableImageDeprecationResult,
+  type DisableIpamOrganizationAdminAccountRequest,
+  type DisableIpamOrganizationAdminAccountResult,
+  type DisableSerialConsoleAccessRequest,
+  type DisableSerialConsoleAccessResult,
+  type DisableSnapshotBlockPublicAccessRequest,
+  type DisableSnapshotBlockPublicAccessResult,
+  type DisableTransitGatewayRouteTablePropagationRequest,
+  type DisableTransitGatewayRouteTablePropagationResult,
+  type DisableVgwRoutePropagationRequest,
+  type DisableVpcClassicLinkRequest,
+  type DisableVpcClassicLinkResult,
+  type DisableVpcClassicLinkDnsSupportRequest,
+  type DisableVpcClassicLinkDnsSupportResult,
+  type DisassociateAddressRequest,
+  type DisassociateClientVpnTargetNetworkRequest,
+  type DisassociateClientVpnTargetNetworkResult,
+  type DisassociateEnclaveCertificateIamRoleRequest,
+  type DisassociateEnclaveCertificateIamRoleResult,
+  type DisassociateIamInstanceProfileRequest,
+  type DisassociateIamInstanceProfileResult,
+  type DisassociateInstanceEventWindowRequest,
+  type DisassociateInstanceEventWindowResult,
+  type DisassociateIpamByoasnRequest,
+  type DisassociateIpamByoasnResult,
+  type DisassociateIpamResourceDiscoveryRequest,
+  type DisassociateIpamResourceDiscoveryResult,
+  type DisassociateNatGatewayAddressRequest,
+  type DisassociateNatGatewayAddressResult,
+  type DisassociateRouteTableRequest,
+  type DisassociateSubnetCidrBlockRequest,
+  type DisassociateSubnetCidrBlockResult,
+  type DisassociateTransitGatewayMulticastDomainRequest,
+  type DisassociateTransitGatewayMulticastDomainResult,
+  type DisassociateTransitGatewayPolicyTableRequest,
+  type DisassociateTransitGatewayPolicyTableResult,
+  type DisassociateTransitGatewayRouteTableRequest,
+  type DisassociateTransitGatewayRouteTableResult,
+  type DisassociateTrunkInterfaceRequest,
+  type DisassociateTrunkInterfaceResult,
+  type DisassociateVpcCidrBlockRequest,
+  type DisassociateVpcCidrBlockResult,
+  type EnableAddressTransferRequest,
+  type EnableAddressTransferResult,
+  type EnableAwsNetworkPerformanceMetricSubscriptionRequest,
+  type EnableAwsNetworkPerformanceMetricSubscriptionResult,
+  type EnableEbsEncryptionByDefaultRequest,
+  type EnableEbsEncryptionByDefaultResult,
+  type EnableFastLaunchRequest,
+  type EnableFastLaunchResult,
+  type EnableFastSnapshotRestoresRequest,
+  type EnableFastSnapshotRestoresResult,
+  type EnableImageRequest,
+  type EnableImageResult,
+  type EnableImageBlockPublicAccessRequest,
+  type EnableImageBlockPublicAccessResult,
+  type EnableImageDeprecationRequest,
+  type EnableImageDeprecationResult,
+  type EnableIpamOrganizationAdminAccountRequest,
+  type EnableIpamOrganizationAdminAccountResult,
+  type EnableReachabilityAnalyzerOrganizationSharingRequest,
+  type EnableReachabilityAnalyzerOrganizationSharingResult,
+  type EnableSerialConsoleAccessRequest,
+  type EnableSerialConsoleAccessResult,
+  type EnableSnapshotBlockPublicAccessRequest,
+  type EnableSnapshotBlockPublicAccessResult,
+  type EnableTransitGatewayRouteTablePropagationRequest,
+  type EnableTransitGatewayRouteTablePropagationResult,
+  type EnableVgwRoutePropagationRequest,
+  type EnableVolumeIORequest,
+  type EnableVpcClassicLinkRequest,
+  type EnableVpcClassicLinkResult,
+  type EnableVpcClassicLinkDnsSupportRequest,
+  type EnableVpcClassicLinkDnsSupportResult,
+  type ExportClientVpnClientCertificateRevocationListRequest,
+  type ExportClientVpnClientCertificateRevocationListResult,
+  type ExportClientVpnClientConfigurationRequest,
+  type ExportClientVpnClientConfigurationResult,
+  type ExportImageRequest,
+  type ExportImageResult,
+  type ExportTransitGatewayRoutesRequest,
+  type ExportTransitGatewayRoutesResult,
+  type GetAssociatedEnclaveCertificateIamRolesRequest,
+  type GetAssociatedEnclaveCertificateIamRolesResult,
+  type GetAssociatedIpv6PoolCidrsRequest,
+  type GetAssociatedIpv6PoolCidrsResult,
+  type GetAwsNetworkPerformanceDataRequest,
+  type GetAwsNetworkPerformanceDataResult,
+  type GetCapacityReservationUsageRequest,
+  type GetCapacityReservationUsageResult,
+  type GetCoipPoolUsageRequest,
+  type GetCoipPoolUsageResult,
+  type GetConsoleOutputRequest,
+  type GetConsoleOutputResult,
+  type GetConsoleScreenshotRequest,
+  type GetConsoleScreenshotResult,
+  type GetDefaultCreditSpecificationRequest,
+  type GetDefaultCreditSpecificationResult,
+  type GetEbsDefaultKmsKeyIdRequest,
+  type GetEbsDefaultKmsKeyIdResult,
+  type GetEbsEncryptionByDefaultRequest,
+  type GetEbsEncryptionByDefaultResult,
+  type GetFlowLogsIntegrationTemplateRequest,
+  type GetFlowLogsIntegrationTemplateResult,
+  type GetGroupsForCapacityReservationRequest,
+  type GetGroupsForCapacityReservationResult,
+  type GetHostReservationPurchasePreviewRequest,
+  type GetHostReservationPurchasePreviewResult,
+  type GetImageBlockPublicAccessStateRequest,
+  type GetImageBlockPublicAccessStateResult,
+  type GetInstanceMetadataDefaultsRequest,
+  type GetInstanceMetadataDefaultsResult,
+  type GetInstanceTypesFromInstanceRequirementsRequest,
+  type GetInstanceTypesFromInstanceRequirementsResult,
+  type GetInstanceUefiDataRequest,
+  type GetInstanceUefiDataResult,
+  type GetIpamAddressHistoryRequest,
+  type GetIpamAddressHistoryResult,
+  type GetIpamDiscoveredAccountsRequest,
+  type GetIpamDiscoveredAccountsResult,
+  type GetIpamDiscoveredPublicAddressesRequest,
+  type GetIpamDiscoveredPublicAddressesResult,
+  type GetIpamDiscoveredResourceCidrsRequest,
+  type GetIpamDiscoveredResourceCidrsResult,
+  type GetIpamPoolAllocationsRequest,
+  type GetIpamPoolAllocationsResult,
+  type GetIpamPoolCidrsRequest,
+  type GetIpamPoolCidrsResult,
+  type GetIpamResourceCidrsRequest,
+  type GetIpamResourceCidrsResult,
+  type GetLaunchTemplateDataRequest,
+  type GetLaunchTemplateDataResult,
+  type GetManagedPrefixListAssociationsRequest,
+  type GetManagedPrefixListAssociationsResult,
+  type GetManagedPrefixListEntriesRequest,
+  type GetManagedPrefixListEntriesResult,
+  type GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
+  type GetNetworkInsightsAccessScopeAnalysisFindingsResult,
+  type GetNetworkInsightsAccessScopeContentRequest,
+  type GetNetworkInsightsAccessScopeContentResult,
+  type GetPasswordDataRequest,
+  type GetPasswordDataResult,
+  type GetReservedInstancesExchangeQuoteRequest,
+  type GetReservedInstancesExchangeQuoteResult,
+  type GetSecurityGroupsForVpcRequest,
+  type GetSecurityGroupsForVpcResult,
+  type GetSerialConsoleAccessStatusRequest,
+  type GetSerialConsoleAccessStatusResult,
+  type GetSnapshotBlockPublicAccessStateRequest,
+  type GetSnapshotBlockPublicAccessStateResult,
+  type GetSpotPlacementScoresRequest,
+  type GetSpotPlacementScoresResult,
+  type GetSubnetCidrReservationsRequest,
+  type GetSubnetCidrReservationsResult,
+  type GetTransitGatewayAttachmentPropagationsRequest,
+  type GetTransitGatewayAttachmentPropagationsResult,
+  type GetTransitGatewayMulticastDomainAssociationsRequest,
+  type GetTransitGatewayMulticastDomainAssociationsResult,
+  type GetTransitGatewayPolicyTableAssociationsRequest,
+  type GetTransitGatewayPolicyTableAssociationsResult,
+  type GetTransitGatewayPolicyTableEntriesRequest,
+  type GetTransitGatewayPolicyTableEntriesResult,
+  type GetTransitGatewayPrefixListReferencesRequest,
+  type GetTransitGatewayPrefixListReferencesResult,
+  type GetTransitGatewayRouteTableAssociationsRequest,
+  type GetTransitGatewayRouteTableAssociationsResult,
+  type GetTransitGatewayRouteTablePropagationsRequest,
+  type GetTransitGatewayRouteTablePropagationsResult,
+  type GetVerifiedAccessEndpointPolicyRequest,
+  type GetVerifiedAccessEndpointPolicyResult,
+  type GetVerifiedAccessGroupPolicyRequest,
+  type GetVerifiedAccessGroupPolicyResult,
+  type GetVpnConnectionDeviceSampleConfigurationRequest,
+  type GetVpnConnectionDeviceSampleConfigurationResult,
+  type GetVpnConnectionDeviceTypesRequest,
+  type GetVpnConnectionDeviceTypesResult,
+  type GetVpnTunnelReplacementStatusRequest,
+  type GetVpnTunnelReplacementStatusResult,
+  type ImportClientVpnClientCertificateRevocationListRequest,
+  type ImportClientVpnClientCertificateRevocationListResult,
+  type ImportImageRequest,
+  type ImportImageResult,
+  type ImportInstanceRequest,
+  type ImportInstanceResult,
+  type ImportKeyPairRequest,
+  type ImportKeyPairResult,
+  type ImportSnapshotRequest,
+  type ImportSnapshotResult,
+  type ImportVolumeRequest,
+  type ImportVolumeResult,
+  type ListImagesInRecycleBinRequest,
+  type ListImagesInRecycleBinResult,
+  type ListSnapshotsInRecycleBinRequest,
+  type ListSnapshotsInRecycleBinResult,
+  type LockSnapshotRequest,
+  type LockSnapshotResult,
+  type ModifyAddressAttributeRequest,
+  type ModifyAddressAttributeResult,
+  type ModifyAvailabilityZoneGroupRequest,
+  type ModifyAvailabilityZoneGroupResult,
+  type ModifyCapacityReservationRequest,
+  type ModifyCapacityReservationResult,
+  type ModifyCapacityReservationFleetRequest,
+  type ModifyCapacityReservationFleetResult,
+  type ModifyClientVpnEndpointRequest,
+  type ModifyClientVpnEndpointResult,
+  type ModifyDefaultCreditSpecificationRequest,
+  type ModifyDefaultCreditSpecificationResult,
+  type ModifyEbsDefaultKmsKeyIdRequest,
+  type ModifyEbsDefaultKmsKeyIdResult,
+  type ModifyFleetRequest,
+  type ModifyFleetResult,
+  type ModifyFpgaImageAttributeRequest,
+  type ModifyFpgaImageAttributeResult,
+  type ModifyHostsRequest,
+  type ModifyHostsResult,
+  type ModifyIdFormatRequest,
+  type ModifyIdentityIdFormatRequest,
+  type ModifyImageAttributeRequest,
+  type ModifyInstanceAttributeRequest,
+  type ModifyInstanceCapacityReservationAttributesRequest,
+  type ModifyInstanceCapacityReservationAttributesResult,
+  type ModifyInstanceCreditSpecificationRequest,
+  type ModifyInstanceCreditSpecificationResult,
+  type ModifyInstanceEventStartTimeRequest,
+  type ModifyInstanceEventStartTimeResult,
+  type ModifyInstanceEventWindowRequest,
+  type ModifyInstanceEventWindowResult,
+  type ModifyInstanceMaintenanceOptionsRequest,
+  type ModifyInstanceMaintenanceOptionsResult,
+  type ModifyInstanceMetadataDefaultsRequest,
+  type ModifyInstanceMetadataDefaultsResult,
+  type ModifyInstanceMetadataOptionsRequest,
+  type ModifyInstanceMetadataOptionsResult,
+  type ModifyInstancePlacementRequest,
+  type ModifyInstancePlacementResult,
+  type ModifyIpamRequest,
+  type ModifyIpamResult,
+  type ModifyIpamPoolRequest,
+  type ModifyIpamPoolResult,
+  type ModifyIpamResourceCidrRequest,
+  type ModifyIpamResourceCidrResult,
+  type ModifyIpamResourceDiscoveryRequest,
+  type ModifyIpamResourceDiscoveryResult,
+  type ModifyIpamScopeRequest,
+  type ModifyIpamScopeResult,
+  type ModifyLaunchTemplateRequest,
+  type ModifyLaunchTemplateResult,
+  type ModifyLocalGatewayRouteRequest,
+  type ModifyLocalGatewayRouteResult,
+  type ModifyManagedPrefixListRequest,
+  type ModifyManagedPrefixListResult,
+  type ModifyNetworkInterfaceAttributeRequest,
+  type ModifyPrivateDnsNameOptionsRequest,
+  type ModifyPrivateDnsNameOptionsResult,
+  type ModifyReservedInstancesRequest,
+  type ModifyReservedInstancesResult,
+  type ModifySecurityGroupRulesRequest,
+  type ModifySecurityGroupRulesResult,
+  type ModifySnapshotAttributeRequest,
+  type ModifySnapshotTierRequest,
+  type ModifySnapshotTierResult,
+  type ModifySpotFleetRequestRequest,
+  type ModifySpotFleetRequestResponse,
+  type ModifySubnetAttributeRequest,
+  type ModifyTrafficMirrorFilterNetworkServicesRequest,
+  type ModifyTrafficMirrorFilterNetworkServicesResult,
+  type ModifyTrafficMirrorFilterRuleRequest,
+  type ModifyTrafficMirrorFilterRuleResult,
+  type ModifyTrafficMirrorSessionRequest,
+  type ModifyTrafficMirrorSessionResult,
+  type ModifyTransitGatewayRequest,
+  type ModifyTransitGatewayResult,
+  type ModifyTransitGatewayPrefixListReferenceRequest,
+  type ModifyTransitGatewayPrefixListReferenceResult,
+  type ModifyTransitGatewayVpcAttachmentRequest,
+  type ModifyTransitGatewayVpcAttachmentResult,
+  type ModifyVerifiedAccessEndpointRequest,
+  type ModifyVerifiedAccessEndpointResult,
+  type ModifyVerifiedAccessEndpointPolicyRequest,
+  type ModifyVerifiedAccessEndpointPolicyResult,
+  type ModifyVerifiedAccessGroupRequest,
+  type ModifyVerifiedAccessGroupResult,
+  type ModifyVerifiedAccessGroupPolicyRequest,
+  type ModifyVerifiedAccessGroupPolicyResult,
+  type ModifyVerifiedAccessInstanceRequest,
+  type ModifyVerifiedAccessInstanceResult,
+  type ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
+  type ModifyVerifiedAccessInstanceLoggingConfigurationResult,
+  type ModifyVerifiedAccessTrustProviderRequest,
+  type ModifyVerifiedAccessTrustProviderResult,
+  type ModifyVolumeRequest,
+  type ModifyVolumeResult,
+  type ModifyVolumeAttributeRequest,
+  type ModifyVpcAttributeRequest,
+  type ModifyVpcEndpointRequest,
+  type ModifyVpcEndpointResult,
+  type ModifyVpcEndpointConnectionNotificationRequest,
+  type ModifyVpcEndpointConnectionNotificationResult,
+  type ModifyVpcEndpointServiceConfigurationRequest,
+  type ModifyVpcEndpointServiceConfigurationResult,
+  type ModifyVpcEndpointServicePayerResponsibilityRequest,
+  type ModifyVpcEndpointServicePayerResponsibilityResult,
+  type ModifyVpcEndpointServicePermissionsRequest,
+  type ModifyVpcEndpointServicePermissionsResult,
+  type ModifyVpcPeeringConnectionOptionsRequest,
+  type ModifyVpcPeeringConnectionOptionsResult,
+  type ModifyVpcTenancyRequest,
+  type ModifyVpcTenancyResult,
+  type ModifyVpnConnectionRequest,
+  type ModifyVpnConnectionResult,
+  type ModifyVpnConnectionOptionsRequest,
+  type ModifyVpnConnectionOptionsResult,
+  type ModifyVpnTunnelCertificateRequest,
+  type ModifyVpnTunnelCertificateResult,
+  type ModifyVpnTunnelOptionsRequest,
+  type ModifyVpnTunnelOptionsResult,
+  type MonitorInstancesRequest,
+  type MonitorInstancesResult,
+  type MoveAddressToVpcRequest,
+  type MoveAddressToVpcResult,
+  type MoveByoipCidrToIpamRequest,
+  type MoveByoipCidrToIpamResult,
+  type ProvisionByoipCidrRequest,
+  type ProvisionByoipCidrResult,
+  type ProvisionIpamByoasnRequest,
+  type ProvisionIpamByoasnResult,
+  type ProvisionIpamPoolCidrRequest,
+  type ProvisionIpamPoolCidrResult,
+  type ProvisionPublicIpv4PoolCidrRequest,
+  type ProvisionPublicIpv4PoolCidrResult,
+  type PurchaseCapacityBlockRequest,
+  type PurchaseCapacityBlockResult,
+  type PurchaseHostReservationRequest,
+  type PurchaseHostReservationResult,
+  type PurchaseReservedInstancesOfferingRequest,
+  type PurchaseReservedInstancesOfferingResult,
+  type PurchaseScheduledInstancesRequest,
+  type PurchaseScheduledInstancesResult,
+  type RebootInstancesRequest,
+  type RegisterImageRequest,
+  type RegisterImageResult,
+  type RegisterInstanceEventNotificationAttributesRequest,
+  type RegisterInstanceEventNotificationAttributesResult,
+  type RegisterTransitGatewayMulticastGroupMembersRequest,
+  type RegisterTransitGatewayMulticastGroupMembersResult,
+  type RegisterTransitGatewayMulticastGroupSourcesRequest,
+  type RegisterTransitGatewayMulticastGroupSourcesResult,
+  type RejectTransitGatewayMulticastDomainAssociationsRequest,
+  type RejectTransitGatewayMulticastDomainAssociationsResult,
+  type RejectTransitGatewayPeeringAttachmentRequest,
+  type RejectTransitGatewayPeeringAttachmentResult,
+  type RejectTransitGatewayVpcAttachmentRequest,
+  type RejectTransitGatewayVpcAttachmentResult,
+  type RejectVpcEndpointConnectionsRequest,
+  type RejectVpcEndpointConnectionsResult,
+  type RejectVpcPeeringConnectionRequest,
+  type RejectVpcPeeringConnectionResult,
+  type ReleaseAddressRequest,
+  type ReleaseHostsRequest,
+  type ReleaseHostsResult,
+  type ReleaseIpamPoolAllocationRequest,
+  type ReleaseIpamPoolAllocationResult,
+  type ReplaceIamInstanceProfileAssociationRequest,
+  type ReplaceIamInstanceProfileAssociationResult,
+  type ReplaceNetworkAclAssociationRequest,
+  type ReplaceNetworkAclAssociationResult,
+  type ReplaceNetworkAclEntryRequest,
+  type ReplaceRouteRequest,
+  type ReplaceRouteTableAssociationRequest,
+  type ReplaceRouteTableAssociationResult,
+  type ReplaceTransitGatewayRouteRequest,
+  type ReplaceTransitGatewayRouteResult,
+  type ReplaceVpnTunnelRequest,
+  type ReplaceVpnTunnelResult,
+  type ReportInstanceStatusRequest,
+  type RequestSpotFleetRequest,
+  type RequestSpotFleetResponse,
+  type RequestSpotInstancesRequest,
+  type RequestSpotInstancesResult,
+  type ResetAddressAttributeRequest,
+  type ResetAddressAttributeResult,
+  type ResetEbsDefaultKmsKeyIdRequest,
+  type ResetEbsDefaultKmsKeyIdResult,
+  type ResetFpgaImageAttributeRequest,
+  type ResetFpgaImageAttributeResult,
+  type ResetImageAttributeRequest,
+  type ResetInstanceAttributeRequest,
+  type ResetNetworkInterfaceAttributeRequest,
+  type ResetSnapshotAttributeRequest,
+  type RestoreAddressToClassicRequest,
+  type RestoreAddressToClassicResult,
+  type RestoreImageFromRecycleBinRequest,
+  type RestoreImageFromRecycleBinResult,
+  type RestoreManagedPrefixListVersionRequest,
+  type RestoreManagedPrefixListVersionResult,
+  type RestoreSnapshotFromRecycleBinRequest,
+  type RestoreSnapshotFromRecycleBinResult,
+  type RestoreSnapshotTierRequest,
+  type RestoreSnapshotTierResult,
+  type RevokeClientVpnIngressRequest,
+  type RevokeClientVpnIngressResult,
+  type RevokeSecurityGroupEgressRequest,
+  type RevokeSecurityGroupEgressResult,
+  type RevokeSecurityGroupIngressRequest,
+  type RevokeSecurityGroupIngressResult,
+  type RunInstancesRequest,
+  type Reservation,
+  type RunScheduledInstancesRequest,
+  type RunScheduledInstancesResult,
+  type SearchLocalGatewayRoutesRequest,
+  type SearchLocalGatewayRoutesResult,
+  type SearchTransitGatewayMulticastGroupsRequest,
+  type SearchTransitGatewayMulticastGroupsResult,
+  type SearchTransitGatewayRoutesRequest,
+  type SearchTransitGatewayRoutesResult,
+  type SendDiagnosticInterruptRequest,
+  type StartInstancesRequest,
+  type StartInstancesResult,
+  type StartNetworkInsightsAccessScopeAnalysisRequest,
+  type StartNetworkInsightsAccessScopeAnalysisResult,
+  type StartNetworkInsightsAnalysisRequest,
+  type StartNetworkInsightsAnalysisResult,
+  type StartVpcEndpointServicePrivateDnsVerificationRequest,
+  type StartVpcEndpointServicePrivateDnsVerificationResult,
+  type StopInstancesRequest,
+  type StopInstancesResult,
+  type TerminateClientVpnConnectionsRequest,
+  type TerminateClientVpnConnectionsResult,
+  type TerminateInstancesRequest,
+  type TerminateInstancesResult,
+  type UnassignIpv6AddressesRequest,
+  type UnassignIpv6AddressesResult,
+  type UnassignPrivateIpAddressesRequest,
+  type UnassignPrivateNatGatewayAddressRequest,
+  type UnassignPrivateNatGatewayAddressResult,
+  type UnlockSnapshotRequest,
+  type UnlockSnapshotResult,
+  type UnmonitorInstancesRequest,
+  type UnmonitorInstancesResult,
+  type UpdateSecurityGroupRuleDescriptionsEgressRequest,
+  type UpdateSecurityGroupRuleDescriptionsEgressResult,
+  type UpdateSecurityGroupRuleDescriptionsIngressRequest,
+  type UpdateSecurityGroupRuleDescriptionsIngressResult,
+  type WithdrawByoipCidrRequest,
+  type WithdrawByoipCidrResult,
 } from "@aws-sdk/client-ec2";
-import { type HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
-import { Context, Effect, Layer, Record, Data } from "effect";
-import { EC2ClientInstance, EC2ClientInstanceLayer } from "./EC2ClientInstance";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
+import { Context, Data, Effect, Layer, Record } from "effect";
+import {
+  EC2ClientInstance,
+  EC2ClientInstanceLayer,
+} from "./EC2ClientInstance";
 import { DefaultEC2ClientConfigLayer } from "./EC2ClientInstanceConfig";
-import { EC2ServiceError, SdkError, TaggedException } from "./Errors";
+import {
+  type TaggedException,
+  SdkError,
+} from "./Errors";
 
 const commands = {
   AcceptAddressTransferCommand,
-  AcceptReservedInstancesExchangeQuoteCommand,
-  AcceptTransitGatewayMulticastDomainAssociationsCommand,
-  AcceptTransitGatewayPeeringAttachmentCommand,
-  AcceptTransitGatewayVpcAttachmentCommand,
-  AcceptVpcEndpointConnectionsCommand,
-  AcceptVpcPeeringConnectionCommand,
-  AdvertiseByoipCidrCommand,
-  AllocateAddressCommand,
-  AllocateHostsCommand,
-  AllocateIpamPoolCidrCommand,
-  ApplySecurityGroupsToClientVpnTargetNetworkCommand,
-  AssignIpv6AddressesCommand,
-  AssignPrivateIpAddressesCommand,
-  AssignPrivateNatGatewayAddressCommand,
-  AssociateAddressCommand,
-  AssociateClientVpnTargetNetworkCommand,
-  AssociateDhcpOptionsCommand,
-  AssociateEnclaveCertificateIamRoleCommand,
-  AssociateIamInstanceProfileCommand,
-  AssociateInstanceEventWindowCommand,
-  AssociateIpamByoasnCommand,
-  AssociateIpamResourceDiscoveryCommand,
-  AssociateNatGatewayAddressCommand,
-  AssociateRouteTableCommand,
-  AssociateSubnetCidrBlockCommand,
-  AssociateTransitGatewayMulticastDomainCommand,
-  AssociateTransitGatewayPolicyTableCommand,
-  AssociateTransitGatewayRouteTableCommand,
-  AssociateTrunkInterfaceCommand,
-  AssociateVpcCidrBlockCommand,
-  AttachClassicLinkVpcCommand,
-  AttachInternetGatewayCommand,
-  AttachNetworkInterfaceCommand,
-  AttachVerifiedAccessTrustProviderCommand,
-  AttachVolumeCommand,
-  AttachVpnGatewayCommand,
-  AuthorizeClientVpnIngressCommand,
-  AuthorizeSecurityGroupEgressCommand,
-  AuthorizeSecurityGroupIngressCommand,
-  BundleInstanceCommand,
-  CancelBundleTaskCommand,
-  CancelCapacityReservationCommand,
-  CancelCapacityReservationFleetsCommand,
-  CancelConversionTaskCommand,
-  CancelExportTaskCommand,
-  CancelImageLaunchPermissionCommand,
-  CancelImportTaskCommand,
-  CancelReservedInstancesListingCommand,
-  CancelSpotFleetRequestsCommand,
-  CancelSpotInstanceRequestsCommand,
-  ConfirmProductInstanceCommand,
-  CopyFpgaImageCommand,
-  CopyImageCommand,
-  CopySnapshotCommand,
-  CreateCapacityReservationCommand,
-  CreateCapacityReservationFleetCommand,
-  CreateCarrierGatewayCommand,
-  CreateClientVpnEndpointCommand,
-  CreateClientVpnRouteCommand,
-  CreateCoipCidrCommand,
-  CreateCoipPoolCommand,
-  CreateCustomerGatewayCommand,
-  CreateDefaultSubnetCommand,
-  CreateDefaultVpcCommand,
-  CreateDhcpOptionsCommand,
-  CreateEgressOnlyInternetGatewayCommand,
-  CreateFleetCommand,
-  CreateFlowLogsCommand,
-  CreateFpgaImageCommand,
-  CreateImageCommand,
-  CreateInstanceConnectEndpointCommand,
-  CreateInstanceEventWindowCommand,
-  CreateInstanceExportTaskCommand,
-  CreateInternetGatewayCommand,
-  CreateIpamCommand,
-  CreateIpamPoolCommand,
-  CreateIpamResourceDiscoveryCommand,
-  CreateIpamScopeCommand,
-  CreateKeyPairCommand,
-  CreateLaunchTemplateCommand,
-  CreateLaunchTemplateVersionCommand,
-  CreateLocalGatewayRouteCommand,
-  CreateLocalGatewayRouteTableCommand,
-  CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-  CreateLocalGatewayRouteTableVpcAssociationCommand,
-  CreateManagedPrefixListCommand,
-  CreateNatGatewayCommand,
-  CreateNetworkAclCommand,
-  CreateNetworkAclEntryCommand,
-  CreateNetworkInsightsAccessScopeCommand,
-  CreateNetworkInsightsPathCommand,
-  CreateNetworkInterfaceCommand,
-  CreateNetworkInterfacePermissionCommand,
-  CreatePlacementGroupCommand,
-  CreatePublicIpv4PoolCommand,
-  CreateReplaceRootVolumeTaskCommand,
-  CreateReservedInstancesListingCommand,
-  CreateRestoreImageTaskCommand,
-  CreateRouteCommand,
-  CreateRouteTableCommand,
-  CreateSecurityGroupCommand,
-  CreateSnapshotCommand,
-  CreateSnapshotsCommand,
-  CreateSpotDatafeedSubscriptionCommand,
-  CreateStoreImageTaskCommand,
-  CreateSubnetCommand,
-  CreateSubnetCidrReservationCommand,
-  CreateTagsCommand,
-  CreateTrafficMirrorFilterCommand,
-  CreateTrafficMirrorFilterRuleCommand,
-  CreateTrafficMirrorSessionCommand,
-  CreateTrafficMirrorTargetCommand,
-  CreateTransitGatewayCommand,
-  CreateTransitGatewayConnectCommand,
-  CreateTransitGatewayConnectPeerCommand,
-  CreateTransitGatewayMulticastDomainCommand,
-  CreateTransitGatewayPeeringAttachmentCommand,
-  CreateTransitGatewayPolicyTableCommand,
-  CreateTransitGatewayPrefixListReferenceCommand,
-  CreateTransitGatewayRouteCommand,
-  CreateTransitGatewayRouteTableCommand,
-  CreateTransitGatewayRouteTableAnnouncementCommand,
-  CreateTransitGatewayVpcAttachmentCommand,
-  CreateVerifiedAccessEndpointCommand,
-  CreateVerifiedAccessGroupCommand,
-  CreateVerifiedAccessInstanceCommand,
-  CreateVerifiedAccessTrustProviderCommand,
-  CreateVolumeCommand,
-  CreateVpcCommand,
-  CreateVpcEndpointCommand,
-  CreateVpcEndpointConnectionNotificationCommand,
-  CreateVpcEndpointServiceConfigurationCommand,
-  CreateVpcPeeringConnectionCommand,
-  CreateVpnConnectionCommand,
-  CreateVpnConnectionRouteCommand,
-  CreateVpnGatewayCommand,
-  DeleteCarrierGatewayCommand,
-  DeleteClientVpnEndpointCommand,
-  DeleteClientVpnRouteCommand,
-  DeleteCoipCidrCommand,
-  DeleteCoipPoolCommand,
-  DeleteCustomerGatewayCommand,
-  DeleteDhcpOptionsCommand,
-  DeleteEgressOnlyInternetGatewayCommand,
-  DeleteFleetsCommand,
-  DeleteFlowLogsCommand,
-  DeleteFpgaImageCommand,
-  DeleteInstanceConnectEndpointCommand,
-  DeleteInstanceEventWindowCommand,
-  DeleteInternetGatewayCommand,
-  DeleteIpamCommand,
-  DeleteIpamPoolCommand,
-  DeleteIpamResourceDiscoveryCommand,
-  DeleteIpamScopeCommand,
-  DeleteKeyPairCommand,
-  DeleteLaunchTemplateCommand,
-  DeleteLaunchTemplateVersionsCommand,
-  DeleteLocalGatewayRouteCommand,
-  DeleteLocalGatewayRouteTableCommand,
-  DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
-  DeleteLocalGatewayRouteTableVpcAssociationCommand,
-  DeleteManagedPrefixListCommand,
-  DeleteNatGatewayCommand,
-  DeleteNetworkAclCommand,
-  DeleteNetworkAclEntryCommand,
-  DeleteNetworkInsightsAccessScopeCommand,
-  DeleteNetworkInsightsAccessScopeAnalysisCommand,
-  DeleteNetworkInsightsAnalysisCommand,
-  DeleteNetworkInsightsPathCommand,
-  DeleteNetworkInterfaceCommand,
-  DeleteNetworkInterfacePermissionCommand,
-  DeletePlacementGroupCommand,
-  DeletePublicIpv4PoolCommand,
-  DeleteQueuedReservedInstancesCommand,
-  DeleteRouteCommand,
-  DeleteRouteTableCommand,
-  DeleteSecurityGroupCommand,
-  DeleteSnapshotCommand,
-  DeleteSpotDatafeedSubscriptionCommand,
-  DeleteSubnetCommand,
-  DeleteSubnetCidrReservationCommand,
-  DeleteTagsCommand,
-  DeleteTrafficMirrorFilterCommand,
-  DeleteTrafficMirrorFilterRuleCommand,
-  DeleteTrafficMirrorSessionCommand,
-  DeleteTrafficMirrorTargetCommand,
-  DeleteTransitGatewayCommand,
-  DeleteTransitGatewayConnectCommand,
-  DeleteTransitGatewayConnectPeerCommand,
-  DeleteTransitGatewayMulticastDomainCommand,
-  DeleteTransitGatewayPeeringAttachmentCommand,
-  DeleteTransitGatewayPolicyTableCommand,
-  DeleteTransitGatewayPrefixListReferenceCommand,
-  DeleteTransitGatewayRouteCommand,
-  DeleteTransitGatewayRouteTableCommand,
-  DeleteTransitGatewayRouteTableAnnouncementCommand,
-  DeleteTransitGatewayVpcAttachmentCommand,
-  DeleteVerifiedAccessEndpointCommand,
-  DeleteVerifiedAccessGroupCommand,
-  DeleteVerifiedAccessInstanceCommand,
-  DeleteVerifiedAccessTrustProviderCommand,
-  DeleteVolumeCommand,
-  DeleteVpcCommand,
-  DeleteVpcEndpointConnectionNotificationsCommand,
-  DeleteVpcEndpointsCommand,
-  DeleteVpcEndpointServiceConfigurationsCommand,
-  DeleteVpcPeeringConnectionCommand,
-  DeleteVpnConnectionCommand,
-  DeleteVpnConnectionRouteCommand,
-  DeleteVpnGatewayCommand,
-  DeprovisionByoipCidrCommand,
-  DeprovisionIpamByoasnCommand,
-  DeprovisionIpamPoolCidrCommand,
-  DeprovisionPublicIpv4PoolCidrCommand,
-  DeregisterImageCommand,
-  DeregisterInstanceEventNotificationAttributesCommand,
-  DeregisterTransitGatewayMulticastGroupMembersCommand,
-  DeregisterTransitGatewayMulticastGroupSourcesCommand,
-  DescribeAccountAttributesCommand,
-  DescribeAddressesCommand,
-  DescribeAddressesAttributeCommand,
-  DescribeAddressTransfersCommand,
-  DescribeAggregateIdFormatCommand,
-  DescribeAvailabilityZonesCommand,
-  DescribeAwsNetworkPerformanceMetricSubscriptionsCommand,
-  DescribeBundleTasksCommand,
-  DescribeByoipCidrsCommand,
-  DescribeCapacityBlockOfferingsCommand,
-  DescribeCapacityReservationFleetsCommand,
-  DescribeCapacityReservationsCommand,
-  DescribeCarrierGatewaysCommand,
-  DescribeClassicLinkInstancesCommand,
-  DescribeClientVpnAuthorizationRulesCommand,
-  DescribeClientVpnConnectionsCommand,
-  DescribeClientVpnEndpointsCommand,
-  DescribeClientVpnRoutesCommand,
-  DescribeClientVpnTargetNetworksCommand,
-  DescribeCoipPoolsCommand,
-  DescribeConversionTasksCommand,
-  DescribeCustomerGatewaysCommand,
-  DescribeDhcpOptionsCommand,
-  DescribeEgressOnlyInternetGatewaysCommand,
-  DescribeElasticGpusCommand,
-  DescribeExportImageTasksCommand,
-  DescribeExportTasksCommand,
-  DescribeFastLaunchImagesCommand,
-  DescribeFastSnapshotRestoresCommand,
-  DescribeFleetHistoryCommand,
-  DescribeFleetInstancesCommand,
-  DescribeFleetsCommand,
-  DescribeFlowLogsCommand,
-  DescribeFpgaImageAttributeCommand,
-  DescribeFpgaImagesCommand,
-  DescribeHostReservationOfferingsCommand,
-  DescribeHostReservationsCommand,
-  DescribeHostsCommand,
-  DescribeIamInstanceProfileAssociationsCommand,
-  DescribeIdentityIdFormatCommand,
-  DescribeIdFormatCommand,
-  DescribeImageAttributeCommand,
-  DescribeImagesCommand,
-  DescribeImportImageTasksCommand,
-  DescribeImportSnapshotTasksCommand,
-  DescribeInstanceAttributeCommand,
-  DescribeInstanceConnectEndpointsCommand,
-  DescribeInstanceCreditSpecificationsCommand,
-  DescribeInstanceEventNotificationAttributesCommand,
-  DescribeInstanceEventWindowsCommand,
-  DescribeInstancesCommand,
-  DescribeInstanceStatusCommand,
-  DescribeInstanceTopologyCommand,
-  DescribeInstanceTypeOfferingsCommand,
-  DescribeInstanceTypesCommand,
-  DescribeInternetGatewaysCommand,
-  DescribeIpamByoasnCommand,
-  DescribeIpamPoolsCommand,
-  DescribeIpamResourceDiscoveriesCommand,
-  DescribeIpamResourceDiscoveryAssociationsCommand,
-  DescribeIpamsCommand,
-  DescribeIpamScopesCommand,
-  DescribeIpv6PoolsCommand,
-  DescribeKeyPairsCommand,
-  DescribeLaunchTemplatesCommand,
-  DescribeLaunchTemplateVersionsCommand,
-  DescribeLocalGatewayRouteTablesCommand,
-  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
-  DescribeLocalGatewayRouteTableVpcAssociationsCommand,
-  DescribeLocalGatewaysCommand,
-  DescribeLocalGatewayVirtualInterfaceGroupsCommand,
-  DescribeLocalGatewayVirtualInterfacesCommand,
-  DescribeLockedSnapshotsCommand,
-  DescribeManagedPrefixListsCommand,
-  DescribeMovingAddressesCommand,
-  DescribeNatGatewaysCommand,
-  DescribeNetworkAclsCommand,
-  DescribeNetworkInsightsAccessScopeAnalysesCommand,
-  DescribeNetworkInsightsAccessScopesCommand,
-  DescribeNetworkInsightsAnalysesCommand,
-  DescribeNetworkInsightsPathsCommand,
-  DescribeNetworkInterfaceAttributeCommand,
-  DescribeNetworkInterfacePermissionsCommand,
-  DescribeNetworkInterfacesCommand,
-  DescribePlacementGroupsCommand,
-  DescribePrefixListsCommand,
-  DescribePrincipalIdFormatCommand,
-  DescribePublicIpv4PoolsCommand,
-  DescribeRegionsCommand,
-  DescribeReplaceRootVolumeTasksCommand,
-  DescribeReservedInstancesCommand,
-  DescribeReservedInstancesListingsCommand,
-  DescribeReservedInstancesModificationsCommand,
-  DescribeReservedInstancesOfferingsCommand,
-  DescribeRouteTablesCommand,
-  DescribeScheduledInstanceAvailabilityCommand,
-  DescribeScheduledInstancesCommand,
-  DescribeSecurityGroupReferencesCommand,
-  DescribeSecurityGroupRulesCommand,
-  DescribeSecurityGroupsCommand,
-  DescribeSnapshotAttributeCommand,
-  DescribeSnapshotsCommand,
-  DescribeSnapshotTierStatusCommand,
-  DescribeSpotDatafeedSubscriptionCommand,
-  DescribeSpotFleetInstancesCommand,
-  DescribeSpotFleetRequestHistoryCommand,
-  DescribeSpotFleetRequestsCommand,
-  DescribeSpotInstanceRequestsCommand,
-  DescribeSpotPriceHistoryCommand,
-  DescribeStaleSecurityGroupsCommand,
-  DescribeStoreImageTasksCommand,
-  DescribeSubnetsCommand,
-  DescribeTagsCommand,
-  DescribeTrafficMirrorFiltersCommand,
-  DescribeTrafficMirrorSessionsCommand,
-  DescribeTrafficMirrorTargetsCommand,
-  DescribeTransitGatewayAttachmentsCommand,
-  DescribeTransitGatewayConnectPeersCommand,
-  DescribeTransitGatewayConnectsCommand,
-  DescribeTransitGatewayMulticastDomainsCommand,
-  DescribeTransitGatewayPeeringAttachmentsCommand,
-  DescribeTransitGatewayPolicyTablesCommand,
-  DescribeTransitGatewayRouteTableAnnouncementsCommand,
-  DescribeTransitGatewayRouteTablesCommand,
-  DescribeTransitGatewaysCommand,
-  DescribeTransitGatewayVpcAttachmentsCommand,
-  DescribeTrunkInterfaceAssociationsCommand,
-  DescribeVerifiedAccessEndpointsCommand,
-  DescribeVerifiedAccessGroupsCommand,
-  DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
-  DescribeVerifiedAccessInstancesCommand,
-  DescribeVerifiedAccessTrustProvidersCommand,
-  DescribeVolumeAttributeCommand,
-  DescribeVolumesCommand,
-  DescribeVolumesModificationsCommand,
-  DescribeVolumeStatusCommand,
-  DescribeVpcAttributeCommand,
-  DescribeVpcClassicLinkCommand,
-  DescribeVpcClassicLinkDnsSupportCommand,
-  DescribeVpcEndpointConnectionNotificationsCommand,
-  DescribeVpcEndpointConnectionsCommand,
-  DescribeVpcEndpointsCommand,
-  DescribeVpcEndpointServiceConfigurationsCommand,
-  DescribeVpcEndpointServicePermissionsCommand,
-  DescribeVpcEndpointServicesCommand,
-  DescribeVpcPeeringConnectionsCommand,
-  DescribeVpcsCommand,
-  DescribeVpnConnectionsCommand,
-  DescribeVpnGatewaysCommand,
-  DetachClassicLinkVpcCommand,
-  DetachInternetGatewayCommand,
-  DetachNetworkInterfaceCommand,
-  DetachVerifiedAccessTrustProviderCommand,
-  DetachVolumeCommand,
-  DetachVpnGatewayCommand,
-  DisableAddressTransferCommand,
-  DisableAwsNetworkPerformanceMetricSubscriptionCommand,
-  DisableEbsEncryptionByDefaultCommand,
-  DisableFastLaunchCommand,
-  DisableFastSnapshotRestoresCommand,
-  DisableImageCommand,
-  DisableImageBlockPublicAccessCommand,
-  DisableImageDeprecationCommand,
-  DisableIpamOrganizationAdminAccountCommand,
-  DisableSerialConsoleAccessCommand,
-  DisableSnapshotBlockPublicAccessCommand,
-  DisableTransitGatewayRouteTablePropagationCommand,
-  DisableVgwRoutePropagationCommand,
-  DisableVpcClassicLinkCommand,
-  DisableVpcClassicLinkDnsSupportCommand,
-  DisassociateAddressCommand,
-  DisassociateClientVpnTargetNetworkCommand,
-  DisassociateEnclaveCertificateIamRoleCommand,
-  DisassociateIamInstanceProfileCommand,
-  DisassociateInstanceEventWindowCommand,
-  DisassociateIpamByoasnCommand,
-  DisassociateIpamResourceDiscoveryCommand,
-  DisassociateNatGatewayAddressCommand,
-  DisassociateRouteTableCommand,
-  DisassociateSubnetCidrBlockCommand,
-  DisassociateTransitGatewayMulticastDomainCommand,
-  DisassociateTransitGatewayPolicyTableCommand,
-  DisassociateTransitGatewayRouteTableCommand,
-  DisassociateTrunkInterfaceCommand,
-  DisassociateVpcCidrBlockCommand,
-  EnableAddressTransferCommand,
-  EnableAwsNetworkPerformanceMetricSubscriptionCommand,
-  EnableEbsEncryptionByDefaultCommand,
-  EnableFastLaunchCommand,
-  EnableFastSnapshotRestoresCommand,
-  EnableImageCommand,
-  EnableImageBlockPublicAccessCommand,
-  EnableImageDeprecationCommand,
-  EnableIpamOrganizationAdminAccountCommand,
-  EnableReachabilityAnalyzerOrganizationSharingCommand,
-  EnableSerialConsoleAccessCommand,
-  EnableSnapshotBlockPublicAccessCommand,
-  EnableTransitGatewayRouteTablePropagationCommand,
-  EnableVgwRoutePropagationCommand,
-  EnableVolumeIOCommand,
-  EnableVpcClassicLinkCommand,
-  EnableVpcClassicLinkDnsSupportCommand,
-  ExportClientVpnClientCertificateRevocationListCommand,
-  ExportClientVpnClientConfigurationCommand,
-  ExportImageCommand,
-  ExportTransitGatewayRoutesCommand,
-  GetAssociatedEnclaveCertificateIamRolesCommand,
-  GetAssociatedIpv6PoolCidrsCommand,
-  GetAwsNetworkPerformanceDataCommand,
-  GetCapacityReservationUsageCommand,
-  GetCoipPoolUsageCommand,
-  GetConsoleOutputCommand,
-  GetConsoleScreenshotCommand,
-  GetDefaultCreditSpecificationCommand,
-  GetEbsDefaultKmsKeyIdCommand,
-  GetEbsEncryptionByDefaultCommand,
-  GetFlowLogsIntegrationTemplateCommand,
-  GetGroupsForCapacityReservationCommand,
-  GetHostReservationPurchasePreviewCommand,
-  GetImageBlockPublicAccessStateCommand,
-  GetInstanceTypesFromInstanceRequirementsCommand,
-  GetInstanceUefiDataCommand,
-  GetIpamAddressHistoryCommand,
-  GetIpamDiscoveredAccountsCommand,
-  GetIpamDiscoveredPublicAddressesCommand,
-  GetIpamDiscoveredResourceCidrsCommand,
-  GetIpamPoolAllocationsCommand,
-  GetIpamPoolCidrsCommand,
-  GetIpamResourceCidrsCommand,
-  GetLaunchTemplateDataCommand,
-  GetManagedPrefixListAssociationsCommand,
-  GetManagedPrefixListEntriesCommand,
-  GetNetworkInsightsAccessScopeAnalysisFindingsCommand,
-  GetNetworkInsightsAccessScopeContentCommand,
-  GetPasswordDataCommand,
-  GetReservedInstancesExchangeQuoteCommand,
-  GetSecurityGroupsForVpcCommand,
-  GetSerialConsoleAccessStatusCommand,
-  GetSnapshotBlockPublicAccessStateCommand,
-  GetSpotPlacementScoresCommand,
-  GetSubnetCidrReservationsCommand,
-  GetTransitGatewayAttachmentPropagationsCommand,
-  GetTransitGatewayMulticastDomainAssociationsCommand,
-  GetTransitGatewayPolicyTableAssociationsCommand,
-  GetTransitGatewayPolicyTableEntriesCommand,
-  GetTransitGatewayPrefixListReferencesCommand,
-  GetTransitGatewayRouteTableAssociationsCommand,
-  GetTransitGatewayRouteTablePropagationsCommand,
-  GetVerifiedAccessEndpointPolicyCommand,
-  GetVerifiedAccessGroupPolicyCommand,
-  GetVpnConnectionDeviceSampleConfigurationCommand,
-  GetVpnConnectionDeviceTypesCommand,
-  GetVpnTunnelReplacementStatusCommand,
-  ImportClientVpnClientCertificateRevocationListCommand,
-  ImportImageCommand,
-  ImportInstanceCommand,
-  ImportKeyPairCommand,
-  ImportSnapshotCommand,
-  ImportVolumeCommand,
-  ListImagesInRecycleBinCommand,
-  ListSnapshotsInRecycleBinCommand,
-  LockSnapshotCommand,
-  ModifyAddressAttributeCommand,
-  ModifyAvailabilityZoneGroupCommand,
-  ModifyCapacityReservationCommand,
-  ModifyCapacityReservationFleetCommand,
-  ModifyClientVpnEndpointCommand,
-  ModifyDefaultCreditSpecificationCommand,
-  ModifyEbsDefaultKmsKeyIdCommand,
-  ModifyFleetCommand,
-  ModifyFpgaImageAttributeCommand,
-  ModifyHostsCommand,
-  ModifyIdentityIdFormatCommand,
-  ModifyIdFormatCommand,
-  ModifyImageAttributeCommand,
-  ModifyInstanceAttributeCommand,
-  ModifyInstanceCapacityReservationAttributesCommand,
-  ModifyInstanceCreditSpecificationCommand,
-  ModifyInstanceEventStartTimeCommand,
-  ModifyInstanceEventWindowCommand,
-  ModifyInstanceMaintenanceOptionsCommand,
-  ModifyInstanceMetadataOptionsCommand,
-  ModifyInstancePlacementCommand,
-  ModifyIpamCommand,
-  ModifyIpamPoolCommand,
-  ModifyIpamResourceCidrCommand,
-  ModifyIpamResourceDiscoveryCommand,
-  ModifyIpamScopeCommand,
-  ModifyLaunchTemplateCommand,
-  ModifyLocalGatewayRouteCommand,
-  ModifyManagedPrefixListCommand,
-  ModifyNetworkInterfaceAttributeCommand,
-  ModifyPrivateDnsNameOptionsCommand,
-  ModifyReservedInstancesCommand,
-  ModifySecurityGroupRulesCommand,
-  ModifySnapshotAttributeCommand,
-  ModifySnapshotTierCommand,
-  ModifySpotFleetRequestCommand,
-  ModifySubnetAttributeCommand,
-  ModifyTrafficMirrorFilterNetworkServicesCommand,
-  ModifyTrafficMirrorFilterRuleCommand,
-  ModifyTrafficMirrorSessionCommand,
-  ModifyTransitGatewayCommand,
-  ModifyTransitGatewayPrefixListReferenceCommand,
-  ModifyTransitGatewayVpcAttachmentCommand,
-  ModifyVerifiedAccessEndpointCommand,
-  ModifyVerifiedAccessEndpointPolicyCommand,
-  ModifyVerifiedAccessGroupCommand,
-  ModifyVerifiedAccessGroupPolicyCommand,
-  ModifyVerifiedAccessInstanceCommand,
-  ModifyVerifiedAccessInstanceLoggingConfigurationCommand,
-  ModifyVerifiedAccessTrustProviderCommand,
-  ModifyVolumeCommand,
-  ModifyVolumeAttributeCommand,
-  ModifyVpcAttributeCommand,
-  ModifyVpcEndpointCommand,
-  ModifyVpcEndpointConnectionNotificationCommand,
-  ModifyVpcEndpointServiceConfigurationCommand,
-  ModifyVpcEndpointServicePayerResponsibilityCommand,
-  ModifyVpcEndpointServicePermissionsCommand,
-  ModifyVpcPeeringConnectionOptionsCommand,
-  ModifyVpcTenancyCommand,
-  ModifyVpnConnectionCommand,
-  ModifyVpnConnectionOptionsCommand,
-  ModifyVpnTunnelCertificateCommand,
-  ModifyVpnTunnelOptionsCommand,
-  MonitorInstancesCommand,
-  MoveAddressToVpcCommand,
-  MoveByoipCidrToIpamCommand,
-  ProvisionByoipCidrCommand,
-  ProvisionIpamByoasnCommand,
-  ProvisionIpamPoolCidrCommand,
-  ProvisionPublicIpv4PoolCidrCommand,
-  PurchaseCapacityBlockCommand,
-  PurchaseHostReservationCommand,
-  PurchaseReservedInstancesOfferingCommand,
-  PurchaseScheduledInstancesCommand,
-  RebootInstancesCommand,
-  RegisterImageCommand,
-  RegisterInstanceEventNotificationAttributesCommand,
-  RegisterTransitGatewayMulticastGroupMembersCommand,
-  RegisterTransitGatewayMulticastGroupSourcesCommand,
-  RejectTransitGatewayMulticastDomainAssociationsCommand,
-  RejectTransitGatewayPeeringAttachmentCommand,
-  RejectTransitGatewayVpcAttachmentCommand,
-  RejectVpcEndpointConnectionsCommand,
-  RejectVpcPeeringConnectionCommand,
-  ReleaseAddressCommand,
-  ReleaseHostsCommand,
-  ReleaseIpamPoolAllocationCommand,
-  ReplaceIamInstanceProfileAssociationCommand,
-  ReplaceNetworkAclAssociationCommand,
-  ReplaceNetworkAclEntryCommand,
-  ReplaceRouteCommand,
-  ReplaceRouteTableAssociationCommand,
-  ReplaceTransitGatewayRouteCommand,
-  ReplaceVpnTunnelCommand,
-  ReportInstanceStatusCommand,
-  RequestSpotFleetCommand,
-  RequestSpotInstancesCommand,
-  ResetAddressAttributeCommand,
-  ResetEbsDefaultKmsKeyIdCommand,
-  ResetFpgaImageAttributeCommand,
-  ResetImageAttributeCommand,
-  ResetInstanceAttributeCommand,
-  ResetNetworkInterfaceAttributeCommand,
-  ResetSnapshotAttributeCommand,
-  RestoreAddressToClassicCommand,
-  RestoreImageFromRecycleBinCommand,
-  RestoreManagedPrefixListVersionCommand,
-  RestoreSnapshotFromRecycleBinCommand,
-  RestoreSnapshotTierCommand,
-  RevokeClientVpnIngressCommand,
-  RevokeSecurityGroupEgressCommand,
-  RevokeSecurityGroupIngressCommand,
-  RunInstancesCommand,
-  RunScheduledInstancesCommand,
-  SearchLocalGatewayRoutesCommand,
-  SearchTransitGatewayMulticastGroupsCommand,
-  SearchTransitGatewayRoutesCommand,
-  SendDiagnosticInterruptCommand,
-  StartInstancesCommand,
-  StartNetworkInsightsAccessScopeAnalysisCommand,
-  StartNetworkInsightsAnalysisCommand,
-  StartVpcEndpointServicePrivateDnsVerificationCommand,
-  StopInstancesCommand,
-  TerminateClientVpnConnectionsCommand,
-  TerminateInstancesCommand,
-  UnassignIpv6AddressesCommand,
-  UnassignPrivateIpAddressesCommand,
-  UnassignPrivateNatGatewayAddressCommand,
-  UnlockSnapshotCommand,
-  UnmonitorInstancesCommand,
-  UpdateSecurityGroupRuleDescriptionsEgressCommand,
-  UpdateSecurityGroupRuleDescriptionsIngressCommand,
-  WithdrawByoipCidrCommand,
+ AcceptReservedInstancesExchangeQuoteCommand,
+ AcceptTransitGatewayMulticastDomainAssociationsCommand,
+ AcceptTransitGatewayPeeringAttachmentCommand,
+ AcceptTransitGatewayVpcAttachmentCommand,
+ AcceptVpcEndpointConnectionsCommand,
+ AcceptVpcPeeringConnectionCommand,
+ AdvertiseByoipCidrCommand,
+ AllocateAddressCommand,
+ AllocateHostsCommand,
+ AllocateIpamPoolCidrCommand,
+ ApplySecurityGroupsToClientVpnTargetNetworkCommand,
+ AssignIpv6AddressesCommand,
+ AssignPrivateIpAddressesCommand,
+ AssignPrivateNatGatewayAddressCommand,
+ AssociateAddressCommand,
+ AssociateClientVpnTargetNetworkCommand,
+ AssociateDhcpOptionsCommand,
+ AssociateEnclaveCertificateIamRoleCommand,
+ AssociateIamInstanceProfileCommand,
+ AssociateInstanceEventWindowCommand,
+ AssociateIpamByoasnCommand,
+ AssociateIpamResourceDiscoveryCommand,
+ AssociateNatGatewayAddressCommand,
+ AssociateRouteTableCommand,
+ AssociateSubnetCidrBlockCommand,
+ AssociateTransitGatewayMulticastDomainCommand,
+ AssociateTransitGatewayPolicyTableCommand,
+ AssociateTransitGatewayRouteTableCommand,
+ AssociateTrunkInterfaceCommand,
+ AssociateVpcCidrBlockCommand,
+ AttachClassicLinkVpcCommand,
+ AttachInternetGatewayCommand,
+ AttachNetworkInterfaceCommand,
+ AttachVerifiedAccessTrustProviderCommand,
+ AttachVolumeCommand,
+ AttachVpnGatewayCommand,
+ AuthorizeClientVpnIngressCommand,
+ AuthorizeSecurityGroupEgressCommand,
+ AuthorizeSecurityGroupIngressCommand,
+ BundleInstanceCommand,
+ CancelBundleTaskCommand,
+ CancelCapacityReservationCommand,
+ CancelCapacityReservationFleetsCommand,
+ CancelConversionTaskCommand,
+ CancelExportTaskCommand,
+ CancelImageLaunchPermissionCommand,
+ CancelImportTaskCommand,
+ CancelReservedInstancesListingCommand,
+ CancelSpotFleetRequestsCommand,
+ CancelSpotInstanceRequestsCommand,
+ ConfirmProductInstanceCommand,
+ CopyFpgaImageCommand,
+ CopyImageCommand,
+ CopySnapshotCommand,
+ CreateCapacityReservationCommand,
+ CreateCapacityReservationFleetCommand,
+ CreateCarrierGatewayCommand,
+ CreateClientVpnEndpointCommand,
+ CreateClientVpnRouteCommand,
+ CreateCoipCidrCommand,
+ CreateCoipPoolCommand,
+ CreateCustomerGatewayCommand,
+ CreateDefaultSubnetCommand,
+ CreateDefaultVpcCommand,
+ CreateDhcpOptionsCommand,
+ CreateEgressOnlyInternetGatewayCommand,
+ CreateFleetCommand,
+ CreateFlowLogsCommand,
+ CreateFpgaImageCommand,
+ CreateImageCommand,
+ CreateInstanceConnectEndpointCommand,
+ CreateInstanceEventWindowCommand,
+ CreateInstanceExportTaskCommand,
+ CreateInternetGatewayCommand,
+ CreateIpamCommand,
+ CreateIpamPoolCommand,
+ CreateIpamResourceDiscoveryCommand,
+ CreateIpamScopeCommand,
+ CreateKeyPairCommand,
+ CreateLaunchTemplateCommand,
+ CreateLaunchTemplateVersionCommand,
+ CreateLocalGatewayRouteCommand,
+ CreateLocalGatewayRouteTableCommand,
+ CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
+ CreateLocalGatewayRouteTableVpcAssociationCommand,
+ CreateManagedPrefixListCommand,
+ CreateNatGatewayCommand,
+ CreateNetworkAclCommand,
+ CreateNetworkAclEntryCommand,
+ CreateNetworkInsightsAccessScopeCommand,
+ CreateNetworkInsightsPathCommand,
+ CreateNetworkInterfaceCommand,
+ CreateNetworkInterfacePermissionCommand,
+ CreatePlacementGroupCommand,
+ CreatePublicIpv4PoolCommand,
+ CreateReplaceRootVolumeTaskCommand,
+ CreateReservedInstancesListingCommand,
+ CreateRestoreImageTaskCommand,
+ CreateRouteCommand,
+ CreateRouteTableCommand,
+ CreateSecurityGroupCommand,
+ CreateSnapshotCommand,
+ CreateSnapshotsCommand,
+ CreateSpotDatafeedSubscriptionCommand,
+ CreateStoreImageTaskCommand,
+ CreateSubnetCommand,
+ CreateSubnetCidrReservationCommand,
+ CreateTagsCommand,
+ CreateTrafficMirrorFilterCommand,
+ CreateTrafficMirrorFilterRuleCommand,
+ CreateTrafficMirrorSessionCommand,
+ CreateTrafficMirrorTargetCommand,
+ CreateTransitGatewayCommand,
+ CreateTransitGatewayConnectCommand,
+ CreateTransitGatewayConnectPeerCommand,
+ CreateTransitGatewayMulticastDomainCommand,
+ CreateTransitGatewayPeeringAttachmentCommand,
+ CreateTransitGatewayPolicyTableCommand,
+ CreateTransitGatewayPrefixListReferenceCommand,
+ CreateTransitGatewayRouteCommand,
+ CreateTransitGatewayRouteTableCommand,
+ CreateTransitGatewayRouteTableAnnouncementCommand,
+ CreateTransitGatewayVpcAttachmentCommand,
+ CreateVerifiedAccessEndpointCommand,
+ CreateVerifiedAccessGroupCommand,
+ CreateVerifiedAccessInstanceCommand,
+ CreateVerifiedAccessTrustProviderCommand,
+ CreateVolumeCommand,
+ CreateVpcCommand,
+ CreateVpcEndpointCommand,
+ CreateVpcEndpointConnectionNotificationCommand,
+ CreateVpcEndpointServiceConfigurationCommand,
+ CreateVpcPeeringConnectionCommand,
+ CreateVpnConnectionCommand,
+ CreateVpnConnectionRouteCommand,
+ CreateVpnGatewayCommand,
+ DeleteCarrierGatewayCommand,
+ DeleteClientVpnEndpointCommand,
+ DeleteClientVpnRouteCommand,
+ DeleteCoipCidrCommand,
+ DeleteCoipPoolCommand,
+ DeleteCustomerGatewayCommand,
+ DeleteDhcpOptionsCommand,
+ DeleteEgressOnlyInternetGatewayCommand,
+ DeleteFleetsCommand,
+ DeleteFlowLogsCommand,
+ DeleteFpgaImageCommand,
+ DeleteInstanceConnectEndpointCommand,
+ DeleteInstanceEventWindowCommand,
+ DeleteInternetGatewayCommand,
+ DeleteIpamCommand,
+ DeleteIpamPoolCommand,
+ DeleteIpamResourceDiscoveryCommand,
+ DeleteIpamScopeCommand,
+ DeleteKeyPairCommand,
+ DeleteLaunchTemplateCommand,
+ DeleteLaunchTemplateVersionsCommand,
+ DeleteLocalGatewayRouteCommand,
+ DeleteLocalGatewayRouteTableCommand,
+ DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand,
+ DeleteLocalGatewayRouteTableVpcAssociationCommand,
+ DeleteManagedPrefixListCommand,
+ DeleteNatGatewayCommand,
+ DeleteNetworkAclCommand,
+ DeleteNetworkAclEntryCommand,
+ DeleteNetworkInsightsAccessScopeCommand,
+ DeleteNetworkInsightsAccessScopeAnalysisCommand,
+ DeleteNetworkInsightsAnalysisCommand,
+ DeleteNetworkInsightsPathCommand,
+ DeleteNetworkInterfaceCommand,
+ DeleteNetworkInterfacePermissionCommand,
+ DeletePlacementGroupCommand,
+ DeletePublicIpv4PoolCommand,
+ DeleteQueuedReservedInstancesCommand,
+ DeleteRouteCommand,
+ DeleteRouteTableCommand,
+ DeleteSecurityGroupCommand,
+ DeleteSnapshotCommand,
+ DeleteSpotDatafeedSubscriptionCommand,
+ DeleteSubnetCommand,
+ DeleteSubnetCidrReservationCommand,
+ DeleteTagsCommand,
+ DeleteTrafficMirrorFilterCommand,
+ DeleteTrafficMirrorFilterRuleCommand,
+ DeleteTrafficMirrorSessionCommand,
+ DeleteTrafficMirrorTargetCommand,
+ DeleteTransitGatewayCommand,
+ DeleteTransitGatewayConnectCommand,
+ DeleteTransitGatewayConnectPeerCommand,
+ DeleteTransitGatewayMulticastDomainCommand,
+ DeleteTransitGatewayPeeringAttachmentCommand,
+ DeleteTransitGatewayPolicyTableCommand,
+ DeleteTransitGatewayPrefixListReferenceCommand,
+ DeleteTransitGatewayRouteCommand,
+ DeleteTransitGatewayRouteTableCommand,
+ DeleteTransitGatewayRouteTableAnnouncementCommand,
+ DeleteTransitGatewayVpcAttachmentCommand,
+ DeleteVerifiedAccessEndpointCommand,
+ DeleteVerifiedAccessGroupCommand,
+ DeleteVerifiedAccessInstanceCommand,
+ DeleteVerifiedAccessTrustProviderCommand,
+ DeleteVolumeCommand,
+ DeleteVpcCommand,
+ DeleteVpcEndpointConnectionNotificationsCommand,
+ DeleteVpcEndpointServiceConfigurationsCommand,
+ DeleteVpcEndpointsCommand,
+ DeleteVpcPeeringConnectionCommand,
+ DeleteVpnConnectionCommand,
+ DeleteVpnConnectionRouteCommand,
+ DeleteVpnGatewayCommand,
+ DeprovisionByoipCidrCommand,
+ DeprovisionIpamByoasnCommand,
+ DeprovisionIpamPoolCidrCommand,
+ DeprovisionPublicIpv4PoolCidrCommand,
+ DeregisterImageCommand,
+ DeregisterInstanceEventNotificationAttributesCommand,
+ DeregisterTransitGatewayMulticastGroupMembersCommand,
+ DeregisterTransitGatewayMulticastGroupSourcesCommand,
+ DescribeAccountAttributesCommand,
+ DescribeAddressTransfersCommand,
+ DescribeAddressesCommand,
+ DescribeAddressesAttributeCommand,
+ DescribeAggregateIdFormatCommand,
+ DescribeAvailabilityZonesCommand,
+ DescribeAwsNetworkPerformanceMetricSubscriptionsCommand,
+ DescribeBundleTasksCommand,
+ DescribeByoipCidrsCommand,
+ DescribeCapacityBlockOfferingsCommand,
+ DescribeCapacityReservationFleetsCommand,
+ DescribeCapacityReservationsCommand,
+ DescribeCarrierGatewaysCommand,
+ DescribeClassicLinkInstancesCommand,
+ DescribeClientVpnAuthorizationRulesCommand,
+ DescribeClientVpnConnectionsCommand,
+ DescribeClientVpnEndpointsCommand,
+ DescribeClientVpnRoutesCommand,
+ DescribeClientVpnTargetNetworksCommand,
+ DescribeCoipPoolsCommand,
+ DescribeConversionTasksCommand,
+ DescribeCustomerGatewaysCommand,
+ DescribeDhcpOptionsCommand,
+ DescribeEgressOnlyInternetGatewaysCommand,
+ DescribeElasticGpusCommand,
+ DescribeExportImageTasksCommand,
+ DescribeExportTasksCommand,
+ DescribeFastLaunchImagesCommand,
+ DescribeFastSnapshotRestoresCommand,
+ DescribeFleetHistoryCommand,
+ DescribeFleetInstancesCommand,
+ DescribeFleetsCommand,
+ DescribeFlowLogsCommand,
+ DescribeFpgaImageAttributeCommand,
+ DescribeFpgaImagesCommand,
+ DescribeHostReservationOfferingsCommand,
+ DescribeHostReservationsCommand,
+ DescribeHostsCommand,
+ DescribeIamInstanceProfileAssociationsCommand,
+ DescribeIdFormatCommand,
+ DescribeIdentityIdFormatCommand,
+ DescribeImageAttributeCommand,
+ DescribeImagesCommand,
+ DescribeImportImageTasksCommand,
+ DescribeImportSnapshotTasksCommand,
+ DescribeInstanceAttributeCommand,
+ DescribeInstanceConnectEndpointsCommand,
+ DescribeInstanceCreditSpecificationsCommand,
+ DescribeInstanceEventNotificationAttributesCommand,
+ DescribeInstanceEventWindowsCommand,
+ DescribeInstanceStatusCommand,
+ DescribeInstanceTopologyCommand,
+ DescribeInstanceTypeOfferingsCommand,
+ DescribeInstanceTypesCommand,
+ DescribeInstancesCommand,
+ DescribeInternetGatewaysCommand,
+ DescribeIpamByoasnCommand,
+ DescribeIpamPoolsCommand,
+ DescribeIpamResourceDiscoveriesCommand,
+ DescribeIpamResourceDiscoveryAssociationsCommand,
+ DescribeIpamScopesCommand,
+ DescribeIpamsCommand,
+ DescribeIpv6PoolsCommand,
+ DescribeKeyPairsCommand,
+ DescribeLaunchTemplateVersionsCommand,
+ DescribeLaunchTemplatesCommand,
+ DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand,
+ DescribeLocalGatewayRouteTableVpcAssociationsCommand,
+ DescribeLocalGatewayRouteTablesCommand,
+ DescribeLocalGatewayVirtualInterfaceGroupsCommand,
+ DescribeLocalGatewayVirtualInterfacesCommand,
+ DescribeLocalGatewaysCommand,
+ DescribeLockedSnapshotsCommand,
+ DescribeMacHostsCommand,
+ DescribeManagedPrefixListsCommand,
+ DescribeMovingAddressesCommand,
+ DescribeNatGatewaysCommand,
+ DescribeNetworkAclsCommand,
+ DescribeNetworkInsightsAccessScopeAnalysesCommand,
+ DescribeNetworkInsightsAccessScopesCommand,
+ DescribeNetworkInsightsAnalysesCommand,
+ DescribeNetworkInsightsPathsCommand,
+ DescribeNetworkInterfaceAttributeCommand,
+ DescribeNetworkInterfacePermissionsCommand,
+ DescribeNetworkInterfacesCommand,
+ DescribePlacementGroupsCommand,
+ DescribePrefixListsCommand,
+ DescribePrincipalIdFormatCommand,
+ DescribePublicIpv4PoolsCommand,
+ DescribeRegionsCommand,
+ DescribeReplaceRootVolumeTasksCommand,
+ DescribeReservedInstancesCommand,
+ DescribeReservedInstancesListingsCommand,
+ DescribeReservedInstancesModificationsCommand,
+ DescribeReservedInstancesOfferingsCommand,
+ DescribeRouteTablesCommand,
+ DescribeScheduledInstanceAvailabilityCommand,
+ DescribeScheduledInstancesCommand,
+ DescribeSecurityGroupReferencesCommand,
+ DescribeSecurityGroupRulesCommand,
+ DescribeSecurityGroupsCommand,
+ DescribeSnapshotAttributeCommand,
+ DescribeSnapshotTierStatusCommand,
+ DescribeSnapshotsCommand,
+ DescribeSpotDatafeedSubscriptionCommand,
+ DescribeSpotFleetInstancesCommand,
+ DescribeSpotFleetRequestHistoryCommand,
+ DescribeSpotFleetRequestsCommand,
+ DescribeSpotInstanceRequestsCommand,
+ DescribeSpotPriceHistoryCommand,
+ DescribeStaleSecurityGroupsCommand,
+ DescribeStoreImageTasksCommand,
+ DescribeSubnetsCommand,
+ DescribeTagsCommand,
+ DescribeTrafficMirrorFiltersCommand,
+ DescribeTrafficMirrorSessionsCommand,
+ DescribeTrafficMirrorTargetsCommand,
+ DescribeTransitGatewayAttachmentsCommand,
+ DescribeTransitGatewayConnectPeersCommand,
+ DescribeTransitGatewayConnectsCommand,
+ DescribeTransitGatewayMulticastDomainsCommand,
+ DescribeTransitGatewayPeeringAttachmentsCommand,
+ DescribeTransitGatewayPolicyTablesCommand,
+ DescribeTransitGatewayRouteTableAnnouncementsCommand,
+ DescribeTransitGatewayRouteTablesCommand,
+ DescribeTransitGatewayVpcAttachmentsCommand,
+ DescribeTransitGatewaysCommand,
+ DescribeTrunkInterfaceAssociationsCommand,
+ DescribeVerifiedAccessEndpointsCommand,
+ DescribeVerifiedAccessGroupsCommand,
+ DescribeVerifiedAccessInstanceLoggingConfigurationsCommand,
+ DescribeVerifiedAccessInstancesCommand,
+ DescribeVerifiedAccessTrustProvidersCommand,
+ DescribeVolumeAttributeCommand,
+ DescribeVolumeStatusCommand,
+ DescribeVolumesCommand,
+ DescribeVolumesModificationsCommand,
+ DescribeVpcAttributeCommand,
+ DescribeVpcClassicLinkCommand,
+ DescribeVpcClassicLinkDnsSupportCommand,
+ DescribeVpcEndpointConnectionNotificationsCommand,
+ DescribeVpcEndpointConnectionsCommand,
+ DescribeVpcEndpointServiceConfigurationsCommand,
+ DescribeVpcEndpointServicePermissionsCommand,
+ DescribeVpcEndpointServicesCommand,
+ DescribeVpcEndpointsCommand,
+ DescribeVpcPeeringConnectionsCommand,
+ DescribeVpcsCommand,
+ DescribeVpnConnectionsCommand,
+ DescribeVpnGatewaysCommand,
+ DetachClassicLinkVpcCommand,
+ DetachInternetGatewayCommand,
+ DetachNetworkInterfaceCommand,
+ DetachVerifiedAccessTrustProviderCommand,
+ DetachVolumeCommand,
+ DetachVpnGatewayCommand,
+ DisableAddressTransferCommand,
+ DisableAwsNetworkPerformanceMetricSubscriptionCommand,
+ DisableEbsEncryptionByDefaultCommand,
+ DisableFastLaunchCommand,
+ DisableFastSnapshotRestoresCommand,
+ DisableImageCommand,
+ DisableImageBlockPublicAccessCommand,
+ DisableImageDeprecationCommand,
+ DisableIpamOrganizationAdminAccountCommand,
+ DisableSerialConsoleAccessCommand,
+ DisableSnapshotBlockPublicAccessCommand,
+ DisableTransitGatewayRouteTablePropagationCommand,
+ DisableVgwRoutePropagationCommand,
+ DisableVpcClassicLinkCommand,
+ DisableVpcClassicLinkDnsSupportCommand,
+ DisassociateAddressCommand,
+ DisassociateClientVpnTargetNetworkCommand,
+ DisassociateEnclaveCertificateIamRoleCommand,
+ DisassociateIamInstanceProfileCommand,
+ DisassociateInstanceEventWindowCommand,
+ DisassociateIpamByoasnCommand,
+ DisassociateIpamResourceDiscoveryCommand,
+ DisassociateNatGatewayAddressCommand,
+ DisassociateRouteTableCommand,
+ DisassociateSubnetCidrBlockCommand,
+ DisassociateTransitGatewayMulticastDomainCommand,
+ DisassociateTransitGatewayPolicyTableCommand,
+ DisassociateTransitGatewayRouteTableCommand,
+ DisassociateTrunkInterfaceCommand,
+ DisassociateVpcCidrBlockCommand,
+ EnableAddressTransferCommand,
+ EnableAwsNetworkPerformanceMetricSubscriptionCommand,
+ EnableEbsEncryptionByDefaultCommand,
+ EnableFastLaunchCommand,
+ EnableFastSnapshotRestoresCommand,
+ EnableImageCommand,
+ EnableImageBlockPublicAccessCommand,
+ EnableImageDeprecationCommand,
+ EnableIpamOrganizationAdminAccountCommand,
+ EnableReachabilityAnalyzerOrganizationSharingCommand,
+ EnableSerialConsoleAccessCommand,
+ EnableSnapshotBlockPublicAccessCommand,
+ EnableTransitGatewayRouteTablePropagationCommand,
+ EnableVgwRoutePropagationCommand,
+ EnableVolumeIOCommand,
+ EnableVpcClassicLinkCommand,
+ EnableVpcClassicLinkDnsSupportCommand,
+ ExportClientVpnClientCertificateRevocationListCommand,
+ ExportClientVpnClientConfigurationCommand,
+ ExportImageCommand,
+ ExportTransitGatewayRoutesCommand,
+ GetAssociatedEnclaveCertificateIamRolesCommand,
+ GetAssociatedIpv6PoolCidrsCommand,
+ GetAwsNetworkPerformanceDataCommand,
+ GetCapacityReservationUsageCommand,
+ GetCoipPoolUsageCommand,
+ GetConsoleOutputCommand,
+ GetConsoleScreenshotCommand,
+ GetDefaultCreditSpecificationCommand,
+ GetEbsDefaultKmsKeyIdCommand,
+ GetEbsEncryptionByDefaultCommand,
+ GetFlowLogsIntegrationTemplateCommand,
+ GetGroupsForCapacityReservationCommand,
+ GetHostReservationPurchasePreviewCommand,
+ GetImageBlockPublicAccessStateCommand,
+ GetInstanceMetadataDefaultsCommand,
+ GetInstanceTypesFromInstanceRequirementsCommand,
+ GetInstanceUefiDataCommand,
+ GetIpamAddressHistoryCommand,
+ GetIpamDiscoveredAccountsCommand,
+ GetIpamDiscoveredPublicAddressesCommand,
+ GetIpamDiscoveredResourceCidrsCommand,
+ GetIpamPoolAllocationsCommand,
+ GetIpamPoolCidrsCommand,
+ GetIpamResourceCidrsCommand,
+ GetLaunchTemplateDataCommand,
+ GetManagedPrefixListAssociationsCommand,
+ GetManagedPrefixListEntriesCommand,
+ GetNetworkInsightsAccessScopeAnalysisFindingsCommand,
+ GetNetworkInsightsAccessScopeContentCommand,
+ GetPasswordDataCommand,
+ GetReservedInstancesExchangeQuoteCommand,
+ GetSecurityGroupsForVpcCommand,
+ GetSerialConsoleAccessStatusCommand,
+ GetSnapshotBlockPublicAccessStateCommand,
+ GetSpotPlacementScoresCommand,
+ GetSubnetCidrReservationsCommand,
+ GetTransitGatewayAttachmentPropagationsCommand,
+ GetTransitGatewayMulticastDomainAssociationsCommand,
+ GetTransitGatewayPolicyTableAssociationsCommand,
+ GetTransitGatewayPolicyTableEntriesCommand,
+ GetTransitGatewayPrefixListReferencesCommand,
+ GetTransitGatewayRouteTableAssociationsCommand,
+ GetTransitGatewayRouteTablePropagationsCommand,
+ GetVerifiedAccessEndpointPolicyCommand,
+ GetVerifiedAccessGroupPolicyCommand,
+ GetVpnConnectionDeviceSampleConfigurationCommand,
+ GetVpnConnectionDeviceTypesCommand,
+ GetVpnTunnelReplacementStatusCommand,
+ ImportClientVpnClientCertificateRevocationListCommand,
+ ImportImageCommand,
+ ImportInstanceCommand,
+ ImportKeyPairCommand,
+ ImportSnapshotCommand,
+ ImportVolumeCommand,
+ ListImagesInRecycleBinCommand,
+ ListSnapshotsInRecycleBinCommand,
+ LockSnapshotCommand,
+ ModifyAddressAttributeCommand,
+ ModifyAvailabilityZoneGroupCommand,
+ ModifyCapacityReservationCommand,
+ ModifyCapacityReservationFleetCommand,
+ ModifyClientVpnEndpointCommand,
+ ModifyDefaultCreditSpecificationCommand,
+ ModifyEbsDefaultKmsKeyIdCommand,
+ ModifyFleetCommand,
+ ModifyFpgaImageAttributeCommand,
+ ModifyHostsCommand,
+ ModifyIdFormatCommand,
+ ModifyIdentityIdFormatCommand,
+ ModifyImageAttributeCommand,
+ ModifyInstanceAttributeCommand,
+ ModifyInstanceCapacityReservationAttributesCommand,
+ ModifyInstanceCreditSpecificationCommand,
+ ModifyInstanceEventStartTimeCommand,
+ ModifyInstanceEventWindowCommand,
+ ModifyInstanceMaintenanceOptionsCommand,
+ ModifyInstanceMetadataDefaultsCommand,
+ ModifyInstanceMetadataOptionsCommand,
+ ModifyInstancePlacementCommand,
+ ModifyIpamCommand,
+ ModifyIpamPoolCommand,
+ ModifyIpamResourceCidrCommand,
+ ModifyIpamResourceDiscoveryCommand,
+ ModifyIpamScopeCommand,
+ ModifyLaunchTemplateCommand,
+ ModifyLocalGatewayRouteCommand,
+ ModifyManagedPrefixListCommand,
+ ModifyNetworkInterfaceAttributeCommand,
+ ModifyPrivateDnsNameOptionsCommand,
+ ModifyReservedInstancesCommand,
+ ModifySecurityGroupRulesCommand,
+ ModifySnapshotAttributeCommand,
+ ModifySnapshotTierCommand,
+ ModifySpotFleetRequestCommand,
+ ModifySubnetAttributeCommand,
+ ModifyTrafficMirrorFilterNetworkServicesCommand,
+ ModifyTrafficMirrorFilterRuleCommand,
+ ModifyTrafficMirrorSessionCommand,
+ ModifyTransitGatewayCommand,
+ ModifyTransitGatewayPrefixListReferenceCommand,
+ ModifyTransitGatewayVpcAttachmentCommand,
+ ModifyVerifiedAccessEndpointCommand,
+ ModifyVerifiedAccessEndpointPolicyCommand,
+ ModifyVerifiedAccessGroupCommand,
+ ModifyVerifiedAccessGroupPolicyCommand,
+ ModifyVerifiedAccessInstanceCommand,
+ ModifyVerifiedAccessInstanceLoggingConfigurationCommand,
+ ModifyVerifiedAccessTrustProviderCommand,
+ ModifyVolumeCommand,
+ ModifyVolumeAttributeCommand,
+ ModifyVpcAttributeCommand,
+ ModifyVpcEndpointCommand,
+ ModifyVpcEndpointConnectionNotificationCommand,
+ ModifyVpcEndpointServiceConfigurationCommand,
+ ModifyVpcEndpointServicePayerResponsibilityCommand,
+ ModifyVpcEndpointServicePermissionsCommand,
+ ModifyVpcPeeringConnectionOptionsCommand,
+ ModifyVpcTenancyCommand,
+ ModifyVpnConnectionCommand,
+ ModifyVpnConnectionOptionsCommand,
+ ModifyVpnTunnelCertificateCommand,
+ ModifyVpnTunnelOptionsCommand,
+ MonitorInstancesCommand,
+ MoveAddressToVpcCommand,
+ MoveByoipCidrToIpamCommand,
+ ProvisionByoipCidrCommand,
+ ProvisionIpamByoasnCommand,
+ ProvisionIpamPoolCidrCommand,
+ ProvisionPublicIpv4PoolCidrCommand,
+ PurchaseCapacityBlockCommand,
+ PurchaseHostReservationCommand,
+ PurchaseReservedInstancesOfferingCommand,
+ PurchaseScheduledInstancesCommand,
+ RebootInstancesCommand,
+ RegisterImageCommand,
+ RegisterInstanceEventNotificationAttributesCommand,
+ RegisterTransitGatewayMulticastGroupMembersCommand,
+ RegisterTransitGatewayMulticastGroupSourcesCommand,
+ RejectTransitGatewayMulticastDomainAssociationsCommand,
+ RejectTransitGatewayPeeringAttachmentCommand,
+ RejectTransitGatewayVpcAttachmentCommand,
+ RejectVpcEndpointConnectionsCommand,
+ RejectVpcPeeringConnectionCommand,
+ ReleaseAddressCommand,
+ ReleaseHostsCommand,
+ ReleaseIpamPoolAllocationCommand,
+ ReplaceIamInstanceProfileAssociationCommand,
+ ReplaceNetworkAclAssociationCommand,
+ ReplaceNetworkAclEntryCommand,
+ ReplaceRouteCommand,
+ ReplaceRouteTableAssociationCommand,
+ ReplaceTransitGatewayRouteCommand,
+ ReplaceVpnTunnelCommand,
+ ReportInstanceStatusCommand,
+ RequestSpotFleetCommand,
+ RequestSpotInstancesCommand,
+ ResetAddressAttributeCommand,
+ ResetEbsDefaultKmsKeyIdCommand,
+ ResetFpgaImageAttributeCommand,
+ ResetImageAttributeCommand,
+ ResetInstanceAttributeCommand,
+ ResetNetworkInterfaceAttributeCommand,
+ ResetSnapshotAttributeCommand,
+ RestoreAddressToClassicCommand,
+ RestoreImageFromRecycleBinCommand,
+ RestoreManagedPrefixListVersionCommand,
+ RestoreSnapshotFromRecycleBinCommand,
+ RestoreSnapshotTierCommand,
+ RevokeClientVpnIngressCommand,
+ RevokeSecurityGroupEgressCommand,
+ RevokeSecurityGroupIngressCommand,
+ RunInstancesCommand,
+ RunScheduledInstancesCommand,
+ SearchLocalGatewayRoutesCommand,
+ SearchTransitGatewayMulticastGroupsCommand,
+ SearchTransitGatewayRoutesCommand,
+ SendDiagnosticInterruptCommand,
+ StartInstancesCommand,
+ StartNetworkInsightsAccessScopeAnalysisCommand,
+ StartNetworkInsightsAnalysisCommand,
+ StartVpcEndpointServicePrivateDnsVerificationCommand,
+ StopInstancesCommand,
+ TerminateClientVpnConnectionsCommand,
+ TerminateInstancesCommand,
+ UnassignIpv6AddressesCommand,
+ UnassignPrivateIpAddressesCommand,
+ UnassignPrivateNatGatewayAddressCommand,
+ UnlockSnapshotCommand,
+ UnmonitorInstancesCommand,
+ UpdateSecurityGroupRuleDescriptionsEgressCommand,
+ UpdateSecurityGroupRuleDescriptionsIngressCommand,
+ WithdrawByoipCidrCommand
 };
 
 /**
  * @since 1.0.0
  * @category models
  */
-export type EC2Service = {
+export interface EC2Service {
   readonly _: unique symbol;
 
   /**
    * @see {@link AcceptAddressTransferCommand}
    */
-  readonly acceptAddressTransfer: (
-    args: AcceptAddressTransferCommandInput,
+  acceptAddressTransfer(
+    args: AcceptAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptAddressTransferCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptAddressTransferResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptReservedInstancesExchangeQuoteCommand}
    */
-  readonly acceptReservedInstancesExchangeQuote: (
-    args: AcceptReservedInstancesExchangeQuoteCommandInput,
+  acceptReservedInstancesExchangeQuote(
+    args: AcceptReservedInstancesExchangeQuoteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptReservedInstancesExchangeQuoteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptReservedInstancesExchangeQuoteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptTransitGatewayMulticastDomainAssociationsCommand}
    */
-  readonly acceptTransitGatewayMulticastDomainAssociations: (
-    args: AcceptTransitGatewayMulticastDomainAssociationsCommandInput,
+  acceptTransitGatewayMulticastDomainAssociations(
+    args: AcceptTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptTransitGatewayMulticastDomainAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptTransitGatewayMulticastDomainAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptTransitGatewayPeeringAttachmentCommand}
    */
-  readonly acceptTransitGatewayPeeringAttachment: (
-    args: AcceptTransitGatewayPeeringAttachmentCommandInput,
+  acceptTransitGatewayPeeringAttachment(
+    args: AcceptTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptTransitGatewayPeeringAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptTransitGatewayPeeringAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptTransitGatewayVpcAttachmentCommand}
    */
-  readonly acceptTransitGatewayVpcAttachment: (
-    args: AcceptTransitGatewayVpcAttachmentCommandInput,
+  acceptTransitGatewayVpcAttachment(
+    args: AcceptTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptTransitGatewayVpcAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptTransitGatewayVpcAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptVpcEndpointConnectionsCommand}
    */
-  readonly acceptVpcEndpointConnections: (
-    args: AcceptVpcEndpointConnectionsCommandInput,
+  acceptVpcEndpointConnections(
+    args: AcceptVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptVpcEndpointConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptVpcEndpointConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AcceptVpcPeeringConnectionCommand}
    */
-  readonly acceptVpcPeeringConnection: (
-    args: AcceptVpcPeeringConnectionCommandInput,
+  acceptVpcPeeringConnection(
+    args: AcceptVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AcceptVpcPeeringConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AcceptVpcPeeringConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AdvertiseByoipCidrCommand}
    */
-  readonly advertiseByoipCidr: (
-    args: AdvertiseByoipCidrCommandInput,
+  advertiseByoipCidr(
+    args: AdvertiseByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AdvertiseByoipCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AdvertiseByoipCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AllocateAddressCommand}
    */
-  readonly allocateAddress: (
-    args: AllocateAddressCommandInput,
+  allocateAddress(
+    args: AllocateAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<AllocateAddressCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  AllocateAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AllocateHostsCommand}
    */
-  readonly allocateHosts: (
-    args: AllocateHostsCommandInput,
+  allocateHosts(
+    args: AllocateHostsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<AllocateHostsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  AllocateHostsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AllocateIpamPoolCidrCommand}
    */
-  readonly allocateIpamPoolCidr: (
-    args: AllocateIpamPoolCidrCommandInput,
+  allocateIpamPoolCidr(
+    args: AllocateIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AllocateIpamPoolCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AllocateIpamPoolCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ApplySecurityGroupsToClientVpnTargetNetworkCommand}
    */
-  readonly applySecurityGroupsToClientVpnTargetNetwork: (
-    args: ApplySecurityGroupsToClientVpnTargetNetworkCommandInput,
+  applySecurityGroupsToClientVpnTargetNetwork(
+    args: ApplySecurityGroupsToClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ApplySecurityGroupsToClientVpnTargetNetworkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ApplySecurityGroupsToClientVpnTargetNetworkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssignIpv6AddressesCommand}
    */
-  readonly assignIpv6Addresses: (
-    args: AssignIpv6AddressesCommandInput,
+  assignIpv6Addresses(
+    args: AssignIpv6AddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssignIpv6AddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssignIpv6AddressesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssignPrivateIpAddressesCommand}
    */
-  readonly assignPrivateIpAddresses: (
-    args: AssignPrivateIpAddressesCommandInput,
+  assignPrivateIpAddresses(
+    args: AssignPrivateIpAddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssignPrivateIpAddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssignPrivateIpAddressesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssignPrivateNatGatewayAddressCommand}
    */
-  readonly assignPrivateNatGatewayAddress: (
-    args: AssignPrivateNatGatewayAddressCommandInput,
+  assignPrivateNatGatewayAddress(
+    args: AssignPrivateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssignPrivateNatGatewayAddressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssignPrivateNatGatewayAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateAddressCommand}
    */
-  readonly associateAddress: (
-    args: AssociateAddressCommandInput,
+  associateAddress(
+    args: AssociateAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<AssociateAddressCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  AssociateAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateClientVpnTargetNetworkCommand}
    */
-  readonly associateClientVpnTargetNetwork: (
-    args: AssociateClientVpnTargetNetworkCommandInput,
+  associateClientVpnTargetNetwork(
+    args: AssociateClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateClientVpnTargetNetworkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateClientVpnTargetNetworkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateDhcpOptionsCommand}
    */
-  readonly associateDhcpOptions: (
-    args: AssociateDhcpOptionsCommandInput,
+  associateDhcpOptions(
+    args: AssociateDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateDhcpOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateEnclaveCertificateIamRoleCommand}
    */
-  readonly associateEnclaveCertificateIamRole: (
-    args: AssociateEnclaveCertificateIamRoleCommandInput,
+  associateEnclaveCertificateIamRole(
+    args: AssociateEnclaveCertificateIamRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateEnclaveCertificateIamRoleCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateEnclaveCertificateIamRoleResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateIamInstanceProfileCommand}
    */
-  readonly associateIamInstanceProfile: (
-    args: AssociateIamInstanceProfileCommandInput,
+  associateIamInstanceProfile(
+    args: AssociateIamInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateIamInstanceProfileCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateIamInstanceProfileResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateInstanceEventWindowCommand}
    */
-  readonly associateInstanceEventWindow: (
-    args: AssociateInstanceEventWindowCommandInput,
+  associateInstanceEventWindow(
+    args: AssociateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateInstanceEventWindowCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateInstanceEventWindowResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateIpamByoasnCommand}
    */
-  readonly associateIpamByoasn: (
-    args: AssociateIpamByoasnCommandInput,
+  associateIpamByoasn(
+    args: AssociateIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateIpamByoasnCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateIpamByoasnResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateIpamResourceDiscoveryCommand}
    */
-  readonly associateIpamResourceDiscovery: (
-    args: AssociateIpamResourceDiscoveryCommandInput,
+  associateIpamResourceDiscovery(
+    args: AssociateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateIpamResourceDiscoveryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateIpamResourceDiscoveryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateNatGatewayAddressCommand}
    */
-  readonly associateNatGatewayAddress: (
-    args: AssociateNatGatewayAddressCommandInput,
+  associateNatGatewayAddress(
+    args: AssociateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateNatGatewayAddressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateNatGatewayAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateRouteTableCommand}
    */
-  readonly associateRouteTable: (
-    args: AssociateRouteTableCommandInput,
+  associateRouteTable(
+    args: AssociateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateSubnetCidrBlockCommand}
    */
-  readonly associateSubnetCidrBlock: (
-    args: AssociateSubnetCidrBlockCommandInput,
+  associateSubnetCidrBlock(
+    args: AssociateSubnetCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateSubnetCidrBlockCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateSubnetCidrBlockResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateTransitGatewayMulticastDomainCommand}
    */
-  readonly associateTransitGatewayMulticastDomain: (
-    args: AssociateTransitGatewayMulticastDomainCommandInput,
+  associateTransitGatewayMulticastDomain(
+    args: AssociateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateTransitGatewayMulticastDomainCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateTransitGatewayMulticastDomainResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateTransitGatewayPolicyTableCommand}
    */
-  readonly associateTransitGatewayPolicyTable: (
-    args: AssociateTransitGatewayPolicyTableCommandInput,
+  associateTransitGatewayPolicyTable(
+    args: AssociateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateTransitGatewayPolicyTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateTransitGatewayPolicyTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateTransitGatewayRouteTableCommand}
    */
-  readonly associateTransitGatewayRouteTable: (
-    args: AssociateTransitGatewayRouteTableCommandInput,
+  associateTransitGatewayRouteTable(
+    args: AssociateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateTransitGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateTransitGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateTrunkInterfaceCommand}
    */
-  readonly associateTrunkInterface: (
-    args: AssociateTrunkInterfaceCommandInput,
+  associateTrunkInterface(
+    args: AssociateTrunkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateTrunkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateTrunkInterfaceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AssociateVpcCidrBlockCommand}
    */
-  readonly associateVpcCidrBlock: (
-    args: AssociateVpcCidrBlockCommandInput,
+  associateVpcCidrBlock(
+    args: AssociateVpcCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AssociateVpcCidrBlockCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AssociateVpcCidrBlockResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachClassicLinkVpcCommand}
    */
-  readonly attachClassicLinkVpc: (
-    args: AttachClassicLinkVpcCommandInput,
+  attachClassicLinkVpc(
+    args: AttachClassicLinkVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachClassicLinkVpcCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AttachClassicLinkVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachInternetGatewayCommand}
    */
-  readonly attachInternetGateway: (
-    args: AttachInternetGatewayCommandInput,
+  attachInternetGateway(
+    args: AttachInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachNetworkInterfaceCommand}
    */
-  readonly attachNetworkInterface: (
-    args: AttachNetworkInterfaceCommandInput,
+  attachNetworkInterface(
+    args: AttachNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachNetworkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AttachNetworkInterfaceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachVerifiedAccessTrustProviderCommand}
    */
-  readonly attachVerifiedAccessTrustProvider: (
-    args: AttachVerifiedAccessTrustProviderCommandInput,
+  attachVerifiedAccessTrustProvider(
+    args: AttachVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachVerifiedAccessTrustProviderCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AttachVerifiedAccessTrustProviderResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachVolumeCommand}
    */
-  readonly attachVolume: (
-    args: AttachVolumeCommandInput,
+  attachVolume(
+    args: AttachVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<AttachVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  VolumeAttachment,
+    | SdkError
+  >
 
   /**
    * @see {@link AttachVpnGatewayCommand}
    */
-  readonly attachVpnGateway: (
-    args: AttachVpnGatewayCommandInput,
+  attachVpnGateway(
+    args: AttachVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<AttachVpnGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  AttachVpnGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AuthorizeClientVpnIngressCommand}
    */
-  readonly authorizeClientVpnIngress: (
-    args: AuthorizeClientVpnIngressCommandInput,
+  authorizeClientVpnIngress(
+    args: AuthorizeClientVpnIngressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AuthorizeClientVpnIngressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AuthorizeClientVpnIngressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AuthorizeSecurityGroupEgressCommand}
    */
-  readonly authorizeSecurityGroupEgress: (
-    args: AuthorizeSecurityGroupEgressCommandInput,
+  authorizeSecurityGroupEgress(
+    args: AuthorizeSecurityGroupEgressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AuthorizeSecurityGroupEgressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AuthorizeSecurityGroupEgressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link AuthorizeSecurityGroupIngressCommand}
    */
-  readonly authorizeSecurityGroupIngress: (
-    args: AuthorizeSecurityGroupIngressCommandInput,
+  authorizeSecurityGroupIngress(
+    args: AuthorizeSecurityGroupIngressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AuthorizeSecurityGroupIngressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  AuthorizeSecurityGroupIngressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link BundleInstanceCommand}
    */
-  readonly bundleInstance: (
-    args: BundleInstanceCommandInput,
+  bundleInstance(
+    args: BundleInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<BundleInstanceCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  BundleInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelBundleTaskCommand}
    */
-  readonly cancelBundleTask: (
-    args: CancelBundleTaskCommandInput,
+  cancelBundleTask(
+    args: CancelBundleTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CancelBundleTaskCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CancelBundleTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelCapacityReservationCommand}
    */
-  readonly cancelCapacityReservation: (
-    args: CancelCapacityReservationCommandInput,
+  cancelCapacityReservation(
+    args: CancelCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelCapacityReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelCapacityReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelCapacityReservationFleetsCommand}
    */
-  readonly cancelCapacityReservationFleets: (
-    args: CancelCapacityReservationFleetsCommandInput,
+  cancelCapacityReservationFleets(
+    args: CancelCapacityReservationFleetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelCapacityReservationFleetsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelCapacityReservationFleetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelConversionTaskCommand}
    */
-  readonly cancelConversionTask: (
-    args: CancelConversionTaskCommandInput,
+  cancelConversionTask(
+    args: CancelConversionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelConversionTaskCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelExportTaskCommand}
    */
-  readonly cancelExportTask: (
-    args: CancelExportTaskCommandInput,
+  cancelExportTask(
+    args: CancelExportTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CancelExportTaskCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelImageLaunchPermissionCommand}
    */
-  readonly cancelImageLaunchPermission: (
-    args: CancelImageLaunchPermissionCommandInput,
+  cancelImageLaunchPermission(
+    args: CancelImageLaunchPermissionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelImageLaunchPermissionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelImageLaunchPermissionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelImportTaskCommand}
    */
-  readonly cancelImportTask: (
-    args: CancelImportTaskCommandInput,
+  cancelImportTask(
+    args: CancelImportTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CancelImportTaskCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CancelImportTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelReservedInstancesListingCommand}
    */
-  readonly cancelReservedInstancesListing: (
-    args: CancelReservedInstancesListingCommandInput,
+  cancelReservedInstancesListing(
+    args: CancelReservedInstancesListingRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelReservedInstancesListingCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelReservedInstancesListingResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelSpotFleetRequestsCommand}
    */
-  readonly cancelSpotFleetRequests: (
-    args: CancelSpotFleetRequestsCommandInput,
+  cancelSpotFleetRequests(
+    args: CancelSpotFleetRequestsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelSpotFleetRequestsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelSpotFleetRequestsResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link CancelSpotInstanceRequestsCommand}
    */
-  readonly cancelSpotInstanceRequests: (
-    args: CancelSpotInstanceRequestsCommandInput,
+  cancelSpotInstanceRequests(
+    args: CancelSpotInstanceRequestsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CancelSpotInstanceRequestsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CancelSpotInstanceRequestsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ConfirmProductInstanceCommand}
    */
-  readonly confirmProductInstance: (
-    args: ConfirmProductInstanceCommandInput,
+  confirmProductInstance(
+    args: ConfirmProductInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ConfirmProductInstanceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ConfirmProductInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CopyFpgaImageCommand}
    */
-  readonly copyFpgaImage: (
-    args: CopyFpgaImageCommandInput,
+  copyFpgaImage(
+    args: CopyFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CopyFpgaImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CopyFpgaImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CopyImageCommand}
    */
-  readonly copyImage: (
-    args: CopyImageCommandInput,
+  copyImage(
+    args: CopyImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CopyImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CopyImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CopySnapshotCommand}
    */
-  readonly copySnapshot: (
-    args: CopySnapshotCommandInput,
+  copySnapshot(
+    args: CopySnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CopySnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CopySnapshotResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCapacityReservationCommand}
    */
-  readonly createCapacityReservation: (
-    args: CreateCapacityReservationCommandInput,
+  createCapacityReservation(
+    args: CreateCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateCapacityReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateCapacityReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCapacityReservationFleetCommand}
    */
-  readonly createCapacityReservationFleet: (
-    args: CreateCapacityReservationFleetCommandInput,
+  createCapacityReservationFleet(
+    args: CreateCapacityReservationFleetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateCapacityReservationFleetCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateCapacityReservationFleetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCarrierGatewayCommand}
    */
-  readonly createCarrierGateway: (
-    args: CreateCarrierGatewayCommandInput,
+  createCarrierGateway(
+    args: CreateCarrierGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateCarrierGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateCarrierGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateClientVpnEndpointCommand}
    */
-  readonly createClientVpnEndpoint: (
-    args: CreateClientVpnEndpointCommandInput,
+  createClientVpnEndpoint(
+    args: CreateClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateClientVpnEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateClientVpnEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateClientVpnRouteCommand}
    */
-  readonly createClientVpnRoute: (
-    args: CreateClientVpnRouteCommandInput,
+  createClientVpnRoute(
+    args: CreateClientVpnRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateClientVpnRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateClientVpnRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCoipCidrCommand}
    */
-  readonly createCoipCidr: (
-    args: CreateCoipCidrCommandInput,
+  createCoipCidr(
+    args: CreateCoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateCoipCidrCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateCoipCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCoipPoolCommand}
    */
-  readonly createCoipPool: (
-    args: CreateCoipPoolCommandInput,
+  createCoipPool(
+    args: CreateCoipPoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateCoipPoolCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateCoipPoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateCustomerGatewayCommand}
    */
-  readonly createCustomerGateway: (
-    args: CreateCustomerGatewayCommandInput,
+  createCustomerGateway(
+    args: CreateCustomerGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateCustomerGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateCustomerGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateDefaultSubnetCommand}
    */
-  readonly createDefaultSubnet: (
-    args: CreateDefaultSubnetCommandInput,
+  createDefaultSubnet(
+    args: CreateDefaultSubnetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateDefaultSubnetCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateDefaultSubnetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateDefaultVpcCommand}
    */
-  readonly createDefaultVpc: (
-    args: CreateDefaultVpcCommandInput,
+  createDefaultVpc(
+    args: CreateDefaultVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateDefaultVpcCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateDefaultVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateDhcpOptionsCommand}
    */
-  readonly createDhcpOptions: (
-    args: CreateDhcpOptionsCommandInput,
+  createDhcpOptions(
+    args: CreateDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateDhcpOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateDhcpOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateEgressOnlyInternetGatewayCommand}
    */
-  readonly createEgressOnlyInternetGateway: (
-    args: CreateEgressOnlyInternetGatewayCommandInput,
+  createEgressOnlyInternetGateway(
+    args: CreateEgressOnlyInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateEgressOnlyInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateEgressOnlyInternetGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateFleetCommand}
    */
-  readonly createFleet: (
-    args: CreateFleetCommandInput,
+  createFleet(
+    args: CreateFleetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateFleetCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateFleetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateFlowLogsCommand}
    */
-  readonly createFlowLogs: (
-    args: CreateFlowLogsCommandInput,
+  createFlowLogs(
+    args: CreateFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateFlowLogsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateFlowLogsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateFpgaImageCommand}
    */
-  readonly createFpgaImage: (
-    args: CreateFpgaImageCommandInput,
+  createFpgaImage(
+    args: CreateFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateFpgaImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateFpgaImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateImageCommand}
    */
-  readonly createImage: (
-    args: CreateImageCommandInput,
+  createImage(
+    args: CreateImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateInstanceConnectEndpointCommand}
    */
-  readonly createInstanceConnectEndpoint: (
-    args: CreateInstanceConnectEndpointCommandInput,
+  createInstanceConnectEndpoint(
+    args: CreateInstanceConnectEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateInstanceConnectEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateInstanceConnectEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateInstanceEventWindowCommand}
    */
-  readonly createInstanceEventWindow: (
-    args: CreateInstanceEventWindowCommandInput,
+  createInstanceEventWindow(
+    args: CreateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateInstanceEventWindowCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateInstanceEventWindowResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateInstanceExportTaskCommand}
    */
-  readonly createInstanceExportTask: (
-    args: CreateInstanceExportTaskCommandInput,
+  createInstanceExportTask(
+    args: CreateInstanceExportTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateInstanceExportTaskCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateInstanceExportTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateInternetGatewayCommand}
    */
-  readonly createInternetGateway: (
-    args: CreateInternetGatewayCommandInput,
+  createInternetGateway(
+    args: CreateInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateInternetGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateIpamCommand}
    */
-  readonly createIpam: (
-    args: CreateIpamCommandInput,
+  createIpam(
+    args: CreateIpamRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateIpamCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateIpamResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateIpamPoolCommand}
    */
-  readonly createIpamPool: (
-    args: CreateIpamPoolCommandInput,
+  createIpamPool(
+    args: CreateIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateIpamPoolCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateIpamPoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateIpamResourceDiscoveryCommand}
    */
-  readonly createIpamResourceDiscovery: (
-    args: CreateIpamResourceDiscoveryCommandInput,
+  createIpamResourceDiscovery(
+    args: CreateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateIpamResourceDiscoveryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateIpamResourceDiscoveryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateIpamScopeCommand}
    */
-  readonly createIpamScope: (
-    args: CreateIpamScopeCommandInput,
+  createIpamScope(
+    args: CreateIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateIpamScopeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateIpamScopeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateKeyPairCommand}
    */
-  readonly createKeyPair: (
-    args: CreateKeyPairCommandInput,
+  createKeyPair(
+    args: CreateKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateKeyPairCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  KeyPair,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLaunchTemplateCommand}
    */
-  readonly createLaunchTemplate: (
-    args: CreateLaunchTemplateCommandInput,
+  createLaunchTemplate(
+    args: CreateLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLaunchTemplateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLaunchTemplateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLaunchTemplateVersionCommand}
    */
-  readonly createLaunchTemplateVersion: (
-    args: CreateLaunchTemplateVersionCommandInput,
+  createLaunchTemplateVersion(
+    args: CreateLaunchTemplateVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLaunchTemplateVersionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLaunchTemplateVersionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLocalGatewayRouteCommand}
    */
-  readonly createLocalGatewayRoute: (
-    args: CreateLocalGatewayRouteCommandInput,
+  createLocalGatewayRoute(
+    args: CreateLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLocalGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLocalGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLocalGatewayRouteTableCommand}
    */
-  readonly createLocalGatewayRouteTable: (
-    args: CreateLocalGatewayRouteTableCommandInput,
+  createLocalGatewayRouteTable(
+    args: CreateLocalGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLocalGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLocalGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand}
    */
-  readonly createLocalGatewayRouteTableVirtualInterfaceGroupAssociation: (
-    args: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
+  createLocalGatewayRouteTableVirtualInterfaceGroupAssociation(
+    args: CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateLocalGatewayRouteTableVpcAssociationCommand}
    */
-  readonly createLocalGatewayRouteTableVpcAssociation: (
-    args: CreateLocalGatewayRouteTableVpcAssociationCommandInput,
+  createLocalGatewayRouteTableVpcAssociation(
+    args: CreateLocalGatewayRouteTableVpcAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLocalGatewayRouteTableVpcAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateLocalGatewayRouteTableVpcAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateManagedPrefixListCommand}
    */
-  readonly createManagedPrefixList: (
-    args: CreateManagedPrefixListCommandInput,
+  createManagedPrefixList(
+    args: CreateManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateManagedPrefixListCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateManagedPrefixListResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNatGatewayCommand}
    */
-  readonly createNatGateway: (
-    args: CreateNatGatewayCommandInput,
+  createNatGateway(
+    args: CreateNatGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateNatGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateNatGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkAclCommand}
    */
-  readonly createNetworkAcl: (
-    args: CreateNetworkAclCommandInput,
+  createNetworkAcl(
+    args: CreateNetworkAclRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateNetworkAclCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateNetworkAclResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkAclEntryCommand}
    */
-  readonly createNetworkAclEntry: (
-    args: CreateNetworkAclEntryCommandInput,
+  createNetworkAclEntry(
+    args: CreateNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateNetworkAclEntryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkInsightsAccessScopeCommand}
    */
-  readonly createNetworkInsightsAccessScope: (
-    args: CreateNetworkInsightsAccessScopeCommandInput,
+  createNetworkInsightsAccessScope(
+    args: CreateNetworkInsightsAccessScopeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateNetworkInsightsAccessScopeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateNetworkInsightsAccessScopeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkInsightsPathCommand}
    */
-  readonly createNetworkInsightsPath: (
-    args: CreateNetworkInsightsPathCommandInput,
+  createNetworkInsightsPath(
+    args: CreateNetworkInsightsPathRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateNetworkInsightsPathCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateNetworkInsightsPathResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkInterfaceCommand}
    */
-  readonly createNetworkInterface: (
-    args: CreateNetworkInterfaceCommandInput,
+  createNetworkInterface(
+    args: CreateNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateNetworkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateNetworkInterfaceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateNetworkInterfacePermissionCommand}
    */
-  readonly createNetworkInterfacePermission: (
-    args: CreateNetworkInterfacePermissionCommandInput,
+  createNetworkInterfacePermission(
+    args: CreateNetworkInterfacePermissionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateNetworkInterfacePermissionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateNetworkInterfacePermissionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreatePlacementGroupCommand}
    */
-  readonly createPlacementGroup: (
-    args: CreatePlacementGroupCommandInput,
+  createPlacementGroup(
+    args: CreatePlacementGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreatePlacementGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreatePlacementGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreatePublicIpv4PoolCommand}
    */
-  readonly createPublicIpv4Pool: (
-    args: CreatePublicIpv4PoolCommandInput,
+  createPublicIpv4Pool(
+    args: CreatePublicIpv4PoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreatePublicIpv4PoolCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreatePublicIpv4PoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateReplaceRootVolumeTaskCommand}
    */
-  readonly createReplaceRootVolumeTask: (
-    args: CreateReplaceRootVolumeTaskCommandInput,
+  createReplaceRootVolumeTask(
+    args: CreateReplaceRootVolumeTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateReplaceRootVolumeTaskCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateReplaceRootVolumeTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateReservedInstancesListingCommand}
    */
-  readonly createReservedInstancesListing: (
-    args: CreateReservedInstancesListingCommandInput,
+  createReservedInstancesListing(
+    args: CreateReservedInstancesListingRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateReservedInstancesListingCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateReservedInstancesListingResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateRestoreImageTaskCommand}
    */
-  readonly createRestoreImageTask: (
-    args: CreateRestoreImageTaskCommandInput,
+  createRestoreImageTask(
+    args: CreateRestoreImageTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateRestoreImageTaskCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateRestoreImageTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateRouteCommand}
    */
-  readonly createRoute: (
-    args: CreateRouteCommandInput,
+  createRoute(
+    args: CreateRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateRouteCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateRouteTableCommand}
    */
-  readonly createRouteTable: (
-    args: CreateRouteTableCommandInput,
+  createRouteTable(
+    args: CreateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateRouteTableCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSecurityGroupCommand}
    */
-  readonly createSecurityGroup: (
-    args: CreateSecurityGroupCommandInput,
+  createSecurityGroup(
+    args: CreateSecurityGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateSecurityGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateSecurityGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSnapshotCommand}
    */
-  readonly createSnapshot: (
-    args: CreateSnapshotCommandInput,
+  createSnapshot(
+    args: CreateSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateSnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  Snapshot,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSnapshotsCommand}
    */
-  readonly createSnapshots: (
-    args: CreateSnapshotsCommandInput,
+  createSnapshots(
+    args: CreateSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateSnapshotsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateSnapshotsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSpotDatafeedSubscriptionCommand}
    */
-  readonly createSpotDatafeedSubscription: (
-    args: CreateSpotDatafeedSubscriptionCommandInput,
+  createSpotDatafeedSubscription(
+    args: CreateSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateSpotDatafeedSubscriptionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateSpotDatafeedSubscriptionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateStoreImageTaskCommand}
    */
-  readonly createStoreImageTask: (
-    args: CreateStoreImageTaskCommandInput,
+  createStoreImageTask(
+    args: CreateStoreImageTaskRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateStoreImageTaskCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateStoreImageTaskResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSubnetCommand}
    */
-  readonly createSubnet: (
-    args: CreateSubnetCommandInput,
+  createSubnet(
+    args: CreateSubnetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateSubnetCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateSubnetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateSubnetCidrReservationCommand}
    */
-  readonly createSubnetCidrReservation: (
-    args: CreateSubnetCidrReservationCommandInput,
+  createSubnetCidrReservation(
+    args: CreateSubnetCidrReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateSubnetCidrReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateSubnetCidrReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTagsCommand}
    */
-  readonly createTags: (
-    args: CreateTagsCommandInput,
+  createTags(
+    args: CreateTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateTagsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTrafficMirrorFilterCommand}
    */
-  readonly createTrafficMirrorFilter: (
-    args: CreateTrafficMirrorFilterCommandInput,
+  createTrafficMirrorFilter(
+    args: CreateTrafficMirrorFilterRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTrafficMirrorFilterCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTrafficMirrorFilterResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTrafficMirrorFilterRuleCommand}
    */
-  readonly createTrafficMirrorFilterRule: (
-    args: CreateTrafficMirrorFilterRuleCommandInput,
+  createTrafficMirrorFilterRule(
+    args: CreateTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTrafficMirrorFilterRuleCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTrafficMirrorFilterRuleResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTrafficMirrorSessionCommand}
    */
-  readonly createTrafficMirrorSession: (
-    args: CreateTrafficMirrorSessionCommandInput,
+  createTrafficMirrorSession(
+    args: CreateTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTrafficMirrorSessionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTrafficMirrorSessionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTrafficMirrorTargetCommand}
    */
-  readonly createTrafficMirrorTarget: (
-    args: CreateTrafficMirrorTargetCommandInput,
+  createTrafficMirrorTarget(
+    args: CreateTrafficMirrorTargetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTrafficMirrorTargetCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTrafficMirrorTargetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayCommand}
    */
-  readonly createTransitGateway: (
-    args: CreateTransitGatewayCommandInput,
+  createTransitGateway(
+    args: CreateTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayConnectCommand}
    */
-  readonly createTransitGatewayConnect: (
-    args: CreateTransitGatewayConnectCommandInput,
+  createTransitGatewayConnect(
+    args: CreateTransitGatewayConnectRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayConnectCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayConnectResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayConnectPeerCommand}
    */
-  readonly createTransitGatewayConnectPeer: (
-    args: CreateTransitGatewayConnectPeerCommandInput,
+  createTransitGatewayConnectPeer(
+    args: CreateTransitGatewayConnectPeerRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayConnectPeerCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayConnectPeerResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayMulticastDomainCommand}
    */
-  readonly createTransitGatewayMulticastDomain: (
-    args: CreateTransitGatewayMulticastDomainCommandInput,
+  createTransitGatewayMulticastDomain(
+    args: CreateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayMulticastDomainCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayMulticastDomainResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayPeeringAttachmentCommand}
    */
-  readonly createTransitGatewayPeeringAttachment: (
-    args: CreateTransitGatewayPeeringAttachmentCommandInput,
+  createTransitGatewayPeeringAttachment(
+    args: CreateTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayPeeringAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayPeeringAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayPolicyTableCommand}
    */
-  readonly createTransitGatewayPolicyTable: (
-    args: CreateTransitGatewayPolicyTableCommandInput,
+  createTransitGatewayPolicyTable(
+    args: CreateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayPolicyTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayPolicyTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayPrefixListReferenceCommand}
    */
-  readonly createTransitGatewayPrefixListReference: (
-    args: CreateTransitGatewayPrefixListReferenceCommandInput,
+  createTransitGatewayPrefixListReference(
+    args: CreateTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayPrefixListReferenceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayPrefixListReferenceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayRouteCommand}
    */
-  readonly createTransitGatewayRoute: (
-    args: CreateTransitGatewayRouteCommandInput,
+  createTransitGatewayRoute(
+    args: CreateTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayRouteTableCommand}
    */
-  readonly createTransitGatewayRouteTable: (
-    args: CreateTransitGatewayRouteTableCommandInput,
+  createTransitGatewayRouteTable(
+    args: CreateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayRouteTableAnnouncementCommand}
    */
-  readonly createTransitGatewayRouteTableAnnouncement: (
-    args: CreateTransitGatewayRouteTableAnnouncementCommandInput,
+  createTransitGatewayRouteTableAnnouncement(
+    args: CreateTransitGatewayRouteTableAnnouncementRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayRouteTableAnnouncementCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayRouteTableAnnouncementResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateTransitGatewayVpcAttachmentCommand}
    */
-  readonly createTransitGatewayVpcAttachment: (
-    args: CreateTransitGatewayVpcAttachmentCommandInput,
+  createTransitGatewayVpcAttachment(
+    args: CreateTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateTransitGatewayVpcAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateTransitGatewayVpcAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVerifiedAccessEndpointCommand}
    */
-  readonly createVerifiedAccessEndpoint: (
-    args: CreateVerifiedAccessEndpointCommandInput,
+  createVerifiedAccessEndpoint(
+    args: CreateVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVerifiedAccessEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVerifiedAccessEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVerifiedAccessGroupCommand}
    */
-  readonly createVerifiedAccessGroup: (
-    args: CreateVerifiedAccessGroupCommandInput,
+  createVerifiedAccessGroup(
+    args: CreateVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVerifiedAccessGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVerifiedAccessGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVerifiedAccessInstanceCommand}
    */
-  readonly createVerifiedAccessInstance: (
-    args: CreateVerifiedAccessInstanceCommandInput,
+  createVerifiedAccessInstance(
+    args: CreateVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVerifiedAccessInstanceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVerifiedAccessInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVerifiedAccessTrustProviderCommand}
    */
-  readonly createVerifiedAccessTrustProvider: (
-    args: CreateVerifiedAccessTrustProviderCommandInput,
+  createVerifiedAccessTrustProvider(
+    args: CreateVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVerifiedAccessTrustProviderCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVerifiedAccessTrustProviderResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVolumeCommand}
    */
-  readonly createVolume: (
-    args: CreateVolumeCommandInput,
+  createVolume(
+    args: CreateVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  Volume,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpcCommand}
    */
-  readonly createVpc: (
-    args: CreateVpcCommandInput,
+  createVpc(
+    args: CreateVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateVpcCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpcEndpointCommand}
    */
-  readonly createVpcEndpoint: (
-    args: CreateVpcEndpointCommandInput,
+  createVpcEndpoint(
+    args: CreateVpcEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpcEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVpcEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpcEndpointConnectionNotificationCommand}
    */
-  readonly createVpcEndpointConnectionNotification: (
-    args: CreateVpcEndpointConnectionNotificationCommandInput,
+  createVpcEndpointConnectionNotification(
+    args: CreateVpcEndpointConnectionNotificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpcEndpointConnectionNotificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVpcEndpointConnectionNotificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpcEndpointServiceConfigurationCommand}
    */
-  readonly createVpcEndpointServiceConfiguration: (
-    args: CreateVpcEndpointServiceConfigurationCommandInput,
+  createVpcEndpointServiceConfiguration(
+    args: CreateVpcEndpointServiceConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpcEndpointServiceConfigurationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVpcEndpointServiceConfigurationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpcPeeringConnectionCommand}
    */
-  readonly createVpcPeeringConnection: (
-    args: CreateVpcPeeringConnectionCommandInput,
+  createVpcPeeringConnection(
+    args: CreateVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpcPeeringConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVpcPeeringConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpnConnectionCommand}
    */
-  readonly createVpnConnection: (
-    args: CreateVpnConnectionCommandInput,
+  createVpnConnection(
+    args: CreateVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpnConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  CreateVpnConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpnConnectionRouteCommand}
    */
-  readonly createVpnConnectionRoute: (
-    args: CreateVpnConnectionRouteCommandInput,
+  createVpnConnectionRoute(
+    args: CreateVpnConnectionRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVpnConnectionRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link CreateVpnGatewayCommand}
    */
-  readonly createVpnGateway: (
-    args: CreateVpnGatewayCommandInput,
+  createVpnGateway(
+    args: CreateVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<CreateVpnGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  CreateVpnGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteCarrierGatewayCommand}
    */
-  readonly deleteCarrierGateway: (
-    args: DeleteCarrierGatewayCommandInput,
+  deleteCarrierGateway(
+    args: DeleteCarrierGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteCarrierGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteCarrierGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteClientVpnEndpointCommand}
    */
-  readonly deleteClientVpnEndpoint: (
-    args: DeleteClientVpnEndpointCommandInput,
+  deleteClientVpnEndpoint(
+    args: DeleteClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteClientVpnEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteClientVpnEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteClientVpnRouteCommand}
    */
-  readonly deleteClientVpnRoute: (
-    args: DeleteClientVpnRouteCommandInput,
+  deleteClientVpnRoute(
+    args: DeleteClientVpnRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteClientVpnRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteClientVpnRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteCoipCidrCommand}
    */
-  readonly deleteCoipCidr: (
-    args: DeleteCoipCidrCommandInput,
+  deleteCoipCidr(
+    args: DeleteCoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteCoipCidrCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteCoipCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteCoipPoolCommand}
    */
-  readonly deleteCoipPool: (
-    args: DeleteCoipPoolCommandInput,
+  deleteCoipPool(
+    args: DeleteCoipPoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteCoipPoolCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteCoipPoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteCustomerGatewayCommand}
    */
-  readonly deleteCustomerGateway: (
-    args: DeleteCustomerGatewayCommandInput,
+  deleteCustomerGateway(
+    args: DeleteCustomerGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteCustomerGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteDhcpOptionsCommand}
    */
-  readonly deleteDhcpOptions: (
-    args: DeleteDhcpOptionsCommandInput,
+  deleteDhcpOptions(
+    args: DeleteDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteDhcpOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteEgressOnlyInternetGatewayCommand}
    */
-  readonly deleteEgressOnlyInternetGateway: (
-    args: DeleteEgressOnlyInternetGatewayCommandInput,
+  deleteEgressOnlyInternetGateway(
+    args: DeleteEgressOnlyInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteEgressOnlyInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteEgressOnlyInternetGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteFleetsCommand}
    */
-  readonly deleteFleets: (
-    args: DeleteFleetsCommandInput,
+  deleteFleets(
+    args: DeleteFleetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteFleetsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteFleetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteFlowLogsCommand}
    */
-  readonly deleteFlowLogs: (
-    args: DeleteFlowLogsCommandInput,
+  deleteFlowLogs(
+    args: DeleteFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteFlowLogsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteFlowLogsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteFpgaImageCommand}
    */
-  readonly deleteFpgaImage: (
-    args: DeleteFpgaImageCommandInput,
+  deleteFpgaImage(
+    args: DeleteFpgaImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteFpgaImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteFpgaImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteInstanceConnectEndpointCommand}
    */
-  readonly deleteInstanceConnectEndpoint: (
-    args: DeleteInstanceConnectEndpointCommandInput,
+  deleteInstanceConnectEndpoint(
+    args: DeleteInstanceConnectEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteInstanceConnectEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteInstanceConnectEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteInstanceEventWindowCommand}
    */
-  readonly deleteInstanceEventWindow: (
-    args: DeleteInstanceEventWindowCommandInput,
+  deleteInstanceEventWindow(
+    args: DeleteInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteInstanceEventWindowCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteInstanceEventWindowResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteInternetGatewayCommand}
    */
-  readonly deleteInternetGateway: (
-    args: DeleteInternetGatewayCommandInput,
+  deleteInternetGateway(
+    args: DeleteInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteIpamCommand}
    */
-  readonly deleteIpam: (
-    args: DeleteIpamCommandInput,
+  deleteIpam(
+    args: DeleteIpamRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteIpamCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteIpamResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteIpamPoolCommand}
    */
-  readonly deleteIpamPool: (
-    args: DeleteIpamPoolCommandInput,
+  deleteIpamPool(
+    args: DeleteIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteIpamPoolCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteIpamPoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteIpamResourceDiscoveryCommand}
    */
-  readonly deleteIpamResourceDiscovery: (
-    args: DeleteIpamResourceDiscoveryCommandInput,
+  deleteIpamResourceDiscovery(
+    args: DeleteIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteIpamResourceDiscoveryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteIpamResourceDiscoveryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteIpamScopeCommand}
    */
-  readonly deleteIpamScope: (
-    args: DeleteIpamScopeCommandInput,
+  deleteIpamScope(
+    args: DeleteIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteIpamScopeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteIpamScopeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteKeyPairCommand}
    */
-  readonly deleteKeyPair: (
-    args: DeleteKeyPairCommandInput,
+  deleteKeyPair(
+    args: DeleteKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteKeyPairCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteKeyPairResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLaunchTemplateCommand}
    */
-  readonly deleteLaunchTemplate: (
-    args: DeleteLaunchTemplateCommandInput,
+  deleteLaunchTemplate(
+    args: DeleteLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLaunchTemplateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLaunchTemplateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLaunchTemplateVersionsCommand}
    */
-  readonly deleteLaunchTemplateVersions: (
-    args: DeleteLaunchTemplateVersionsCommandInput,
+  deleteLaunchTemplateVersions(
+    args: DeleteLaunchTemplateVersionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLaunchTemplateVersionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLaunchTemplateVersionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLocalGatewayRouteCommand}
    */
-  readonly deleteLocalGatewayRoute: (
-    args: DeleteLocalGatewayRouteCommandInput,
+  deleteLocalGatewayRoute(
+    args: DeleteLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLocalGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLocalGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableCommand}
    */
-  readonly deleteLocalGatewayRouteTable: (
-    args: DeleteLocalGatewayRouteTableCommandInput,
+  deleteLocalGatewayRouteTable(
+    args: DeleteLocalGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLocalGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLocalGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommand}
    */
-  readonly deleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation: (
-    args: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandInput,
+  deleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation(
+    args: DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteLocalGatewayRouteTableVpcAssociationCommand}
    */
-  readonly deleteLocalGatewayRouteTableVpcAssociation: (
-    args: DeleteLocalGatewayRouteTableVpcAssociationCommandInput,
+  deleteLocalGatewayRouteTableVpcAssociation(
+    args: DeleteLocalGatewayRouteTableVpcAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLocalGatewayRouteTableVpcAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteLocalGatewayRouteTableVpcAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteManagedPrefixListCommand}
    */
-  readonly deleteManagedPrefixList: (
-    args: DeleteManagedPrefixListCommandInput,
+  deleteManagedPrefixList(
+    args: DeleteManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteManagedPrefixListCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteManagedPrefixListResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNatGatewayCommand}
    */
-  readonly deleteNatGateway: (
-    args: DeleteNatGatewayCommandInput,
+  deleteNatGateway(
+    args: DeleteNatGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteNatGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DeleteNatGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkAclCommand}
    */
-  readonly deleteNetworkAcl: (
-    args: DeleteNetworkAclCommandInput,
+  deleteNetworkAcl(
+    args: DeleteNetworkAclRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteNetworkAclCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkAclEntryCommand}
    */
-  readonly deleteNetworkAclEntry: (
-    args: DeleteNetworkAclEntryCommandInput,
+  deleteNetworkAclEntry(
+    args: DeleteNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkAclEntryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInsightsAccessScopeCommand}
    */
-  readonly deleteNetworkInsightsAccessScope: (
-    args: DeleteNetworkInsightsAccessScopeCommandInput,
+  deleteNetworkInsightsAccessScope(
+    args: DeleteNetworkInsightsAccessScopeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInsightsAccessScopeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteNetworkInsightsAccessScopeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInsightsAccessScopeAnalysisCommand}
    */
-  readonly deleteNetworkInsightsAccessScopeAnalysis: (
-    args: DeleteNetworkInsightsAccessScopeAnalysisCommandInput,
+  deleteNetworkInsightsAccessScopeAnalysis(
+    args: DeleteNetworkInsightsAccessScopeAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInsightsAccessScopeAnalysisCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteNetworkInsightsAccessScopeAnalysisResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInsightsAnalysisCommand}
    */
-  readonly deleteNetworkInsightsAnalysis: (
-    args: DeleteNetworkInsightsAnalysisCommandInput,
+  deleteNetworkInsightsAnalysis(
+    args: DeleteNetworkInsightsAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInsightsAnalysisCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteNetworkInsightsAnalysisResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInsightsPathCommand}
    */
-  readonly deleteNetworkInsightsPath: (
-    args: DeleteNetworkInsightsPathCommandInput,
+  deleteNetworkInsightsPath(
+    args: DeleteNetworkInsightsPathRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInsightsPathCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteNetworkInsightsPathResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInterfaceCommand}
    */
-  readonly deleteNetworkInterface: (
-    args: DeleteNetworkInterfaceCommandInput,
+  deleteNetworkInterface(
+    args: DeleteNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteNetworkInterfacePermissionCommand}
    */
-  readonly deleteNetworkInterfacePermission: (
-    args: DeleteNetworkInterfacePermissionCommandInput,
+  deleteNetworkInterfacePermission(
+    args: DeleteNetworkInterfacePermissionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteNetworkInterfacePermissionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteNetworkInterfacePermissionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeletePlacementGroupCommand}
    */
-  readonly deletePlacementGroup: (
-    args: DeletePlacementGroupCommandInput,
+  deletePlacementGroup(
+    args: DeletePlacementGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeletePlacementGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeletePublicIpv4PoolCommand}
    */
-  readonly deletePublicIpv4Pool: (
-    args: DeletePublicIpv4PoolCommandInput,
+  deletePublicIpv4Pool(
+    args: DeletePublicIpv4PoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeletePublicIpv4PoolCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeletePublicIpv4PoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteQueuedReservedInstancesCommand}
    */
-  readonly deleteQueuedReservedInstances: (
-    args: DeleteQueuedReservedInstancesCommandInput,
+  deleteQueuedReservedInstances(
+    args: DeleteQueuedReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteQueuedReservedInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteQueuedReservedInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteRouteCommand}
    */
-  readonly deleteRoute: (
-    args: DeleteRouteCommandInput,
+  deleteRoute(
+    args: DeleteRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteRouteCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteRouteTableCommand}
    */
-  readonly deleteRouteTable: (
-    args: DeleteRouteTableCommandInput,
+  deleteRouteTable(
+    args: DeleteRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteRouteTableCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteSecurityGroupCommand}
    */
-  readonly deleteSecurityGroup: (
-    args: DeleteSecurityGroupCommandInput,
+  deleteSecurityGroup(
+    args: DeleteSecurityGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSecurityGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteSnapshotCommand}
    */
-  readonly deleteSnapshot: (
-    args: DeleteSnapshotCommandInput,
+  deleteSnapshot(
+    args: DeleteSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteSnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteSpotDatafeedSubscriptionCommand}
    */
-  readonly deleteSpotDatafeedSubscription: (
-    args: DeleteSpotDatafeedSubscriptionCommandInput,
+  deleteSpotDatafeedSubscription(
+    args: DeleteSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSpotDatafeedSubscriptionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteSubnetCommand}
    */
-  readonly deleteSubnet: (
-    args: DeleteSubnetCommandInput,
+  deleteSubnet(
+    args: DeleteSubnetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteSubnetCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteSubnetCidrReservationCommand}
    */
-  readonly deleteSubnetCidrReservation: (
-    args: DeleteSubnetCidrReservationCommandInput,
+  deleteSubnetCidrReservation(
+    args: DeleteSubnetCidrReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSubnetCidrReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteSubnetCidrReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTagsCommand}
    */
-  readonly deleteTags: (
-    args: DeleteTagsCommandInput,
+  deleteTags(
+    args: DeleteTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteTagsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTrafficMirrorFilterCommand}
    */
-  readonly deleteTrafficMirrorFilter: (
-    args: DeleteTrafficMirrorFilterCommandInput,
+  deleteTrafficMirrorFilter(
+    args: DeleteTrafficMirrorFilterRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTrafficMirrorFilterCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTrafficMirrorFilterResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTrafficMirrorFilterRuleCommand}
    */
-  readonly deleteTrafficMirrorFilterRule: (
-    args: DeleteTrafficMirrorFilterRuleCommandInput,
+  deleteTrafficMirrorFilterRule(
+    args: DeleteTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTrafficMirrorFilterRuleCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTrafficMirrorFilterRuleResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTrafficMirrorSessionCommand}
    */
-  readonly deleteTrafficMirrorSession: (
-    args: DeleteTrafficMirrorSessionCommandInput,
+  deleteTrafficMirrorSession(
+    args: DeleteTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTrafficMirrorSessionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTrafficMirrorSessionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTrafficMirrorTargetCommand}
    */
-  readonly deleteTrafficMirrorTarget: (
-    args: DeleteTrafficMirrorTargetCommandInput,
+  deleteTrafficMirrorTarget(
+    args: DeleteTrafficMirrorTargetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTrafficMirrorTargetCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTrafficMirrorTargetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayCommand}
    */
-  readonly deleteTransitGateway: (
-    args: DeleteTransitGatewayCommandInput,
+  deleteTransitGateway(
+    args: DeleteTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayConnectCommand}
    */
-  readonly deleteTransitGatewayConnect: (
-    args: DeleteTransitGatewayConnectCommandInput,
+  deleteTransitGatewayConnect(
+    args: DeleteTransitGatewayConnectRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayConnectCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayConnectResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayConnectPeerCommand}
    */
-  readonly deleteTransitGatewayConnectPeer: (
-    args: DeleteTransitGatewayConnectPeerCommandInput,
+  deleteTransitGatewayConnectPeer(
+    args: DeleteTransitGatewayConnectPeerRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayConnectPeerCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayConnectPeerResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayMulticastDomainCommand}
    */
-  readonly deleteTransitGatewayMulticastDomain: (
-    args: DeleteTransitGatewayMulticastDomainCommandInput,
+  deleteTransitGatewayMulticastDomain(
+    args: DeleteTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayMulticastDomainCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayMulticastDomainResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayPeeringAttachmentCommand}
    */
-  readonly deleteTransitGatewayPeeringAttachment: (
-    args: DeleteTransitGatewayPeeringAttachmentCommandInput,
+  deleteTransitGatewayPeeringAttachment(
+    args: DeleteTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayPeeringAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayPeeringAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayPolicyTableCommand}
    */
-  readonly deleteTransitGatewayPolicyTable: (
-    args: DeleteTransitGatewayPolicyTableCommandInput,
+  deleteTransitGatewayPolicyTable(
+    args: DeleteTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayPolicyTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayPolicyTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayPrefixListReferenceCommand}
    */
-  readonly deleteTransitGatewayPrefixListReference: (
-    args: DeleteTransitGatewayPrefixListReferenceCommandInput,
+  deleteTransitGatewayPrefixListReference(
+    args: DeleteTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayPrefixListReferenceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayPrefixListReferenceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayRouteCommand}
    */
-  readonly deleteTransitGatewayRoute: (
-    args: DeleteTransitGatewayRouteCommandInput,
+  deleteTransitGatewayRoute(
+    args: DeleteTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayRouteTableCommand}
    */
-  readonly deleteTransitGatewayRouteTable: (
-    args: DeleteTransitGatewayRouteTableCommandInput,
+  deleteTransitGatewayRouteTable(
+    args: DeleteTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayRouteTableAnnouncementCommand}
    */
-  readonly deleteTransitGatewayRouteTableAnnouncement: (
-    args: DeleteTransitGatewayRouteTableAnnouncementCommandInput,
+  deleteTransitGatewayRouteTableAnnouncement(
+    args: DeleteTransitGatewayRouteTableAnnouncementRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayRouteTableAnnouncementCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayRouteTableAnnouncementResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteTransitGatewayVpcAttachmentCommand}
    */
-  readonly deleteTransitGatewayVpcAttachment: (
-    args: DeleteTransitGatewayVpcAttachmentCommandInput,
+  deleteTransitGatewayVpcAttachment(
+    args: DeleteTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteTransitGatewayVpcAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteTransitGatewayVpcAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVerifiedAccessEndpointCommand}
    */
-  readonly deleteVerifiedAccessEndpoint: (
-    args: DeleteVerifiedAccessEndpointCommandInput,
+  deleteVerifiedAccessEndpoint(
+    args: DeleteVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVerifiedAccessEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVerifiedAccessEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVerifiedAccessGroupCommand}
    */
-  readonly deleteVerifiedAccessGroup: (
-    args: DeleteVerifiedAccessGroupCommandInput,
+  deleteVerifiedAccessGroup(
+    args: DeleteVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVerifiedAccessGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVerifiedAccessGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVerifiedAccessInstanceCommand}
    */
-  readonly deleteVerifiedAccessInstance: (
-    args: DeleteVerifiedAccessInstanceCommandInput,
+  deleteVerifiedAccessInstance(
+    args: DeleteVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVerifiedAccessInstanceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVerifiedAccessInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVerifiedAccessTrustProviderCommand}
    */
-  readonly deleteVerifiedAccessTrustProvider: (
-    args: DeleteVerifiedAccessTrustProviderCommandInput,
+  deleteVerifiedAccessTrustProvider(
+    args: DeleteVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVerifiedAccessTrustProviderCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVerifiedAccessTrustProviderResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVolumeCommand}
    */
-  readonly deleteVolume: (
-    args: DeleteVolumeCommandInput,
+  deleteVolume(
+    args: DeleteVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpcCommand}
    */
-  readonly deleteVpc: (
-    args: DeleteVpcCommandInput,
+  deleteVpc(
+    args: DeleteVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteVpcCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpcEndpointConnectionNotificationsCommand}
    */
-  readonly deleteVpcEndpointConnectionNotifications: (
-    args: DeleteVpcEndpointConnectionNotificationsCommandInput,
+  deleteVpcEndpointConnectionNotifications(
+    args: DeleteVpcEndpointConnectionNotificationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpcEndpointConnectionNotificationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DeleteVpcEndpointsCommand}
-   */
-  readonly deleteVpcEndpoints: (
-    args: DeleteVpcEndpointsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpcEndpointsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVpcEndpointConnectionNotificationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpcEndpointServiceConfigurationsCommand}
    */
-  readonly deleteVpcEndpointServiceConfigurations: (
-    args: DeleteVpcEndpointServiceConfigurationsCommandInput,
+  deleteVpcEndpointServiceConfigurations(
+    args: DeleteVpcEndpointServiceConfigurationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpcEndpointServiceConfigurationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVpcEndpointServiceConfigurationsResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DeleteVpcEndpointsCommand}
+   */
+  deleteVpcEndpoints(
+    args: DeleteVpcEndpointsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DeleteVpcEndpointsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpcPeeringConnectionCommand}
    */
-  readonly deleteVpcPeeringConnection: (
-    args: DeleteVpcPeeringConnectionCommandInput,
+  deleteVpcPeeringConnection(
+    args: DeleteVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpcPeeringConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeleteVpcPeeringConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpnConnectionCommand}
    */
-  readonly deleteVpnConnection: (
-    args: DeleteVpnConnectionCommandInput,
+  deleteVpnConnection(
+    args: DeleteVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpnConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpnConnectionRouteCommand}
    */
-  readonly deleteVpnConnectionRoute: (
-    args: DeleteVpnConnectionRouteCommandInput,
+  deleteVpnConnectionRoute(
+    args: DeleteVpnConnectionRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVpnConnectionRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeleteVpnGatewayCommand}
    */
-  readonly deleteVpnGateway: (
-    args: DeleteVpnGatewayCommandInput,
+  deleteVpnGateway(
+    args: DeleteVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeleteVpnGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeprovisionByoipCidrCommand}
    */
-  readonly deprovisionByoipCidr: (
-    args: DeprovisionByoipCidrCommandInput,
+  deprovisionByoipCidr(
+    args: DeprovisionByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeprovisionByoipCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeprovisionByoipCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeprovisionIpamByoasnCommand}
    */
-  readonly deprovisionIpamByoasn: (
-    args: DeprovisionIpamByoasnCommandInput,
+  deprovisionIpamByoasn(
+    args: DeprovisionIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeprovisionIpamByoasnCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeprovisionIpamByoasnResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeprovisionIpamPoolCidrCommand}
    */
-  readonly deprovisionIpamPoolCidr: (
-    args: DeprovisionIpamPoolCidrCommandInput,
+  deprovisionIpamPoolCidr(
+    args: DeprovisionIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeprovisionIpamPoolCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeprovisionIpamPoolCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeprovisionPublicIpv4PoolCidrCommand}
    */
-  readonly deprovisionPublicIpv4PoolCidr: (
-    args: DeprovisionPublicIpv4PoolCidrCommandInput,
+  deprovisionPublicIpv4PoolCidr(
+    args: DeprovisionPublicIpv4PoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeprovisionPublicIpv4PoolCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeprovisionPublicIpv4PoolCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeregisterImageCommand}
    */
-  readonly deregisterImage: (
-    args: DeregisterImageCommandInput,
+  deregisterImage(
+    args: DeregisterImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DeregisterImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DeregisterInstanceEventNotificationAttributesCommand}
    */
-  readonly deregisterInstanceEventNotificationAttributes: (
-    args: DeregisterInstanceEventNotificationAttributesCommandInput,
+  deregisterInstanceEventNotificationAttributes(
+    args: DeregisterInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeregisterInstanceEventNotificationAttributesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeregisterInstanceEventNotificationAttributesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeregisterTransitGatewayMulticastGroupMembersCommand}
    */
-  readonly deregisterTransitGatewayMulticastGroupMembers: (
-    args: DeregisterTransitGatewayMulticastGroupMembersCommandInput,
+  deregisterTransitGatewayMulticastGroupMembers(
+    args: DeregisterTransitGatewayMulticastGroupMembersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeregisterTransitGatewayMulticastGroupMembersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeregisterTransitGatewayMulticastGroupMembersResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DeregisterTransitGatewayMulticastGroupSourcesCommand}
    */
-  readonly deregisterTransitGatewayMulticastGroupSources: (
-    args: DeregisterTransitGatewayMulticastGroupSourcesCommandInput,
+  deregisterTransitGatewayMulticastGroupSources(
+    args: DeregisterTransitGatewayMulticastGroupSourcesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeregisterTransitGatewayMulticastGroupSourcesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DeregisterTransitGatewayMulticastGroupSourcesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeAccountAttributesCommand}
    */
-  readonly describeAccountAttributes: (
-    args: DescribeAccountAttributesCommandInput,
+  describeAccountAttributes(
+    args: DescribeAccountAttributesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAccountAttributesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeAddressesCommand}
-   */
-  readonly describeAddresses: (
-    args: DescribeAddressesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeAddressesAttributeCommand}
-   */
-  readonly describeAddressesAttribute: (
-    args: DescribeAddressesAttributeCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAddressesAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeAccountAttributesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeAddressTransfersCommand}
    */
-  readonly describeAddressTransfers: (
-    args: DescribeAddressTransfersCommandInput,
+  describeAddressTransfers(
+    args: DescribeAddressTransfersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAddressTransfersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeAddressTransfersResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeAddressesCommand}
+   */
+  describeAddresses(
+    args: DescribeAddressesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeAddressesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeAddressesAttributeCommand}
+   */
+  describeAddressesAttribute(
+    args: DescribeAddressesAttributeRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeAddressesAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeAggregateIdFormatCommand}
    */
-  readonly describeAggregateIdFormat: (
-    args: DescribeAggregateIdFormatCommandInput,
+  describeAggregateIdFormat(
+    args: DescribeAggregateIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAggregateIdFormatCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeAggregateIdFormatResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeAvailabilityZonesCommand}
    */
-  readonly describeAvailabilityZones: (
-    args: DescribeAvailabilityZonesCommandInput,
+  describeAvailabilityZones(
+    args: DescribeAvailabilityZonesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAvailabilityZonesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeAvailabilityZonesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeAwsNetworkPerformanceMetricSubscriptionsCommand}
    */
-  readonly describeAwsNetworkPerformanceMetricSubscriptions: (
-    args: DescribeAwsNetworkPerformanceMetricSubscriptionsCommandInput,
+  describeAwsNetworkPerformanceMetricSubscriptions(
+    args: DescribeAwsNetworkPerformanceMetricSubscriptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeAwsNetworkPerformanceMetricSubscriptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeAwsNetworkPerformanceMetricSubscriptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeBundleTasksCommand}
    */
-  readonly describeBundleTasks: (
-    args: DescribeBundleTasksCommandInput,
+  describeBundleTasks(
+    args: DescribeBundleTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeBundleTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeBundleTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeByoipCidrsCommand}
    */
-  readonly describeByoipCidrs: (
-    args: DescribeByoipCidrsCommandInput,
+  describeByoipCidrs(
+    args: DescribeByoipCidrsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeByoipCidrsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeByoipCidrsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCapacityBlockOfferingsCommand}
    */
-  readonly describeCapacityBlockOfferings: (
-    args: DescribeCapacityBlockOfferingsCommandInput,
+  describeCapacityBlockOfferings(
+    args: DescribeCapacityBlockOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCapacityBlockOfferingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCapacityBlockOfferingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCapacityReservationFleetsCommand}
    */
-  readonly describeCapacityReservationFleets: (
-    args: DescribeCapacityReservationFleetsCommandInput,
+  describeCapacityReservationFleets(
+    args: DescribeCapacityReservationFleetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCapacityReservationFleetsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCapacityReservationFleetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCapacityReservationsCommand}
    */
-  readonly describeCapacityReservations: (
-    args: DescribeCapacityReservationsCommandInput,
+  describeCapacityReservations(
+    args: DescribeCapacityReservationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCapacityReservationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCapacityReservationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCarrierGatewaysCommand}
    */
-  readonly describeCarrierGateways: (
-    args: DescribeCarrierGatewaysCommandInput,
+  describeCarrierGateways(
+    args: DescribeCarrierGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCarrierGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCarrierGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClassicLinkInstancesCommand}
    */
-  readonly describeClassicLinkInstances: (
-    args: DescribeClassicLinkInstancesCommandInput,
+  describeClassicLinkInstances(
+    args: DescribeClassicLinkInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClassicLinkInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClassicLinkInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClientVpnAuthorizationRulesCommand}
    */
-  readonly describeClientVpnAuthorizationRules: (
-    args: DescribeClientVpnAuthorizationRulesCommandInput,
+  describeClientVpnAuthorizationRules(
+    args: DescribeClientVpnAuthorizationRulesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClientVpnAuthorizationRulesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClientVpnAuthorizationRulesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClientVpnConnectionsCommand}
    */
-  readonly describeClientVpnConnections: (
-    args: DescribeClientVpnConnectionsCommandInput,
+  describeClientVpnConnections(
+    args: DescribeClientVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClientVpnConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClientVpnConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClientVpnEndpointsCommand}
    */
-  readonly describeClientVpnEndpoints: (
-    args: DescribeClientVpnEndpointsCommandInput,
+  describeClientVpnEndpoints(
+    args: DescribeClientVpnEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClientVpnEndpointsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClientVpnEndpointsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClientVpnRoutesCommand}
    */
-  readonly describeClientVpnRoutes: (
-    args: DescribeClientVpnRoutesCommandInput,
+  describeClientVpnRoutes(
+    args: DescribeClientVpnRoutesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClientVpnRoutesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClientVpnRoutesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeClientVpnTargetNetworksCommand}
    */
-  readonly describeClientVpnTargetNetworks: (
-    args: DescribeClientVpnTargetNetworksCommandInput,
+  describeClientVpnTargetNetworks(
+    args: DescribeClientVpnTargetNetworksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeClientVpnTargetNetworksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeClientVpnTargetNetworksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCoipPoolsCommand}
    */
-  readonly describeCoipPools: (
-    args: DescribeCoipPoolsCommandInput,
+  describeCoipPools(
+    args: DescribeCoipPoolsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCoipPoolsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCoipPoolsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeConversionTasksCommand}
    */
-  readonly describeConversionTasks: (
-    args: DescribeConversionTasksCommandInput,
+  describeConversionTasks(
+    args: DescribeConversionTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeConversionTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeConversionTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeCustomerGatewaysCommand}
    */
-  readonly describeCustomerGateways: (
-    args: DescribeCustomerGatewaysCommandInput,
+  describeCustomerGateways(
+    args: DescribeCustomerGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCustomerGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeCustomerGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeDhcpOptionsCommand}
    */
-  readonly describeDhcpOptions: (
-    args: DescribeDhcpOptionsCommandInput,
+  describeDhcpOptions(
+    args: DescribeDhcpOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeDhcpOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeDhcpOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeEgressOnlyInternetGatewaysCommand}
    */
-  readonly describeEgressOnlyInternetGateways: (
-    args: DescribeEgressOnlyInternetGatewaysCommandInput,
+  describeEgressOnlyInternetGateways(
+    args: DescribeEgressOnlyInternetGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeEgressOnlyInternetGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeEgressOnlyInternetGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeElasticGpusCommand}
    */
-  readonly describeElasticGpus: (
-    args: DescribeElasticGpusCommandInput,
+  describeElasticGpus(
+    args: DescribeElasticGpusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeElasticGpusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeElasticGpusResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeExportImageTasksCommand}
    */
-  readonly describeExportImageTasks: (
-    args: DescribeExportImageTasksCommandInput,
+  describeExportImageTasks(
+    args: DescribeExportImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeExportImageTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeExportImageTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeExportTasksCommand}
    */
-  readonly describeExportTasks: (
-    args: DescribeExportTasksCommandInput,
+  describeExportTasks(
+    args: DescribeExportTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeExportTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeExportTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFastLaunchImagesCommand}
    */
-  readonly describeFastLaunchImages: (
-    args: DescribeFastLaunchImagesCommandInput,
+  describeFastLaunchImages(
+    args: DescribeFastLaunchImagesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFastLaunchImagesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFastLaunchImagesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFastSnapshotRestoresCommand}
    */
-  readonly describeFastSnapshotRestores: (
-    args: DescribeFastSnapshotRestoresCommandInput,
+  describeFastSnapshotRestores(
+    args: DescribeFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFastSnapshotRestoresCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFastSnapshotRestoresResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFleetHistoryCommand}
    */
-  readonly describeFleetHistory: (
-    args: DescribeFleetHistoryCommandInput,
+  describeFleetHistory(
+    args: DescribeFleetHistoryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFleetHistoryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFleetHistoryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFleetInstancesCommand}
    */
-  readonly describeFleetInstances: (
-    args: DescribeFleetInstancesCommandInput,
+  describeFleetInstances(
+    args: DescribeFleetInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFleetInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFleetInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFleetsCommand}
    */
-  readonly describeFleets: (
-    args: DescribeFleetsCommandInput,
+  describeFleets(
+    args: DescribeFleetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeFleetsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeFleetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFlowLogsCommand}
    */
-  readonly describeFlowLogs: (
-    args: DescribeFlowLogsCommandInput,
+  describeFlowLogs(
+    args: DescribeFlowLogsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeFlowLogsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeFlowLogsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFpgaImageAttributeCommand}
    */
-  readonly describeFpgaImageAttribute: (
-    args: DescribeFpgaImageAttributeCommandInput,
+  describeFpgaImageAttribute(
+    args: DescribeFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFpgaImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFpgaImageAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeFpgaImagesCommand}
    */
-  readonly describeFpgaImages: (
-    args: DescribeFpgaImagesCommandInput,
+  describeFpgaImages(
+    args: DescribeFpgaImagesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeFpgaImagesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeFpgaImagesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeHostReservationOfferingsCommand}
    */
-  readonly describeHostReservationOfferings: (
-    args: DescribeHostReservationOfferingsCommandInput,
+  describeHostReservationOfferings(
+    args: DescribeHostReservationOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeHostReservationOfferingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeHostReservationOfferingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeHostReservationsCommand}
    */
-  readonly describeHostReservations: (
-    args: DescribeHostReservationsCommandInput,
+  describeHostReservations(
+    args: DescribeHostReservationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeHostReservationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeHostReservationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeHostsCommand}
    */
-  readonly describeHosts: (
-    args: DescribeHostsCommandInput,
+  describeHosts(
+    args: DescribeHostsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeHostsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeHostsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIamInstanceProfileAssociationsCommand}
    */
-  readonly describeIamInstanceProfileAssociations: (
-    args: DescribeIamInstanceProfileAssociationsCommandInput,
+  describeIamInstanceProfileAssociations(
+    args: DescribeIamInstanceProfileAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIamInstanceProfileAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeIdentityIdFormatCommand}
-   */
-  readonly describeIdentityIdFormat: (
-    args: DescribeIdentityIdFormatCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIdentityIdFormatCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIamInstanceProfileAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIdFormatCommand}
    */
-  readonly describeIdFormat: (
-    args: DescribeIdFormatCommandInput,
+  describeIdFormat(
+    args: DescribeIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeIdFormatCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeIdFormatResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeIdentityIdFormatCommand}
+   */
+  describeIdentityIdFormat(
+    args: DescribeIdentityIdFormatRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeIdentityIdFormatResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeImageAttributeCommand}
    */
-  readonly describeImageAttribute: (
-    args: DescribeImageAttributeCommandInput,
+  describeImageAttribute(
+    args: DescribeImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ImageAttribute,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeImagesCommand}
    */
-  readonly describeImages: (
-    args: DescribeImagesCommandInput,
+  describeImages(
+    args: DescribeImagesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeImagesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeImagesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeImportImageTasksCommand}
    */
-  readonly describeImportImageTasks: (
-    args: DescribeImportImageTasksCommandInput,
+  describeImportImageTasks(
+    args: DescribeImportImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeImportImageTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeImportImageTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeImportSnapshotTasksCommand}
    */
-  readonly describeImportSnapshotTasks: (
-    args: DescribeImportSnapshotTasksCommandInput,
+  describeImportSnapshotTasks(
+    args: DescribeImportSnapshotTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeImportSnapshotTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeImportSnapshotTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceAttributeCommand}
    */
-  readonly describeInstanceAttribute: (
-    args: DescribeInstanceAttributeCommandInput,
+  describeInstanceAttribute(
+    args: DescribeInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  InstanceAttribute,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceConnectEndpointsCommand}
    */
-  readonly describeInstanceConnectEndpoints: (
-    args: DescribeInstanceConnectEndpointsCommandInput,
+  describeInstanceConnectEndpoints(
+    args: DescribeInstanceConnectEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceConnectEndpointsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceConnectEndpointsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceCreditSpecificationsCommand}
    */
-  readonly describeInstanceCreditSpecifications: (
-    args: DescribeInstanceCreditSpecificationsCommandInput,
+  describeInstanceCreditSpecifications(
+    args: DescribeInstanceCreditSpecificationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceCreditSpecificationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceCreditSpecificationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceEventNotificationAttributesCommand}
    */
-  readonly describeInstanceEventNotificationAttributes: (
-    args: DescribeInstanceEventNotificationAttributesCommandInput,
+  describeInstanceEventNotificationAttributes(
+    args: DescribeInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceEventNotificationAttributesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceEventNotificationAttributesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceEventWindowsCommand}
    */
-  readonly describeInstanceEventWindows: (
-    args: DescribeInstanceEventWindowsCommandInput,
+  describeInstanceEventWindows(
+    args: DescribeInstanceEventWindowsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceEventWindowsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeInstancesCommand}
-   */
-  readonly describeInstances: (
-    args: DescribeInstancesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceEventWindowsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceStatusCommand}
    */
-  readonly describeInstanceStatus: (
-    args: DescribeInstanceStatusCommandInput,
+  describeInstanceStatus(
+    args: DescribeInstanceStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceStatusResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceTopologyCommand}
    */
-  readonly describeInstanceTopology: (
-    args: DescribeInstanceTopologyCommandInput,
+  describeInstanceTopology(
+    args: DescribeInstanceTopologyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceTopologyCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceTopologyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceTypeOfferingsCommand}
    */
-  readonly describeInstanceTypeOfferings: (
-    args: DescribeInstanceTypeOfferingsCommandInput,
+  describeInstanceTypeOfferings(
+    args: DescribeInstanceTypeOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceTypeOfferingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceTypeOfferingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInstanceTypesCommand}
    */
-  readonly describeInstanceTypes: (
-    args: DescribeInstanceTypesCommandInput,
+  describeInstanceTypes(
+    args: DescribeInstanceTypesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInstanceTypesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInstanceTypesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeInstancesCommand}
+   */
+  describeInstances(
+    args: DescribeInstancesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeInternetGatewaysCommand}
    */
-  readonly describeInternetGateways: (
-    args: DescribeInternetGatewaysCommandInput,
+  describeInternetGateways(
+    args: DescribeInternetGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeInternetGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeInternetGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpamByoasnCommand}
    */
-  readonly describeIpamByoasn: (
-    args: DescribeIpamByoasnCommandInput,
+  describeIpamByoasn(
+    args: DescribeIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpamByoasnCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIpamByoasnResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpamPoolsCommand}
    */
-  readonly describeIpamPools: (
-    args: DescribeIpamPoolsCommandInput,
+  describeIpamPools(
+    args: DescribeIpamPoolsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpamPoolsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIpamPoolsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpamResourceDiscoveriesCommand}
    */
-  readonly describeIpamResourceDiscoveries: (
-    args: DescribeIpamResourceDiscoveriesCommandInput,
+  describeIpamResourceDiscoveries(
+    args: DescribeIpamResourceDiscoveriesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpamResourceDiscoveriesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIpamResourceDiscoveriesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpamResourceDiscoveryAssociationsCommand}
    */
-  readonly describeIpamResourceDiscoveryAssociations: (
-    args: DescribeIpamResourceDiscoveryAssociationsCommandInput,
+  describeIpamResourceDiscoveryAssociations(
+    args: DescribeIpamResourceDiscoveryAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpamResourceDiscoveryAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeIpamsCommand}
-   */
-  readonly describeIpams: (
-    args: DescribeIpamsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeIpamsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeIpamResourceDiscoveryAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpamScopesCommand}
    */
-  readonly describeIpamScopes: (
-    args: DescribeIpamScopesCommandInput,
+  describeIpamScopes(
+    args: DescribeIpamScopesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpamScopesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIpamScopesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeIpamsCommand}
+   */
+  describeIpams(
+    args: DescribeIpamsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeIpamsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeIpv6PoolsCommand}
    */
-  readonly describeIpv6Pools: (
-    args: DescribeIpv6PoolsCommandInput,
+  describeIpv6Pools(
+    args: DescribeIpv6PoolsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeIpv6PoolsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeIpv6PoolsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeKeyPairsCommand}
    */
-  readonly describeKeyPairs: (
-    args: DescribeKeyPairsCommandInput,
+  describeKeyPairs(
+    args: DescribeKeyPairsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeKeyPairsCommandOutput, SdkError | EC2ServiceError>;
-
-  /**
-   * @see {@link DescribeLaunchTemplatesCommand}
-   */
-  readonly describeLaunchTemplates: (
-    args: DescribeLaunchTemplatesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLaunchTemplatesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeKeyPairsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLaunchTemplateVersionsCommand}
    */
-  readonly describeLaunchTemplateVersions: (
-    args: DescribeLaunchTemplateVersionsCommandInput,
+  describeLaunchTemplateVersions(
+    args: DescribeLaunchTemplateVersionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLaunchTemplateVersionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLaunchTemplateVersionsResult,
+    | SdkError
+  >
 
   /**
-   * @see {@link DescribeLocalGatewayRouteTablesCommand}
+   * @see {@link DescribeLaunchTemplatesCommand}
    */
-  readonly describeLocalGatewayRouteTables: (
-    args: DescribeLocalGatewayRouteTablesCommandInput,
+  describeLaunchTemplates(
+    args: DescribeLaunchTemplatesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewayRouteTablesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLaunchTemplatesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommand}
    */
-  readonly describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations: (
-    args: DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandInput,
+  describeLocalGatewayRouteTableVirtualInterfaceGroupAssociations(
+    args: DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLocalGatewayRouteTableVpcAssociationsCommand}
    */
-  readonly describeLocalGatewayRouteTableVpcAssociations: (
-    args: DescribeLocalGatewayRouteTableVpcAssociationsCommandInput,
+  describeLocalGatewayRouteTableVpcAssociations(
+    args: DescribeLocalGatewayRouteTableVpcAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewayRouteTableVpcAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLocalGatewayRouteTableVpcAssociationsResult,
+    | SdkError
+  >
 
   /**
-   * @see {@link DescribeLocalGatewaysCommand}
+   * @see {@link DescribeLocalGatewayRouteTablesCommand}
    */
-  readonly describeLocalGateways: (
-    args: DescribeLocalGatewaysCommandInput,
+  describeLocalGatewayRouteTables(
+    args: DescribeLocalGatewayRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLocalGatewayRouteTablesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLocalGatewayVirtualInterfaceGroupsCommand}
    */
-  readonly describeLocalGatewayVirtualInterfaceGroups: (
-    args: DescribeLocalGatewayVirtualInterfaceGroupsCommandInput,
+  describeLocalGatewayVirtualInterfaceGroups(
+    args: DescribeLocalGatewayVirtualInterfaceGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewayVirtualInterfaceGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLocalGatewayVirtualInterfaceGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLocalGatewayVirtualInterfacesCommand}
    */
-  readonly describeLocalGatewayVirtualInterfaces: (
-    args: DescribeLocalGatewayVirtualInterfacesCommandInput,
+  describeLocalGatewayVirtualInterfaces(
+    args: DescribeLocalGatewayVirtualInterfacesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLocalGatewayVirtualInterfacesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLocalGatewayVirtualInterfacesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeLocalGatewaysCommand}
+   */
+  describeLocalGateways(
+    args: DescribeLocalGatewaysRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeLocalGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeLockedSnapshotsCommand}
    */
-  readonly describeLockedSnapshots: (
-    args: DescribeLockedSnapshotsCommandInput,
+  describeLockedSnapshots(
+    args: DescribeLockedSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeLockedSnapshotsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeLockedSnapshotsResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeMacHostsCommand}
+   */
+  describeMacHosts(
+    args: DescribeMacHostsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeMacHostsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeManagedPrefixListsCommand}
    */
-  readonly describeManagedPrefixLists: (
-    args: DescribeManagedPrefixListsCommandInput,
+  describeManagedPrefixLists(
+    args: DescribeManagedPrefixListsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeManagedPrefixListsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeManagedPrefixListsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeMovingAddressesCommand}
    */
-  readonly describeMovingAddresses: (
-    args: DescribeMovingAddressesCommandInput,
+  describeMovingAddresses(
+    args: DescribeMovingAddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeMovingAddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeMovingAddressesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNatGatewaysCommand}
    */
-  readonly describeNatGateways: (
-    args: DescribeNatGatewaysCommandInput,
+  describeNatGateways(
+    args: DescribeNatGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNatGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNatGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkAclsCommand}
    */
-  readonly describeNetworkAcls: (
-    args: DescribeNetworkAclsCommandInput,
+  describeNetworkAcls(
+    args: DescribeNetworkAclsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkAclsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkAclsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInsightsAccessScopeAnalysesCommand}
    */
-  readonly describeNetworkInsightsAccessScopeAnalyses: (
-    args: DescribeNetworkInsightsAccessScopeAnalysesCommandInput,
+  describeNetworkInsightsAccessScopeAnalyses(
+    args: DescribeNetworkInsightsAccessScopeAnalysesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInsightsAccessScopeAnalysesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInsightsAccessScopeAnalysesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInsightsAccessScopesCommand}
    */
-  readonly describeNetworkInsightsAccessScopes: (
-    args: DescribeNetworkInsightsAccessScopesCommandInput,
+  describeNetworkInsightsAccessScopes(
+    args: DescribeNetworkInsightsAccessScopesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInsightsAccessScopesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInsightsAccessScopesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInsightsAnalysesCommand}
    */
-  readonly describeNetworkInsightsAnalyses: (
-    args: DescribeNetworkInsightsAnalysesCommandInput,
+  describeNetworkInsightsAnalyses(
+    args: DescribeNetworkInsightsAnalysesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInsightsAnalysesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInsightsAnalysesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInsightsPathsCommand}
    */
-  readonly describeNetworkInsightsPaths: (
-    args: DescribeNetworkInsightsPathsCommandInput,
+  describeNetworkInsightsPaths(
+    args: DescribeNetworkInsightsPathsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInsightsPathsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInsightsPathsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInterfaceAttributeCommand}
    */
-  readonly describeNetworkInterfaceAttribute: (
-    args: DescribeNetworkInterfaceAttributeCommandInput,
+  describeNetworkInterfaceAttribute(
+    args: DescribeNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInterfaceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInterfaceAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInterfacePermissionsCommand}
    */
-  readonly describeNetworkInterfacePermissions: (
-    args: DescribeNetworkInterfacePermissionsCommandInput,
+  describeNetworkInterfacePermissions(
+    args: DescribeNetworkInterfacePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInterfacePermissionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInterfacePermissionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeNetworkInterfacesCommand}
    */
-  readonly describeNetworkInterfaces: (
-    args: DescribeNetworkInterfacesCommandInput,
+  describeNetworkInterfaces(
+    args: DescribeNetworkInterfacesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeNetworkInterfacesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeNetworkInterfacesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribePlacementGroupsCommand}
    */
-  readonly describePlacementGroups: (
-    args: DescribePlacementGroupsCommandInput,
+  describePlacementGroups(
+    args: DescribePlacementGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribePlacementGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribePlacementGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribePrefixListsCommand}
    */
-  readonly describePrefixLists: (
-    args: DescribePrefixListsCommandInput,
+  describePrefixLists(
+    args: DescribePrefixListsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribePrefixListsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribePrefixListsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribePrincipalIdFormatCommand}
    */
-  readonly describePrincipalIdFormat: (
-    args: DescribePrincipalIdFormatCommandInput,
+  describePrincipalIdFormat(
+    args: DescribePrincipalIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribePrincipalIdFormatCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribePrincipalIdFormatResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribePublicIpv4PoolsCommand}
    */
-  readonly describePublicIpv4Pools: (
-    args: DescribePublicIpv4PoolsCommandInput,
+  describePublicIpv4Pools(
+    args: DescribePublicIpv4PoolsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribePublicIpv4PoolsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribePublicIpv4PoolsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeRegionsCommand}
    */
-  readonly describeRegions: (
-    args: DescribeRegionsCommandInput,
+  describeRegions(
+    args: DescribeRegionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeRegionsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeRegionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeReplaceRootVolumeTasksCommand}
    */
-  readonly describeReplaceRootVolumeTasks: (
-    args: DescribeReplaceRootVolumeTasksCommandInput,
+  describeReplaceRootVolumeTasks(
+    args: DescribeReplaceRootVolumeTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeReplaceRootVolumeTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeReplaceRootVolumeTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeReservedInstancesCommand}
    */
-  readonly describeReservedInstances: (
-    args: DescribeReservedInstancesCommandInput,
+  describeReservedInstances(
+    args: DescribeReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeReservedInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeReservedInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeReservedInstancesListingsCommand}
    */
-  readonly describeReservedInstancesListings: (
-    args: DescribeReservedInstancesListingsCommandInput,
+  describeReservedInstancesListings(
+    args: DescribeReservedInstancesListingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeReservedInstancesListingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeReservedInstancesListingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeReservedInstancesModificationsCommand}
    */
-  readonly describeReservedInstancesModifications: (
-    args: DescribeReservedInstancesModificationsCommandInput,
+  describeReservedInstancesModifications(
+    args: DescribeReservedInstancesModificationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeReservedInstancesModificationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeReservedInstancesModificationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeReservedInstancesOfferingsCommand}
    */
-  readonly describeReservedInstancesOfferings: (
-    args: DescribeReservedInstancesOfferingsCommandInput,
+  describeReservedInstancesOfferings(
+    args: DescribeReservedInstancesOfferingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeReservedInstancesOfferingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeReservedInstancesOfferingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeRouteTablesCommand}
    */
-  readonly describeRouteTables: (
-    args: DescribeRouteTablesCommandInput,
+  describeRouteTables(
+    args: DescribeRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeRouteTablesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeRouteTablesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeScheduledInstanceAvailabilityCommand}
    */
-  readonly describeScheduledInstanceAvailability: (
-    args: DescribeScheduledInstanceAvailabilityCommandInput,
+  describeScheduledInstanceAvailability(
+    args: DescribeScheduledInstanceAvailabilityRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeScheduledInstanceAvailabilityCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeScheduledInstanceAvailabilityResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeScheduledInstancesCommand}
    */
-  readonly describeScheduledInstances: (
-    args: DescribeScheduledInstancesCommandInput,
+  describeScheduledInstances(
+    args: DescribeScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeScheduledInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeScheduledInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSecurityGroupReferencesCommand}
    */
-  readonly describeSecurityGroupReferences: (
-    args: DescribeSecurityGroupReferencesCommandInput,
+  describeSecurityGroupReferences(
+    args: DescribeSecurityGroupReferencesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSecurityGroupReferencesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSecurityGroupReferencesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSecurityGroupRulesCommand}
    */
-  readonly describeSecurityGroupRules: (
-    args: DescribeSecurityGroupRulesCommandInput,
+  describeSecurityGroupRules(
+    args: DescribeSecurityGroupRulesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSecurityGroupRulesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSecurityGroupRulesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSecurityGroupsCommand}
    */
-  readonly describeSecurityGroups: (
-    args: DescribeSecurityGroupsCommandInput,
+  describeSecurityGroups(
+    args: DescribeSecurityGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSecurityGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSecurityGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSnapshotAttributeCommand}
    */
-  readonly describeSnapshotAttribute: (
-    args: DescribeSnapshotAttributeCommandInput,
+  describeSnapshotAttribute(
+    args: DescribeSnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSnapshotAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeSnapshotsCommand}
-   */
-  readonly describeSnapshots: (
-    args: DescribeSnapshotsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSnapshotsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSnapshotAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSnapshotTierStatusCommand}
    */
-  readonly describeSnapshotTierStatus: (
-    args: DescribeSnapshotTierStatusCommandInput,
+  describeSnapshotTierStatus(
+    args: DescribeSnapshotTierStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSnapshotTierStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSnapshotTierStatusResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeSnapshotsCommand}
+   */
+  describeSnapshots(
+    args: DescribeSnapshotsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeSnapshotsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotDatafeedSubscriptionCommand}
    */
-  readonly describeSpotDatafeedSubscription: (
-    args: DescribeSpotDatafeedSubscriptionCommandInput,
+  describeSpotDatafeedSubscription(
+    args: DescribeSpotDatafeedSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotDatafeedSubscriptionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotDatafeedSubscriptionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotFleetInstancesCommand}
    */
-  readonly describeSpotFleetInstances: (
-    args: DescribeSpotFleetInstancesCommandInput,
+  describeSpotFleetInstances(
+    args: DescribeSpotFleetInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotFleetInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotFleetInstancesResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotFleetRequestHistoryCommand}
    */
-  readonly describeSpotFleetRequestHistory: (
-    args: DescribeSpotFleetRequestHistoryCommandInput,
+  describeSpotFleetRequestHistory(
+    args: DescribeSpotFleetRequestHistoryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotFleetRequestHistoryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotFleetRequestHistoryResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotFleetRequestsCommand}
    */
-  readonly describeSpotFleetRequests: (
-    args: DescribeSpotFleetRequestsCommandInput,
+  describeSpotFleetRequests(
+    args: DescribeSpotFleetRequestsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotFleetRequestsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotFleetRequestsResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotInstanceRequestsCommand}
    */
-  readonly describeSpotInstanceRequests: (
-    args: DescribeSpotInstanceRequestsCommandInput,
+  describeSpotInstanceRequests(
+    args: DescribeSpotInstanceRequestsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotInstanceRequestsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotInstanceRequestsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSpotPriceHistoryCommand}
    */
-  readonly describeSpotPriceHistory: (
-    args: DescribeSpotPriceHistoryCommandInput,
+  describeSpotPriceHistory(
+    args: DescribeSpotPriceHistoryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeSpotPriceHistoryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeSpotPriceHistoryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeStaleSecurityGroupsCommand}
    */
-  readonly describeStaleSecurityGroups: (
-    args: DescribeStaleSecurityGroupsCommandInput,
+  describeStaleSecurityGroups(
+    args: DescribeStaleSecurityGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeStaleSecurityGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeStaleSecurityGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeStoreImageTasksCommand}
    */
-  readonly describeStoreImageTasks: (
-    args: DescribeStoreImageTasksCommandInput,
+  describeStoreImageTasks(
+    args: DescribeStoreImageTasksRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeStoreImageTasksCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeStoreImageTasksResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeSubnetsCommand}
    */
-  readonly describeSubnets: (
-    args: DescribeSubnetsCommandInput,
+  describeSubnets(
+    args: DescribeSubnetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeSubnetsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeSubnetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTagsCommand}
    */
-  readonly describeTags: (
-    args: DescribeTagsCommandInput,
+  describeTags(
+    args: DescribeTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeTagsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeTagsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTrafficMirrorFiltersCommand}
    */
-  readonly describeTrafficMirrorFilters: (
-    args: DescribeTrafficMirrorFiltersCommandInput,
+  describeTrafficMirrorFilters(
+    args: DescribeTrafficMirrorFiltersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTrafficMirrorFiltersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTrafficMirrorFiltersResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTrafficMirrorSessionsCommand}
    */
-  readonly describeTrafficMirrorSessions: (
-    args: DescribeTrafficMirrorSessionsCommandInput,
+  describeTrafficMirrorSessions(
+    args: DescribeTrafficMirrorSessionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTrafficMirrorSessionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTrafficMirrorSessionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTrafficMirrorTargetsCommand}
    */
-  readonly describeTrafficMirrorTargets: (
-    args: DescribeTrafficMirrorTargetsCommandInput,
+  describeTrafficMirrorTargets(
+    args: DescribeTrafficMirrorTargetsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTrafficMirrorTargetsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTrafficMirrorTargetsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayAttachmentsCommand}
    */
-  readonly describeTransitGatewayAttachments: (
-    args: DescribeTransitGatewayAttachmentsCommandInput,
+  describeTransitGatewayAttachments(
+    args: DescribeTransitGatewayAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayAttachmentsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayAttachmentsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayConnectPeersCommand}
    */
-  readonly describeTransitGatewayConnectPeers: (
-    args: DescribeTransitGatewayConnectPeersCommandInput,
+  describeTransitGatewayConnectPeers(
+    args: DescribeTransitGatewayConnectPeersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayConnectPeersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayConnectPeersResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayConnectsCommand}
    */
-  readonly describeTransitGatewayConnects: (
-    args: DescribeTransitGatewayConnectsCommandInput,
+  describeTransitGatewayConnects(
+    args: DescribeTransitGatewayConnectsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayConnectsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayConnectsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayMulticastDomainsCommand}
    */
-  readonly describeTransitGatewayMulticastDomains: (
-    args: DescribeTransitGatewayMulticastDomainsCommandInput,
+  describeTransitGatewayMulticastDomains(
+    args: DescribeTransitGatewayMulticastDomainsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayMulticastDomainsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayMulticastDomainsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayPeeringAttachmentsCommand}
    */
-  readonly describeTransitGatewayPeeringAttachments: (
-    args: DescribeTransitGatewayPeeringAttachmentsCommandInput,
+  describeTransitGatewayPeeringAttachments(
+    args: DescribeTransitGatewayPeeringAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayPeeringAttachmentsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayPeeringAttachmentsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayPolicyTablesCommand}
    */
-  readonly describeTransitGatewayPolicyTables: (
-    args: DescribeTransitGatewayPolicyTablesCommandInput,
+  describeTransitGatewayPolicyTables(
+    args: DescribeTransitGatewayPolicyTablesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayPolicyTablesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayPolicyTablesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayRouteTableAnnouncementsCommand}
    */
-  readonly describeTransitGatewayRouteTableAnnouncements: (
-    args: DescribeTransitGatewayRouteTableAnnouncementsCommandInput,
+  describeTransitGatewayRouteTableAnnouncements(
+    args: DescribeTransitGatewayRouteTableAnnouncementsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayRouteTableAnnouncementsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayRouteTableAnnouncementsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayRouteTablesCommand}
    */
-  readonly describeTransitGatewayRouteTables: (
-    args: DescribeTransitGatewayRouteTablesCommandInput,
+  describeTransitGatewayRouteTables(
+    args: DescribeTransitGatewayRouteTablesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayRouteTablesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeTransitGatewaysCommand}
-   */
-  readonly describeTransitGateways: (
-    args: DescribeTransitGatewaysCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayRouteTablesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTransitGatewayVpcAttachmentsCommand}
    */
-  readonly describeTransitGatewayVpcAttachments: (
-    args: DescribeTransitGatewayVpcAttachmentsCommandInput,
+  describeTransitGatewayVpcAttachments(
+    args: DescribeTransitGatewayVpcAttachmentsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTransitGatewayVpcAttachmentsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTransitGatewayVpcAttachmentsResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeTransitGatewaysCommand}
+   */
+  describeTransitGateways(
+    args: DescribeTransitGatewaysRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeTransitGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeTrunkInterfaceAssociationsCommand}
    */
-  readonly describeTrunkInterfaceAssociations: (
-    args: DescribeTrunkInterfaceAssociationsCommandInput,
+  describeTrunkInterfaceAssociations(
+    args: DescribeTrunkInterfaceAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeTrunkInterfaceAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeTrunkInterfaceAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVerifiedAccessEndpointsCommand}
    */
-  readonly describeVerifiedAccessEndpoints: (
-    args: DescribeVerifiedAccessEndpointsCommandInput,
+  describeVerifiedAccessEndpoints(
+    args: DescribeVerifiedAccessEndpointsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVerifiedAccessEndpointsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVerifiedAccessEndpointsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVerifiedAccessGroupsCommand}
    */
-  readonly describeVerifiedAccessGroups: (
-    args: DescribeVerifiedAccessGroupsCommandInput,
+  describeVerifiedAccessGroups(
+    args: DescribeVerifiedAccessGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVerifiedAccessGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVerifiedAccessGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVerifiedAccessInstanceLoggingConfigurationsCommand}
    */
-  readonly describeVerifiedAccessInstanceLoggingConfigurations: (
-    args: DescribeVerifiedAccessInstanceLoggingConfigurationsCommandInput,
+  describeVerifiedAccessInstanceLoggingConfigurations(
+    args: DescribeVerifiedAccessInstanceLoggingConfigurationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVerifiedAccessInstanceLoggingConfigurationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVerifiedAccessInstanceLoggingConfigurationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVerifiedAccessInstancesCommand}
    */
-  readonly describeVerifiedAccessInstances: (
-    args: DescribeVerifiedAccessInstancesCommandInput,
+  describeVerifiedAccessInstances(
+    args: DescribeVerifiedAccessInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVerifiedAccessInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVerifiedAccessInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVerifiedAccessTrustProvidersCommand}
    */
-  readonly describeVerifiedAccessTrustProviders: (
-    args: DescribeVerifiedAccessTrustProvidersCommandInput,
+  describeVerifiedAccessTrustProviders(
+    args: DescribeVerifiedAccessTrustProvidersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVerifiedAccessTrustProvidersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVerifiedAccessTrustProvidersResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVolumeAttributeCommand}
    */
-  readonly describeVolumeAttribute: (
-    args: DescribeVolumeAttributeCommandInput,
+  describeVolumeAttribute(
+    args: DescribeVolumeAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVolumeAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeVolumesCommand}
-   */
-  readonly describeVolumes: (
-    args: DescribeVolumesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeVolumesCommandOutput, SdkError | EC2ServiceError>;
-
-  /**
-   * @see {@link DescribeVolumesModificationsCommand}
-   */
-  readonly describeVolumesModifications: (
-    args: DescribeVolumesModificationsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVolumesModificationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVolumeAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVolumeStatusCommand}
    */
-  readonly describeVolumeStatus: (
-    args: DescribeVolumeStatusCommandInput,
+  describeVolumeStatus(
+    args: DescribeVolumeStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVolumeStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVolumeStatusResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeVolumesCommand}
+   */
+  describeVolumes(
+    args: DescribeVolumesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeVolumesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeVolumesModificationsCommand}
+   */
+  describeVolumesModifications(
+    args: DescribeVolumesModificationsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeVolumesModificationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcAttributeCommand}
    */
-  readonly describeVpcAttribute: (
-    args: DescribeVpcAttributeCommandInput,
+  describeVpcAttribute(
+    args: DescribeVpcAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcClassicLinkCommand}
    */
-  readonly describeVpcClassicLink: (
-    args: DescribeVpcClassicLinkCommandInput,
+  describeVpcClassicLink(
+    args: DescribeVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcClassicLinkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcClassicLinkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcClassicLinkDnsSupportCommand}
    */
-  readonly describeVpcClassicLinkDnsSupport: (
-    args: DescribeVpcClassicLinkDnsSupportCommandInput,
+  describeVpcClassicLinkDnsSupport(
+    args: DescribeVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcClassicLinkDnsSupportCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcClassicLinkDnsSupportResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcEndpointConnectionNotificationsCommand}
    */
-  readonly describeVpcEndpointConnectionNotifications: (
-    args: DescribeVpcEndpointConnectionNotificationsCommandInput,
+  describeVpcEndpointConnectionNotifications(
+    args: DescribeVpcEndpointConnectionNotificationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointConnectionNotificationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcEndpointConnectionNotificationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcEndpointConnectionsCommand}
    */
-  readonly describeVpcEndpointConnections: (
-    args: DescribeVpcEndpointConnectionsCommandInput,
+  describeVpcEndpointConnections(
+    args: DescribeVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-
-  /**
-   * @see {@link DescribeVpcEndpointsCommand}
-   */
-  readonly describeVpcEndpoints: (
-    args: DescribeVpcEndpointsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcEndpointConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcEndpointServiceConfigurationsCommand}
    */
-  readonly describeVpcEndpointServiceConfigurations: (
-    args: DescribeVpcEndpointServiceConfigurationsCommandInput,
+  describeVpcEndpointServiceConfigurations(
+    args: DescribeVpcEndpointServiceConfigurationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointServiceConfigurationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcEndpointServiceConfigurationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcEndpointServicePermissionsCommand}
    */
-  readonly describeVpcEndpointServicePermissions: (
-    args: DescribeVpcEndpointServicePermissionsCommandInput,
+  describeVpcEndpointServicePermissions(
+    args: DescribeVpcEndpointServicePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointServicePermissionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcEndpointServicePermissionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcEndpointServicesCommand}
    */
-  readonly describeVpcEndpointServices: (
-    args: DescribeVpcEndpointServicesCommandInput,
+  describeVpcEndpointServices(
+    args: DescribeVpcEndpointServicesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcEndpointServicesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcEndpointServicesResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link DescribeVpcEndpointsCommand}
+   */
+  describeVpcEndpoints(
+    args: DescribeVpcEndpointsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  DescribeVpcEndpointsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcPeeringConnectionsCommand}
    */
-  readonly describeVpcPeeringConnections: (
-    args: DescribeVpcPeeringConnectionsCommandInput,
+  describeVpcPeeringConnections(
+    args: DescribeVpcPeeringConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpcPeeringConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpcPeeringConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpcsCommand}
    */
-  readonly describeVpcs: (
-    args: DescribeVpcsCommandInput,
+  describeVpcs(
+    args: DescribeVpcsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DescribeVpcsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DescribeVpcsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpnConnectionsCommand}
    */
-  readonly describeVpnConnections: (
-    args: DescribeVpnConnectionsCommandInput,
+  describeVpnConnections(
+    args: DescribeVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpnConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpnConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DescribeVpnGatewaysCommand}
    */
-  readonly describeVpnGateways: (
-    args: DescribeVpnGatewaysCommandInput,
+  describeVpnGateways(
+    args: DescribeVpnGatewaysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeVpnGatewaysCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DescribeVpnGatewaysResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachClassicLinkVpcCommand}
    */
-  readonly detachClassicLinkVpc: (
-    args: DetachClassicLinkVpcCommandInput,
+  detachClassicLinkVpc(
+    args: DetachClassicLinkVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachClassicLinkVpcCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DetachClassicLinkVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachInternetGatewayCommand}
    */
-  readonly detachInternetGateway: (
-    args: DetachInternetGatewayCommandInput,
+  detachInternetGateway(
+    args: DetachInternetGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachInternetGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachNetworkInterfaceCommand}
    */
-  readonly detachNetworkInterface: (
-    args: DetachNetworkInterfaceCommandInput,
+  detachNetworkInterface(
+    args: DetachNetworkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachNetworkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachVerifiedAccessTrustProviderCommand}
    */
-  readonly detachVerifiedAccessTrustProvider: (
-    args: DetachVerifiedAccessTrustProviderCommandInput,
+  detachVerifiedAccessTrustProvider(
+    args: DetachVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachVerifiedAccessTrustProviderCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DetachVerifiedAccessTrustProviderResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachVolumeCommand}
    */
-  readonly detachVolume: (
-    args: DetachVolumeCommandInput,
+  detachVolume(
+    args: DetachVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DetachVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  VolumeAttachment,
+    | SdkError
+  >
 
   /**
    * @see {@link DetachVpnGatewayCommand}
    */
-  readonly detachVpnGateway: (
-    args: DetachVpnGatewayCommandInput,
+  detachVpnGateway(
+    args: DetachVpnGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DetachVpnGatewayCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableAddressTransferCommand}
    */
-  readonly disableAddressTransfer: (
-    args: DisableAddressTransferCommandInput,
+  disableAddressTransfer(
+    args: DisableAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableAddressTransferCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableAddressTransferResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableAwsNetworkPerformanceMetricSubscriptionCommand}
    */
-  readonly disableAwsNetworkPerformanceMetricSubscription: (
-    args: DisableAwsNetworkPerformanceMetricSubscriptionCommandInput,
+  disableAwsNetworkPerformanceMetricSubscription(
+    args: DisableAwsNetworkPerformanceMetricSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableAwsNetworkPerformanceMetricSubscriptionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableAwsNetworkPerformanceMetricSubscriptionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableEbsEncryptionByDefaultCommand}
    */
-  readonly disableEbsEncryptionByDefault: (
-    args: DisableEbsEncryptionByDefaultCommandInput,
+  disableEbsEncryptionByDefault(
+    args: DisableEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableEbsEncryptionByDefaultCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableEbsEncryptionByDefaultResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableFastLaunchCommand}
    */
-  readonly disableFastLaunch: (
-    args: DisableFastLaunchCommandInput,
+  disableFastLaunch(
+    args: DisableFastLaunchRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableFastLaunchCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableFastLaunchResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableFastSnapshotRestoresCommand}
    */
-  readonly disableFastSnapshotRestores: (
-    args: DisableFastSnapshotRestoresCommandInput,
+  disableFastSnapshotRestores(
+    args: DisableFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableFastSnapshotRestoresCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableFastSnapshotRestoresResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableImageCommand}
    */
-  readonly disableImage: (
-    args: DisableImageCommandInput,
+  disableImage(
+    args: DisableImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<DisableImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  DisableImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableImageBlockPublicAccessCommand}
    */
-  readonly disableImageBlockPublicAccess: (
-    args: DisableImageBlockPublicAccessCommandInput,
+  disableImageBlockPublicAccess(
+    args: DisableImageBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableImageBlockPublicAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableImageBlockPublicAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableImageDeprecationCommand}
    */
-  readonly disableImageDeprecation: (
-    args: DisableImageDeprecationCommandInput,
+  disableImageDeprecation(
+    args: DisableImageDeprecationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableImageDeprecationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableImageDeprecationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableIpamOrganizationAdminAccountCommand}
    */
-  readonly disableIpamOrganizationAdminAccount: (
-    args: DisableIpamOrganizationAdminAccountCommandInput,
+  disableIpamOrganizationAdminAccount(
+    args: DisableIpamOrganizationAdminAccountRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableIpamOrganizationAdminAccountCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableIpamOrganizationAdminAccountResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableSerialConsoleAccessCommand}
    */
-  readonly disableSerialConsoleAccess: (
-    args: DisableSerialConsoleAccessCommandInput,
+  disableSerialConsoleAccess(
+    args: DisableSerialConsoleAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableSerialConsoleAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableSerialConsoleAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableSnapshotBlockPublicAccessCommand}
    */
-  readonly disableSnapshotBlockPublicAccess: (
-    args: DisableSnapshotBlockPublicAccessCommandInput,
+  disableSnapshotBlockPublicAccess(
+    args: DisableSnapshotBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableSnapshotBlockPublicAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableSnapshotBlockPublicAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableTransitGatewayRouteTablePropagationCommand}
    */
-  readonly disableTransitGatewayRouteTablePropagation: (
-    args: DisableTransitGatewayRouteTablePropagationCommandInput,
+  disableTransitGatewayRouteTablePropagation(
+    args: DisableTransitGatewayRouteTablePropagationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableTransitGatewayRouteTablePropagationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableTransitGatewayRouteTablePropagationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableVgwRoutePropagationCommand}
    */
-  readonly disableVgwRoutePropagation: (
-    args: DisableVgwRoutePropagationCommandInput,
+  disableVgwRoutePropagation(
+    args: DisableVgwRoutePropagationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableVgwRoutePropagationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableVpcClassicLinkCommand}
    */
-  readonly disableVpcClassicLink: (
-    args: DisableVpcClassicLinkCommandInput,
+  disableVpcClassicLink(
+    args: DisableVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableVpcClassicLinkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableVpcClassicLinkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisableVpcClassicLinkDnsSupportCommand}
    */
-  readonly disableVpcClassicLinkDnsSupport: (
-    args: DisableVpcClassicLinkDnsSupportCommandInput,
+  disableVpcClassicLinkDnsSupport(
+    args: DisableVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisableVpcClassicLinkDnsSupportCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisableVpcClassicLinkDnsSupportResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateAddressCommand}
    */
-  readonly disassociateAddress: (
-    args: DisassociateAddressCommandInput,
+  disassociateAddress(
+    args: DisassociateAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateAddressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateClientVpnTargetNetworkCommand}
    */
-  readonly disassociateClientVpnTargetNetwork: (
-    args: DisassociateClientVpnTargetNetworkCommandInput,
+  disassociateClientVpnTargetNetwork(
+    args: DisassociateClientVpnTargetNetworkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateClientVpnTargetNetworkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateClientVpnTargetNetworkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateEnclaveCertificateIamRoleCommand}
    */
-  readonly disassociateEnclaveCertificateIamRole: (
-    args: DisassociateEnclaveCertificateIamRoleCommandInput,
+  disassociateEnclaveCertificateIamRole(
+    args: DisassociateEnclaveCertificateIamRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateEnclaveCertificateIamRoleCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateEnclaveCertificateIamRoleResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateIamInstanceProfileCommand}
    */
-  readonly disassociateIamInstanceProfile: (
-    args: DisassociateIamInstanceProfileCommandInput,
+  disassociateIamInstanceProfile(
+    args: DisassociateIamInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateIamInstanceProfileCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateIamInstanceProfileResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateInstanceEventWindowCommand}
    */
-  readonly disassociateInstanceEventWindow: (
-    args: DisassociateInstanceEventWindowCommandInput,
+  disassociateInstanceEventWindow(
+    args: DisassociateInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateInstanceEventWindowCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateInstanceEventWindowResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateIpamByoasnCommand}
    */
-  readonly disassociateIpamByoasn: (
-    args: DisassociateIpamByoasnCommandInput,
+  disassociateIpamByoasn(
+    args: DisassociateIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateIpamByoasnCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateIpamByoasnResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateIpamResourceDiscoveryCommand}
    */
-  readonly disassociateIpamResourceDiscovery: (
-    args: DisassociateIpamResourceDiscoveryCommandInput,
+  disassociateIpamResourceDiscovery(
+    args: DisassociateIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateIpamResourceDiscoveryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateIpamResourceDiscoveryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateNatGatewayAddressCommand}
    */
-  readonly disassociateNatGatewayAddress: (
-    args: DisassociateNatGatewayAddressCommandInput,
+  disassociateNatGatewayAddress(
+    args: DisassociateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateNatGatewayAddressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateNatGatewayAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateRouteTableCommand}
    */
-  readonly disassociateRouteTable: (
-    args: DisassociateRouteTableCommandInput,
+  disassociateRouteTable(
+    args: DisassociateRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateSubnetCidrBlockCommand}
    */
-  readonly disassociateSubnetCidrBlock: (
-    args: DisassociateSubnetCidrBlockCommandInput,
+  disassociateSubnetCidrBlock(
+    args: DisassociateSubnetCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateSubnetCidrBlockCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateSubnetCidrBlockResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateTransitGatewayMulticastDomainCommand}
    */
-  readonly disassociateTransitGatewayMulticastDomain: (
-    args: DisassociateTransitGatewayMulticastDomainCommandInput,
+  disassociateTransitGatewayMulticastDomain(
+    args: DisassociateTransitGatewayMulticastDomainRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateTransitGatewayMulticastDomainCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateTransitGatewayMulticastDomainResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateTransitGatewayPolicyTableCommand}
    */
-  readonly disassociateTransitGatewayPolicyTable: (
-    args: DisassociateTransitGatewayPolicyTableCommandInput,
+  disassociateTransitGatewayPolicyTable(
+    args: DisassociateTransitGatewayPolicyTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateTransitGatewayPolicyTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateTransitGatewayPolicyTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateTransitGatewayRouteTableCommand}
    */
-  readonly disassociateTransitGatewayRouteTable: (
-    args: DisassociateTransitGatewayRouteTableCommandInput,
+  disassociateTransitGatewayRouteTable(
+    args: DisassociateTransitGatewayRouteTableRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateTransitGatewayRouteTableCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateTransitGatewayRouteTableResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateTrunkInterfaceCommand}
    */
-  readonly disassociateTrunkInterface: (
-    args: DisassociateTrunkInterfaceCommandInput,
+  disassociateTrunkInterface(
+    args: DisassociateTrunkInterfaceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateTrunkInterfaceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateTrunkInterfaceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link DisassociateVpcCidrBlockCommand}
    */
-  readonly disassociateVpcCidrBlock: (
-    args: DisassociateVpcCidrBlockCommandInput,
+  disassociateVpcCidrBlock(
+    args: DisassociateVpcCidrBlockRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DisassociateVpcCidrBlockCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  DisassociateVpcCidrBlockResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableAddressTransferCommand}
    */
-  readonly enableAddressTransfer: (
-    args: EnableAddressTransferCommandInput,
+  enableAddressTransfer(
+    args: EnableAddressTransferRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableAddressTransferCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableAddressTransferResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableAwsNetworkPerformanceMetricSubscriptionCommand}
    */
-  readonly enableAwsNetworkPerformanceMetricSubscription: (
-    args: EnableAwsNetworkPerformanceMetricSubscriptionCommandInput,
+  enableAwsNetworkPerformanceMetricSubscription(
+    args: EnableAwsNetworkPerformanceMetricSubscriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableAwsNetworkPerformanceMetricSubscriptionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableAwsNetworkPerformanceMetricSubscriptionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableEbsEncryptionByDefaultCommand}
    */
-  readonly enableEbsEncryptionByDefault: (
-    args: EnableEbsEncryptionByDefaultCommandInput,
+  enableEbsEncryptionByDefault(
+    args: EnableEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableEbsEncryptionByDefaultCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableEbsEncryptionByDefaultResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableFastLaunchCommand}
    */
-  readonly enableFastLaunch: (
-    args: EnableFastLaunchCommandInput,
+  enableFastLaunch(
+    args: EnableFastLaunchRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<EnableFastLaunchCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  EnableFastLaunchResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableFastSnapshotRestoresCommand}
    */
-  readonly enableFastSnapshotRestores: (
-    args: EnableFastSnapshotRestoresCommandInput,
+  enableFastSnapshotRestores(
+    args: EnableFastSnapshotRestoresRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableFastSnapshotRestoresCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableFastSnapshotRestoresResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableImageCommand}
    */
-  readonly enableImage: (
-    args: EnableImageCommandInput,
+  enableImage(
+    args: EnableImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<EnableImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  EnableImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableImageBlockPublicAccessCommand}
    */
-  readonly enableImageBlockPublicAccess: (
-    args: EnableImageBlockPublicAccessCommandInput,
+  enableImageBlockPublicAccess(
+    args: EnableImageBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableImageBlockPublicAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableImageBlockPublicAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableImageDeprecationCommand}
    */
-  readonly enableImageDeprecation: (
-    args: EnableImageDeprecationCommandInput,
+  enableImageDeprecation(
+    args: EnableImageDeprecationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableImageDeprecationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableImageDeprecationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableIpamOrganizationAdminAccountCommand}
    */
-  readonly enableIpamOrganizationAdminAccount: (
-    args: EnableIpamOrganizationAdminAccountCommandInput,
+  enableIpamOrganizationAdminAccount(
+    args: EnableIpamOrganizationAdminAccountRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableIpamOrganizationAdminAccountCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableIpamOrganizationAdminAccountResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableReachabilityAnalyzerOrganizationSharingCommand}
    */
-  readonly enableReachabilityAnalyzerOrganizationSharing: (
-    args: EnableReachabilityAnalyzerOrganizationSharingCommandInput,
+  enableReachabilityAnalyzerOrganizationSharing(
+    args: EnableReachabilityAnalyzerOrganizationSharingRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableReachabilityAnalyzerOrganizationSharingCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableReachabilityAnalyzerOrganizationSharingResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableSerialConsoleAccessCommand}
    */
-  readonly enableSerialConsoleAccess: (
-    args: EnableSerialConsoleAccessCommandInput,
+  enableSerialConsoleAccess(
+    args: EnableSerialConsoleAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableSerialConsoleAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableSerialConsoleAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableSnapshotBlockPublicAccessCommand}
    */
-  readonly enableSnapshotBlockPublicAccess: (
-    args: EnableSnapshotBlockPublicAccessCommandInput,
+  enableSnapshotBlockPublicAccess(
+    args: EnableSnapshotBlockPublicAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableSnapshotBlockPublicAccessCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableSnapshotBlockPublicAccessResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableTransitGatewayRouteTablePropagationCommand}
    */
-  readonly enableTransitGatewayRouteTablePropagation: (
-    args: EnableTransitGatewayRouteTablePropagationCommandInput,
+  enableTransitGatewayRouteTablePropagation(
+    args: EnableTransitGatewayRouteTablePropagationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableTransitGatewayRouteTablePropagationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableTransitGatewayRouteTablePropagationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableVgwRoutePropagationCommand}
    */
-  readonly enableVgwRoutePropagation: (
-    args: EnableVgwRoutePropagationCommandInput,
+  enableVgwRoutePropagation(
+    args: EnableVgwRoutePropagationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableVgwRoutePropagationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableVolumeIOCommand}
    */
-  readonly enableVolumeIO: (
-    args: EnableVolumeIOCommandInput,
+  enableVolumeIO(
+    args: EnableVolumeIORequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<EnableVolumeIOCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableVpcClassicLinkCommand}
    */
-  readonly enableVpcClassicLink: (
-    args: EnableVpcClassicLinkCommandInput,
+  enableVpcClassicLink(
+    args: EnableVpcClassicLinkRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableVpcClassicLinkCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableVpcClassicLinkResult,
+    | SdkError
+  >
 
   /**
    * @see {@link EnableVpcClassicLinkDnsSupportCommand}
    */
-  readonly enableVpcClassicLinkDnsSupport: (
-    args: EnableVpcClassicLinkDnsSupportCommandInput,
+  enableVpcClassicLinkDnsSupport(
+    args: EnableVpcClassicLinkDnsSupportRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableVpcClassicLinkDnsSupportCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  EnableVpcClassicLinkDnsSupportResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ExportClientVpnClientCertificateRevocationListCommand}
    */
-  readonly exportClientVpnClientCertificateRevocationList: (
-    args: ExportClientVpnClientCertificateRevocationListCommandInput,
+  exportClientVpnClientCertificateRevocationList(
+    args: ExportClientVpnClientCertificateRevocationListRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ExportClientVpnClientCertificateRevocationListCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ExportClientVpnClientCertificateRevocationListResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ExportClientVpnClientConfigurationCommand}
    */
-  readonly exportClientVpnClientConfiguration: (
-    args: ExportClientVpnClientConfigurationCommandInput,
+  exportClientVpnClientConfiguration(
+    args: ExportClientVpnClientConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ExportClientVpnClientConfigurationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ExportClientVpnClientConfigurationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ExportImageCommand}
    */
-  readonly exportImage: (
-    args: ExportImageCommandInput,
+  exportImage(
+    args: ExportImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ExportImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ExportImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ExportTransitGatewayRoutesCommand}
    */
-  readonly exportTransitGatewayRoutes: (
-    args: ExportTransitGatewayRoutesCommandInput,
+  exportTransitGatewayRoutes(
+    args: ExportTransitGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ExportTransitGatewayRoutesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ExportTransitGatewayRoutesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetAssociatedEnclaveCertificateIamRolesCommand}
    */
-  readonly getAssociatedEnclaveCertificateIamRoles: (
-    args: GetAssociatedEnclaveCertificateIamRolesCommandInput,
+  getAssociatedEnclaveCertificateIamRoles(
+    args: GetAssociatedEnclaveCertificateIamRolesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAssociatedEnclaveCertificateIamRolesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetAssociatedEnclaveCertificateIamRolesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetAssociatedIpv6PoolCidrsCommand}
    */
-  readonly getAssociatedIpv6PoolCidrs: (
-    args: GetAssociatedIpv6PoolCidrsCommandInput,
+  getAssociatedIpv6PoolCidrs(
+    args: GetAssociatedIpv6PoolCidrsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAssociatedIpv6PoolCidrsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetAssociatedIpv6PoolCidrsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetAwsNetworkPerformanceDataCommand}
    */
-  readonly getAwsNetworkPerformanceData: (
-    args: GetAwsNetworkPerformanceDataCommandInput,
+  getAwsNetworkPerformanceData(
+    args: GetAwsNetworkPerformanceDataRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAwsNetworkPerformanceDataCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetAwsNetworkPerformanceDataResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetCapacityReservationUsageCommand}
    */
-  readonly getCapacityReservationUsage: (
-    args: GetCapacityReservationUsageCommandInput,
+  getCapacityReservationUsage(
+    args: GetCapacityReservationUsageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetCapacityReservationUsageCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetCapacityReservationUsageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetCoipPoolUsageCommand}
    */
-  readonly getCoipPoolUsage: (
-    args: GetCoipPoolUsageCommandInput,
+  getCoipPoolUsage(
+    args: GetCoipPoolUsageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<GetCoipPoolUsageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  GetCoipPoolUsageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetConsoleOutputCommand}
    */
-  readonly getConsoleOutput: (
-    args: GetConsoleOutputCommandInput,
+  getConsoleOutput(
+    args: GetConsoleOutputRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<GetConsoleOutputCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  GetConsoleOutputResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetConsoleScreenshotCommand}
    */
-  readonly getConsoleScreenshot: (
-    args: GetConsoleScreenshotCommandInput,
+  getConsoleScreenshot(
+    args: GetConsoleScreenshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetConsoleScreenshotCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetConsoleScreenshotResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetDefaultCreditSpecificationCommand}
    */
-  readonly getDefaultCreditSpecification: (
-    args: GetDefaultCreditSpecificationCommandInput,
+  getDefaultCreditSpecification(
+    args: GetDefaultCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetDefaultCreditSpecificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetDefaultCreditSpecificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetEbsDefaultKmsKeyIdCommand}
    */
-  readonly getEbsDefaultKmsKeyId: (
-    args: GetEbsDefaultKmsKeyIdCommandInput,
+  getEbsDefaultKmsKeyId(
+    args: GetEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetEbsDefaultKmsKeyIdCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetEbsDefaultKmsKeyIdResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetEbsEncryptionByDefaultCommand}
    */
-  readonly getEbsEncryptionByDefault: (
-    args: GetEbsEncryptionByDefaultCommandInput,
+  getEbsEncryptionByDefault(
+    args: GetEbsEncryptionByDefaultRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetEbsEncryptionByDefaultCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetEbsEncryptionByDefaultResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetFlowLogsIntegrationTemplateCommand}
    */
-  readonly getFlowLogsIntegrationTemplate: (
-    args: GetFlowLogsIntegrationTemplateCommandInput,
+  getFlowLogsIntegrationTemplate(
+    args: GetFlowLogsIntegrationTemplateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetFlowLogsIntegrationTemplateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetFlowLogsIntegrationTemplateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetGroupsForCapacityReservationCommand}
    */
-  readonly getGroupsForCapacityReservation: (
-    args: GetGroupsForCapacityReservationCommandInput,
+  getGroupsForCapacityReservation(
+    args: GetGroupsForCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetGroupsForCapacityReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetGroupsForCapacityReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetHostReservationPurchasePreviewCommand}
    */
-  readonly getHostReservationPurchasePreview: (
-    args: GetHostReservationPurchasePreviewCommandInput,
+  getHostReservationPurchasePreview(
+    args: GetHostReservationPurchasePreviewRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetHostReservationPurchasePreviewCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetHostReservationPurchasePreviewResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetImageBlockPublicAccessStateCommand}
    */
-  readonly getImageBlockPublicAccessState: (
-    args: GetImageBlockPublicAccessStateCommandInput,
+  getImageBlockPublicAccessState(
+    args: GetImageBlockPublicAccessStateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetImageBlockPublicAccessStateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetImageBlockPublicAccessStateResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link GetInstanceMetadataDefaultsCommand}
+   */
+  getInstanceMetadataDefaults(
+    args: GetInstanceMetadataDefaultsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  GetInstanceMetadataDefaultsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetInstanceTypesFromInstanceRequirementsCommand}
    */
-  readonly getInstanceTypesFromInstanceRequirements: (
-    args: GetInstanceTypesFromInstanceRequirementsCommandInput,
+  getInstanceTypesFromInstanceRequirements(
+    args: GetInstanceTypesFromInstanceRequirementsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetInstanceTypesFromInstanceRequirementsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetInstanceTypesFromInstanceRequirementsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetInstanceUefiDataCommand}
    */
-  readonly getInstanceUefiData: (
-    args: GetInstanceUefiDataCommandInput,
+  getInstanceUefiData(
+    args: GetInstanceUefiDataRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetInstanceUefiDataCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetInstanceUefiDataResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamAddressHistoryCommand}
    */
-  readonly getIpamAddressHistory: (
-    args: GetIpamAddressHistoryCommandInput,
+  getIpamAddressHistory(
+    args: GetIpamAddressHistoryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamAddressHistoryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamAddressHistoryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamDiscoveredAccountsCommand}
    */
-  readonly getIpamDiscoveredAccounts: (
-    args: GetIpamDiscoveredAccountsCommandInput,
+  getIpamDiscoveredAccounts(
+    args: GetIpamDiscoveredAccountsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamDiscoveredAccountsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamDiscoveredAccountsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamDiscoveredPublicAddressesCommand}
    */
-  readonly getIpamDiscoveredPublicAddresses: (
-    args: GetIpamDiscoveredPublicAddressesCommandInput,
+  getIpamDiscoveredPublicAddresses(
+    args: GetIpamDiscoveredPublicAddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamDiscoveredPublicAddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamDiscoveredPublicAddressesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamDiscoveredResourceCidrsCommand}
    */
-  readonly getIpamDiscoveredResourceCidrs: (
-    args: GetIpamDiscoveredResourceCidrsCommandInput,
+  getIpamDiscoveredResourceCidrs(
+    args: GetIpamDiscoveredResourceCidrsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamDiscoveredResourceCidrsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamDiscoveredResourceCidrsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamPoolAllocationsCommand}
    */
-  readonly getIpamPoolAllocations: (
-    args: GetIpamPoolAllocationsCommandInput,
+  getIpamPoolAllocations(
+    args: GetIpamPoolAllocationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamPoolAllocationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamPoolAllocationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamPoolCidrsCommand}
    */
-  readonly getIpamPoolCidrs: (
-    args: GetIpamPoolCidrsCommandInput,
+  getIpamPoolCidrs(
+    args: GetIpamPoolCidrsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<GetIpamPoolCidrsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  GetIpamPoolCidrsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetIpamResourceCidrsCommand}
    */
-  readonly getIpamResourceCidrs: (
-    args: GetIpamResourceCidrsCommandInput,
+  getIpamResourceCidrs(
+    args: GetIpamResourceCidrsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetIpamResourceCidrsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetIpamResourceCidrsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetLaunchTemplateDataCommand}
    */
-  readonly getLaunchTemplateData: (
-    args: GetLaunchTemplateDataCommandInput,
+  getLaunchTemplateData(
+    args: GetLaunchTemplateDataRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetLaunchTemplateDataCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetLaunchTemplateDataResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetManagedPrefixListAssociationsCommand}
    */
-  readonly getManagedPrefixListAssociations: (
-    args: GetManagedPrefixListAssociationsCommandInput,
+  getManagedPrefixListAssociations(
+    args: GetManagedPrefixListAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetManagedPrefixListAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetManagedPrefixListAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetManagedPrefixListEntriesCommand}
    */
-  readonly getManagedPrefixListEntries: (
-    args: GetManagedPrefixListEntriesCommandInput,
+  getManagedPrefixListEntries(
+    args: GetManagedPrefixListEntriesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetManagedPrefixListEntriesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetManagedPrefixListEntriesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetNetworkInsightsAccessScopeAnalysisFindingsCommand}
    */
-  readonly getNetworkInsightsAccessScopeAnalysisFindings: (
-    args: GetNetworkInsightsAccessScopeAnalysisFindingsCommandInput,
+  getNetworkInsightsAccessScopeAnalysisFindings(
+    args: GetNetworkInsightsAccessScopeAnalysisFindingsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetNetworkInsightsAccessScopeAnalysisFindingsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetNetworkInsightsAccessScopeAnalysisFindingsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetNetworkInsightsAccessScopeContentCommand}
    */
-  readonly getNetworkInsightsAccessScopeContent: (
-    args: GetNetworkInsightsAccessScopeContentCommandInput,
+  getNetworkInsightsAccessScopeContent(
+    args: GetNetworkInsightsAccessScopeContentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetNetworkInsightsAccessScopeContentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetNetworkInsightsAccessScopeContentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetPasswordDataCommand}
    */
-  readonly getPasswordData: (
-    args: GetPasswordDataCommandInput,
+  getPasswordData(
+    args: GetPasswordDataRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<GetPasswordDataCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  GetPasswordDataResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetReservedInstancesExchangeQuoteCommand}
    */
-  readonly getReservedInstancesExchangeQuote: (
-    args: GetReservedInstancesExchangeQuoteCommandInput,
+  getReservedInstancesExchangeQuote(
+    args: GetReservedInstancesExchangeQuoteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetReservedInstancesExchangeQuoteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetReservedInstancesExchangeQuoteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetSecurityGroupsForVpcCommand}
    */
-  readonly getSecurityGroupsForVpc: (
-    args: GetSecurityGroupsForVpcCommandInput,
+  getSecurityGroupsForVpc(
+    args: GetSecurityGroupsForVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSecurityGroupsForVpcCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetSecurityGroupsForVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetSerialConsoleAccessStatusCommand}
    */
-  readonly getSerialConsoleAccessStatus: (
-    args: GetSerialConsoleAccessStatusCommandInput,
+  getSerialConsoleAccessStatus(
+    args: GetSerialConsoleAccessStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSerialConsoleAccessStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetSerialConsoleAccessStatusResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetSnapshotBlockPublicAccessStateCommand}
    */
-  readonly getSnapshotBlockPublicAccessState: (
-    args: GetSnapshotBlockPublicAccessStateCommandInput,
+  getSnapshotBlockPublicAccessState(
+    args: GetSnapshotBlockPublicAccessStateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSnapshotBlockPublicAccessStateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetSnapshotBlockPublicAccessStateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetSpotPlacementScoresCommand}
    */
-  readonly getSpotPlacementScores: (
-    args: GetSpotPlacementScoresCommandInput,
+  getSpotPlacementScores(
+    args: GetSpotPlacementScoresRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSpotPlacementScoresCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetSpotPlacementScoresResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetSubnetCidrReservationsCommand}
    */
-  readonly getSubnetCidrReservations: (
-    args: GetSubnetCidrReservationsCommandInput,
+  getSubnetCidrReservations(
+    args: GetSubnetCidrReservationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSubnetCidrReservationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetSubnetCidrReservationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayAttachmentPropagationsCommand}
    */
-  readonly getTransitGatewayAttachmentPropagations: (
-    args: GetTransitGatewayAttachmentPropagationsCommandInput,
+  getTransitGatewayAttachmentPropagations(
+    args: GetTransitGatewayAttachmentPropagationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayAttachmentPropagationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayAttachmentPropagationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayMulticastDomainAssociationsCommand}
    */
-  readonly getTransitGatewayMulticastDomainAssociations: (
-    args: GetTransitGatewayMulticastDomainAssociationsCommandInput,
+  getTransitGatewayMulticastDomainAssociations(
+    args: GetTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayMulticastDomainAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayMulticastDomainAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayPolicyTableAssociationsCommand}
    */
-  readonly getTransitGatewayPolicyTableAssociations: (
-    args: GetTransitGatewayPolicyTableAssociationsCommandInput,
+  getTransitGatewayPolicyTableAssociations(
+    args: GetTransitGatewayPolicyTableAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayPolicyTableAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayPolicyTableAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayPolicyTableEntriesCommand}
    */
-  readonly getTransitGatewayPolicyTableEntries: (
-    args: GetTransitGatewayPolicyTableEntriesCommandInput,
+  getTransitGatewayPolicyTableEntries(
+    args: GetTransitGatewayPolicyTableEntriesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayPolicyTableEntriesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayPolicyTableEntriesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayPrefixListReferencesCommand}
    */
-  readonly getTransitGatewayPrefixListReferences: (
-    args: GetTransitGatewayPrefixListReferencesCommandInput,
+  getTransitGatewayPrefixListReferences(
+    args: GetTransitGatewayPrefixListReferencesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayPrefixListReferencesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayPrefixListReferencesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayRouteTableAssociationsCommand}
    */
-  readonly getTransitGatewayRouteTableAssociations: (
-    args: GetTransitGatewayRouteTableAssociationsCommandInput,
+  getTransitGatewayRouteTableAssociations(
+    args: GetTransitGatewayRouteTableAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayRouteTableAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayRouteTableAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetTransitGatewayRouteTablePropagationsCommand}
    */
-  readonly getTransitGatewayRouteTablePropagations: (
-    args: GetTransitGatewayRouteTablePropagationsCommandInput,
+  getTransitGatewayRouteTablePropagations(
+    args: GetTransitGatewayRouteTablePropagationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetTransitGatewayRouteTablePropagationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetTransitGatewayRouteTablePropagationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetVerifiedAccessEndpointPolicyCommand}
    */
-  readonly getVerifiedAccessEndpointPolicy: (
-    args: GetVerifiedAccessEndpointPolicyCommandInput,
+  getVerifiedAccessEndpointPolicy(
+    args: GetVerifiedAccessEndpointPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetVerifiedAccessEndpointPolicyCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetVerifiedAccessEndpointPolicyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetVerifiedAccessGroupPolicyCommand}
    */
-  readonly getVerifiedAccessGroupPolicy: (
-    args: GetVerifiedAccessGroupPolicyCommandInput,
+  getVerifiedAccessGroupPolicy(
+    args: GetVerifiedAccessGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetVerifiedAccessGroupPolicyCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetVerifiedAccessGroupPolicyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetVpnConnectionDeviceSampleConfigurationCommand}
    */
-  readonly getVpnConnectionDeviceSampleConfiguration: (
-    args: GetVpnConnectionDeviceSampleConfigurationCommandInput,
+  getVpnConnectionDeviceSampleConfiguration(
+    args: GetVpnConnectionDeviceSampleConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetVpnConnectionDeviceSampleConfigurationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetVpnConnectionDeviceSampleConfigurationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetVpnConnectionDeviceTypesCommand}
    */
-  readonly getVpnConnectionDeviceTypes: (
-    args: GetVpnConnectionDeviceTypesCommandInput,
+  getVpnConnectionDeviceTypes(
+    args: GetVpnConnectionDeviceTypesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetVpnConnectionDeviceTypesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetVpnConnectionDeviceTypesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link GetVpnTunnelReplacementStatusCommand}
    */
-  readonly getVpnTunnelReplacementStatus: (
-    args: GetVpnTunnelReplacementStatusCommandInput,
+  getVpnTunnelReplacementStatus(
+    args: GetVpnTunnelReplacementStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetVpnTunnelReplacementStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  GetVpnTunnelReplacementStatusResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportClientVpnClientCertificateRevocationListCommand}
    */
-  readonly importClientVpnClientCertificateRevocationList: (
-    args: ImportClientVpnClientCertificateRevocationListCommandInput,
+  importClientVpnClientCertificateRevocationList(
+    args: ImportClientVpnClientCertificateRevocationListRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ImportClientVpnClientCertificateRevocationListCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ImportClientVpnClientCertificateRevocationListResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportImageCommand}
    */
-  readonly importImage: (
-    args: ImportImageCommandInput,
+  importImage(
+    args: ImportImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ImportImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ImportImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportInstanceCommand}
    */
-  readonly importInstance: (
-    args: ImportInstanceCommandInput,
+  importInstance(
+    args: ImportInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ImportInstanceCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ImportInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportKeyPairCommand}
    */
-  readonly importKeyPair: (
-    args: ImportKeyPairCommandInput,
+  importKeyPair(
+    args: ImportKeyPairRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ImportKeyPairCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ImportKeyPairResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportSnapshotCommand}
    */
-  readonly importSnapshot: (
-    args: ImportSnapshotCommandInput,
+  importSnapshot(
+    args: ImportSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ImportSnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ImportSnapshotResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ImportVolumeCommand}
    */
-  readonly importVolume: (
-    args: ImportVolumeCommandInput,
+  importVolume(
+    args: ImportVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ImportVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ImportVolumeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ListImagesInRecycleBinCommand}
    */
-  readonly listImagesInRecycleBin: (
-    args: ListImagesInRecycleBinCommandInput,
+  listImagesInRecycleBin(
+    args: ListImagesInRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListImagesInRecycleBinCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ListImagesInRecycleBinResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ListSnapshotsInRecycleBinCommand}
    */
-  readonly listSnapshotsInRecycleBin: (
-    args: ListSnapshotsInRecycleBinCommandInput,
+  listSnapshotsInRecycleBin(
+    args: ListSnapshotsInRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListSnapshotsInRecycleBinCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ListSnapshotsInRecycleBinResult,
+    | SdkError
+  >
 
   /**
    * @see {@link LockSnapshotCommand}
    */
-  readonly lockSnapshot: (
-    args: LockSnapshotCommandInput,
+  lockSnapshot(
+    args: LockSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<LockSnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  LockSnapshotResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyAddressAttributeCommand}
    */
-  readonly modifyAddressAttribute: (
-    args: ModifyAddressAttributeCommandInput,
+  modifyAddressAttribute(
+    args: ModifyAddressAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyAddressAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyAddressAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyAvailabilityZoneGroupCommand}
    */
-  readonly modifyAvailabilityZoneGroup: (
-    args: ModifyAvailabilityZoneGroupCommandInput,
+  modifyAvailabilityZoneGroup(
+    args: ModifyAvailabilityZoneGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyAvailabilityZoneGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyAvailabilityZoneGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyCapacityReservationCommand}
    */
-  readonly modifyCapacityReservation: (
-    args: ModifyCapacityReservationCommandInput,
+  modifyCapacityReservation(
+    args: ModifyCapacityReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyCapacityReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyCapacityReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyCapacityReservationFleetCommand}
    */
-  readonly modifyCapacityReservationFleet: (
-    args: ModifyCapacityReservationFleetCommandInput,
+  modifyCapacityReservationFleet(
+    args: ModifyCapacityReservationFleetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyCapacityReservationFleetCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyCapacityReservationFleetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyClientVpnEndpointCommand}
    */
-  readonly modifyClientVpnEndpoint: (
-    args: ModifyClientVpnEndpointCommandInput,
+  modifyClientVpnEndpoint(
+    args: ModifyClientVpnEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyClientVpnEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyClientVpnEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyDefaultCreditSpecificationCommand}
    */
-  readonly modifyDefaultCreditSpecification: (
-    args: ModifyDefaultCreditSpecificationCommandInput,
+  modifyDefaultCreditSpecification(
+    args: ModifyDefaultCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyDefaultCreditSpecificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyDefaultCreditSpecificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyEbsDefaultKmsKeyIdCommand}
    */
-  readonly modifyEbsDefaultKmsKeyId: (
-    args: ModifyEbsDefaultKmsKeyIdCommandInput,
+  modifyEbsDefaultKmsKeyId(
+    args: ModifyEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyEbsDefaultKmsKeyIdCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyEbsDefaultKmsKeyIdResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyFleetCommand}
    */
-  readonly modifyFleet: (
-    args: ModifyFleetCommandInput,
+  modifyFleet(
+    args: ModifyFleetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyFleetCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyFleetResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyFpgaImageAttributeCommand}
    */
-  readonly modifyFpgaImageAttribute: (
-    args: ModifyFpgaImageAttributeCommandInput,
+  modifyFpgaImageAttribute(
+    args: ModifyFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyFpgaImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyFpgaImageAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyHostsCommand}
    */
-  readonly modifyHosts: (
-    args: ModifyHostsCommandInput,
+  modifyHosts(
+    args: ModifyHostsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyHostsCommandOutput, SdkError | EC2ServiceError>;
-
-  /**
-   * @see {@link ModifyIdentityIdFormatCommand}
-   */
-  readonly modifyIdentityIdFormat: (
-    args: ModifyIdentityIdFormatCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyIdentityIdFormatCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyHostsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIdFormatCommand}
    */
-  readonly modifyIdFormat: (
-    args: ModifyIdFormatCommandInput,
+  modifyIdFormat(
+    args: ModifyIdFormatRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyIdFormatCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
+
+  /**
+   * @see {@link ModifyIdentityIdFormatCommand}
+   */
+  modifyIdentityIdFormat(
+    args: ModifyIdentityIdFormatRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyImageAttributeCommand}
    */
-  readonly modifyImageAttribute: (
-    args: ModifyImageAttributeCommandInput,
+  modifyImageAttribute(
+    args: ModifyImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceAttributeCommand}
    */
-  readonly modifyInstanceAttribute: (
-    args: ModifyInstanceAttributeCommandInput,
+  modifyInstanceAttribute(
+    args: ModifyInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceCapacityReservationAttributesCommand}
    */
-  readonly modifyInstanceCapacityReservationAttributes: (
-    args: ModifyInstanceCapacityReservationAttributesCommandInput,
+  modifyInstanceCapacityReservationAttributes(
+    args: ModifyInstanceCapacityReservationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceCapacityReservationAttributesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceCapacityReservationAttributesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceCreditSpecificationCommand}
    */
-  readonly modifyInstanceCreditSpecification: (
-    args: ModifyInstanceCreditSpecificationCommandInput,
+  modifyInstanceCreditSpecification(
+    args: ModifyInstanceCreditSpecificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceCreditSpecificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceCreditSpecificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceEventStartTimeCommand}
    */
-  readonly modifyInstanceEventStartTime: (
-    args: ModifyInstanceEventStartTimeCommandInput,
+  modifyInstanceEventStartTime(
+    args: ModifyInstanceEventStartTimeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceEventStartTimeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceEventStartTimeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceEventWindowCommand}
    */
-  readonly modifyInstanceEventWindow: (
-    args: ModifyInstanceEventWindowCommandInput,
+  modifyInstanceEventWindow(
+    args: ModifyInstanceEventWindowRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceEventWindowCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceEventWindowResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceMaintenanceOptionsCommand}
    */
-  readonly modifyInstanceMaintenanceOptions: (
-    args: ModifyInstanceMaintenanceOptionsCommandInput,
+  modifyInstanceMaintenanceOptions(
+    args: ModifyInstanceMaintenanceOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceMaintenanceOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceMaintenanceOptionsResult,
+    | SdkError
+  >
+
+  /**
+   * @see {@link ModifyInstanceMetadataDefaultsCommand}
+   */
+  modifyInstanceMetadataDefaults(
+    args: ModifyInstanceMetadataDefaultsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+  ModifyInstanceMetadataDefaultsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstanceMetadataOptionsCommand}
    */
-  readonly modifyInstanceMetadataOptions: (
-    args: ModifyInstanceMetadataOptionsCommandInput,
+  modifyInstanceMetadataOptions(
+    args: ModifyInstanceMetadataOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstanceMetadataOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstanceMetadataOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyInstancePlacementCommand}
    */
-  readonly modifyInstancePlacement: (
-    args: ModifyInstancePlacementCommandInput,
+  modifyInstancePlacement(
+    args: ModifyInstancePlacementRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyInstancePlacementCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyInstancePlacementResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIpamCommand}
    */
-  readonly modifyIpam: (
-    args: ModifyIpamCommandInput,
+  modifyIpam(
+    args: ModifyIpamRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyIpamCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyIpamResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIpamPoolCommand}
    */
-  readonly modifyIpamPool: (
-    args: ModifyIpamPoolCommandInput,
+  modifyIpamPool(
+    args: ModifyIpamPoolRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyIpamPoolCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyIpamPoolResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIpamResourceCidrCommand}
    */
-  readonly modifyIpamResourceCidr: (
-    args: ModifyIpamResourceCidrCommandInput,
+  modifyIpamResourceCidr(
+    args: ModifyIpamResourceCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyIpamResourceCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyIpamResourceCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIpamResourceDiscoveryCommand}
    */
-  readonly modifyIpamResourceDiscovery: (
-    args: ModifyIpamResourceDiscoveryCommandInput,
+  modifyIpamResourceDiscovery(
+    args: ModifyIpamResourceDiscoveryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyIpamResourceDiscoveryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyIpamResourceDiscoveryResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyIpamScopeCommand}
    */
-  readonly modifyIpamScope: (
-    args: ModifyIpamScopeCommandInput,
+  modifyIpamScope(
+    args: ModifyIpamScopeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyIpamScopeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyIpamScopeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyLaunchTemplateCommand}
    */
-  readonly modifyLaunchTemplate: (
-    args: ModifyLaunchTemplateCommandInput,
+  modifyLaunchTemplate(
+    args: ModifyLaunchTemplateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyLaunchTemplateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyLaunchTemplateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyLocalGatewayRouteCommand}
    */
-  readonly modifyLocalGatewayRoute: (
-    args: ModifyLocalGatewayRouteCommandInput,
+  modifyLocalGatewayRoute(
+    args: ModifyLocalGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyLocalGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyLocalGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyManagedPrefixListCommand}
    */
-  readonly modifyManagedPrefixList: (
-    args: ModifyManagedPrefixListCommandInput,
+  modifyManagedPrefixList(
+    args: ModifyManagedPrefixListRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyManagedPrefixListCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyManagedPrefixListResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyNetworkInterfaceAttributeCommand}
    */
-  readonly modifyNetworkInterfaceAttribute: (
-    args: ModifyNetworkInterfaceAttributeCommandInput,
+  modifyNetworkInterfaceAttribute(
+    args: ModifyNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyNetworkInterfaceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyPrivateDnsNameOptionsCommand}
    */
-  readonly modifyPrivateDnsNameOptions: (
-    args: ModifyPrivateDnsNameOptionsCommandInput,
+  modifyPrivateDnsNameOptions(
+    args: ModifyPrivateDnsNameOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyPrivateDnsNameOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyPrivateDnsNameOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyReservedInstancesCommand}
    */
-  readonly modifyReservedInstances: (
-    args: ModifyReservedInstancesCommandInput,
+  modifyReservedInstances(
+    args: ModifyReservedInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyReservedInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyReservedInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifySecurityGroupRulesCommand}
    */
-  readonly modifySecurityGroupRules: (
-    args: ModifySecurityGroupRulesCommandInput,
+  modifySecurityGroupRules(
+    args: ModifySecurityGroupRulesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifySecurityGroupRulesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifySecurityGroupRulesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifySnapshotAttributeCommand}
    */
-  readonly modifySnapshotAttribute: (
-    args: ModifySnapshotAttributeCommandInput,
+  modifySnapshotAttribute(
+    args: ModifySnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifySnapshotAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifySnapshotTierCommand}
    */
-  readonly modifySnapshotTier: (
-    args: ModifySnapshotTierCommandInput,
+  modifySnapshotTier(
+    args: ModifySnapshotTierRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifySnapshotTierCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifySnapshotTierResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifySpotFleetRequestCommand}
    */
-  readonly modifySpotFleetRequest: (
-    args: ModifySpotFleetRequestCommandInput,
+  modifySpotFleetRequest(
+    args: ModifySpotFleetRequestRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifySpotFleetRequestCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifySpotFleetRequestResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifySubnetAttributeCommand}
    */
-  readonly modifySubnetAttribute: (
-    args: ModifySubnetAttributeCommandInput,
+  modifySubnetAttribute(
+    args: ModifySubnetAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifySubnetAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTrafficMirrorFilterNetworkServicesCommand}
    */
-  readonly modifyTrafficMirrorFilterNetworkServices: (
-    args: ModifyTrafficMirrorFilterNetworkServicesCommandInput,
+  modifyTrafficMirrorFilterNetworkServices(
+    args: ModifyTrafficMirrorFilterNetworkServicesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTrafficMirrorFilterNetworkServicesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTrafficMirrorFilterNetworkServicesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTrafficMirrorFilterRuleCommand}
    */
-  readonly modifyTrafficMirrorFilterRule: (
-    args: ModifyTrafficMirrorFilterRuleCommandInput,
+  modifyTrafficMirrorFilterRule(
+    args: ModifyTrafficMirrorFilterRuleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTrafficMirrorFilterRuleCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTrafficMirrorFilterRuleResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTrafficMirrorSessionCommand}
    */
-  readonly modifyTrafficMirrorSession: (
-    args: ModifyTrafficMirrorSessionCommandInput,
+  modifyTrafficMirrorSession(
+    args: ModifyTrafficMirrorSessionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTrafficMirrorSessionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTrafficMirrorSessionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTransitGatewayCommand}
    */
-  readonly modifyTransitGateway: (
-    args: ModifyTransitGatewayCommandInput,
+  modifyTransitGateway(
+    args: ModifyTransitGatewayRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTransitGatewayCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTransitGatewayResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTransitGatewayPrefixListReferenceCommand}
    */
-  readonly modifyTransitGatewayPrefixListReference: (
-    args: ModifyTransitGatewayPrefixListReferenceCommandInput,
+  modifyTransitGatewayPrefixListReference(
+    args: ModifyTransitGatewayPrefixListReferenceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTransitGatewayPrefixListReferenceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTransitGatewayPrefixListReferenceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyTransitGatewayVpcAttachmentCommand}
    */
-  readonly modifyTransitGatewayVpcAttachment: (
-    args: ModifyTransitGatewayVpcAttachmentCommandInput,
+  modifyTransitGatewayVpcAttachment(
+    args: ModifyTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyTransitGatewayVpcAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyTransitGatewayVpcAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessEndpointCommand}
    */
-  readonly modifyVerifiedAccessEndpoint: (
-    args: ModifyVerifiedAccessEndpointCommandInput,
+  modifyVerifiedAccessEndpoint(
+    args: ModifyVerifiedAccessEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessEndpointPolicyCommand}
    */
-  readonly modifyVerifiedAccessEndpointPolicy: (
-    args: ModifyVerifiedAccessEndpointPolicyCommandInput,
+  modifyVerifiedAccessEndpointPolicy(
+    args: ModifyVerifiedAccessEndpointPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessEndpointPolicyCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessEndpointPolicyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessGroupCommand}
    */
-  readonly modifyVerifiedAccessGroup: (
-    args: ModifyVerifiedAccessGroupCommandInput,
+  modifyVerifiedAccessGroup(
+    args: ModifyVerifiedAccessGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessGroupCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessGroupResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessGroupPolicyCommand}
    */
-  readonly modifyVerifiedAccessGroupPolicy: (
-    args: ModifyVerifiedAccessGroupPolicyCommandInput,
+  modifyVerifiedAccessGroupPolicy(
+    args: ModifyVerifiedAccessGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessGroupPolicyCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessGroupPolicyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessInstanceCommand}
    */
-  readonly modifyVerifiedAccessInstance: (
-    args: ModifyVerifiedAccessInstanceCommandInput,
+  modifyVerifiedAccessInstance(
+    args: ModifyVerifiedAccessInstanceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessInstanceCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessInstanceResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessInstanceLoggingConfigurationCommand}
    */
-  readonly modifyVerifiedAccessInstanceLoggingConfiguration: (
-    args: ModifyVerifiedAccessInstanceLoggingConfigurationCommandInput,
+  modifyVerifiedAccessInstanceLoggingConfiguration(
+    args: ModifyVerifiedAccessInstanceLoggingConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessInstanceLoggingConfigurationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessInstanceLoggingConfigurationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVerifiedAccessTrustProviderCommand}
    */
-  readonly modifyVerifiedAccessTrustProvider: (
-    args: ModifyVerifiedAccessTrustProviderCommandInput,
+  modifyVerifiedAccessTrustProvider(
+    args: ModifyVerifiedAccessTrustProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVerifiedAccessTrustProviderCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVerifiedAccessTrustProviderResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVolumeCommand}
    */
-  readonly modifyVolume: (
-    args: ModifyVolumeCommandInput,
+  modifyVolume(
+    args: ModifyVolumeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyVolumeCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyVolumeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVolumeAttributeCommand}
    */
-  readonly modifyVolumeAttribute: (
-    args: ModifyVolumeAttributeCommandInput,
+  modifyVolumeAttribute(
+    args: ModifyVolumeAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVolumeAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcAttributeCommand}
    */
-  readonly modifyVpcAttribute: (
-    args: ModifyVpcAttributeCommandInput,
+  modifyVpcAttribute(
+    args: ModifyVpcAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcEndpointCommand}
    */
-  readonly modifyVpcEndpoint: (
-    args: ModifyVpcEndpointCommandInput,
+  modifyVpcEndpoint(
+    args: ModifyVpcEndpointRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcEndpointCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcEndpointResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcEndpointConnectionNotificationCommand}
    */
-  readonly modifyVpcEndpointConnectionNotification: (
-    args: ModifyVpcEndpointConnectionNotificationCommandInput,
+  modifyVpcEndpointConnectionNotification(
+    args: ModifyVpcEndpointConnectionNotificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcEndpointConnectionNotificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcEndpointConnectionNotificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcEndpointServiceConfigurationCommand}
    */
-  readonly modifyVpcEndpointServiceConfiguration: (
-    args: ModifyVpcEndpointServiceConfigurationCommandInput,
+  modifyVpcEndpointServiceConfiguration(
+    args: ModifyVpcEndpointServiceConfigurationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcEndpointServiceConfigurationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcEndpointServiceConfigurationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcEndpointServicePayerResponsibilityCommand}
    */
-  readonly modifyVpcEndpointServicePayerResponsibility: (
-    args: ModifyVpcEndpointServicePayerResponsibilityCommandInput,
+  modifyVpcEndpointServicePayerResponsibility(
+    args: ModifyVpcEndpointServicePayerResponsibilityRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcEndpointServicePayerResponsibilityCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcEndpointServicePayerResponsibilityResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcEndpointServicePermissionsCommand}
    */
-  readonly modifyVpcEndpointServicePermissions: (
-    args: ModifyVpcEndpointServicePermissionsCommandInput,
+  modifyVpcEndpointServicePermissions(
+    args: ModifyVpcEndpointServicePermissionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcEndpointServicePermissionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcEndpointServicePermissionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcPeeringConnectionOptionsCommand}
    */
-  readonly modifyVpcPeeringConnectionOptions: (
-    args: ModifyVpcPeeringConnectionOptionsCommandInput,
+  modifyVpcPeeringConnectionOptions(
+    args: ModifyVpcPeeringConnectionOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpcPeeringConnectionOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpcPeeringConnectionOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpcTenancyCommand}
    */
-  readonly modifyVpcTenancy: (
-    args: ModifyVpcTenancyCommandInput,
+  modifyVpcTenancy(
+    args: ModifyVpcTenancyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ModifyVpcTenancyCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ModifyVpcTenancyResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpnConnectionCommand}
    */
-  readonly modifyVpnConnection: (
-    args: ModifyVpnConnectionCommandInput,
+  modifyVpnConnection(
+    args: ModifyVpnConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpnConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpnConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpnConnectionOptionsCommand}
    */
-  readonly modifyVpnConnectionOptions: (
-    args: ModifyVpnConnectionOptionsCommandInput,
+  modifyVpnConnectionOptions(
+    args: ModifyVpnConnectionOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpnConnectionOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpnConnectionOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpnTunnelCertificateCommand}
    */
-  readonly modifyVpnTunnelCertificate: (
-    args: ModifyVpnTunnelCertificateCommandInput,
+  modifyVpnTunnelCertificate(
+    args: ModifyVpnTunnelCertificateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpnTunnelCertificateCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpnTunnelCertificateResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ModifyVpnTunnelOptionsCommand}
    */
-  readonly modifyVpnTunnelOptions: (
-    args: ModifyVpnTunnelOptionsCommandInput,
+  modifyVpnTunnelOptions(
+    args: ModifyVpnTunnelOptionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyVpnTunnelOptionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ModifyVpnTunnelOptionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link MonitorInstancesCommand}
    */
-  readonly monitorInstances: (
-    args: MonitorInstancesCommandInput,
+  monitorInstances(
+    args: MonitorInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<MonitorInstancesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  MonitorInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link MoveAddressToVpcCommand}
    */
-  readonly moveAddressToVpc: (
-    args: MoveAddressToVpcCommandInput,
+  moveAddressToVpc(
+    args: MoveAddressToVpcRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<MoveAddressToVpcCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  MoveAddressToVpcResult,
+    | SdkError
+  >
 
   /**
    * @see {@link MoveByoipCidrToIpamCommand}
    */
-  readonly moveByoipCidrToIpam: (
-    args: MoveByoipCidrToIpamCommandInput,
+  moveByoipCidrToIpam(
+    args: MoveByoipCidrToIpamRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    MoveByoipCidrToIpamCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  MoveByoipCidrToIpamResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ProvisionByoipCidrCommand}
    */
-  readonly provisionByoipCidr: (
-    args: ProvisionByoipCidrCommandInput,
+  provisionByoipCidr(
+    args: ProvisionByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ProvisionByoipCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ProvisionByoipCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ProvisionIpamByoasnCommand}
    */
-  readonly provisionIpamByoasn: (
-    args: ProvisionIpamByoasnCommandInput,
+  provisionIpamByoasn(
+    args: ProvisionIpamByoasnRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ProvisionIpamByoasnCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ProvisionIpamByoasnResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ProvisionIpamPoolCidrCommand}
    */
-  readonly provisionIpamPoolCidr: (
-    args: ProvisionIpamPoolCidrCommandInput,
+  provisionIpamPoolCidr(
+    args: ProvisionIpamPoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ProvisionIpamPoolCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ProvisionIpamPoolCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ProvisionPublicIpv4PoolCidrCommand}
    */
-  readonly provisionPublicIpv4PoolCidr: (
-    args: ProvisionPublicIpv4PoolCidrCommandInput,
+  provisionPublicIpv4PoolCidr(
+    args: ProvisionPublicIpv4PoolCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ProvisionPublicIpv4PoolCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ProvisionPublicIpv4PoolCidrResult,
+    | SdkError
+  >
 
   /**
    * @see {@link PurchaseCapacityBlockCommand}
    */
-  readonly purchaseCapacityBlock: (
-    args: PurchaseCapacityBlockCommandInput,
+  purchaseCapacityBlock(
+    args: PurchaseCapacityBlockRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PurchaseCapacityBlockCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  PurchaseCapacityBlockResult,
+    | SdkError
+  >
 
   /**
    * @see {@link PurchaseHostReservationCommand}
    */
-  readonly purchaseHostReservation: (
-    args: PurchaseHostReservationCommandInput,
+  purchaseHostReservation(
+    args: PurchaseHostReservationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PurchaseHostReservationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  PurchaseHostReservationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link PurchaseReservedInstancesOfferingCommand}
    */
-  readonly purchaseReservedInstancesOffering: (
-    args: PurchaseReservedInstancesOfferingCommandInput,
+  purchaseReservedInstancesOffering(
+    args: PurchaseReservedInstancesOfferingRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PurchaseReservedInstancesOfferingCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  PurchaseReservedInstancesOfferingResult,
+    | SdkError
+  >
 
   /**
    * @see {@link PurchaseScheduledInstancesCommand}
    */
-  readonly purchaseScheduledInstances: (
-    args: PurchaseScheduledInstancesCommandInput,
+  purchaseScheduledInstances(
+    args: PurchaseScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PurchaseScheduledInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  PurchaseScheduledInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RebootInstancesCommand}
    */
-  readonly rebootInstances: (
-    args: RebootInstancesCommandInput,
+  rebootInstances(
+    args: RebootInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<RebootInstancesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link RegisterImageCommand}
    */
-  readonly registerImage: (
-    args: RegisterImageCommandInput,
+  registerImage(
+    args: RegisterImageRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<RegisterImageCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  RegisterImageResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RegisterInstanceEventNotificationAttributesCommand}
    */
-  readonly registerInstanceEventNotificationAttributes: (
-    args: RegisterInstanceEventNotificationAttributesCommandInput,
+  registerInstanceEventNotificationAttributes(
+    args: RegisterInstanceEventNotificationAttributesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RegisterInstanceEventNotificationAttributesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RegisterInstanceEventNotificationAttributesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RegisterTransitGatewayMulticastGroupMembersCommand}
    */
-  readonly registerTransitGatewayMulticastGroupMembers: (
-    args: RegisterTransitGatewayMulticastGroupMembersCommandInput,
+  registerTransitGatewayMulticastGroupMembers(
+    args: RegisterTransitGatewayMulticastGroupMembersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RegisterTransitGatewayMulticastGroupMembersCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RegisterTransitGatewayMulticastGroupMembersResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RegisterTransitGatewayMulticastGroupSourcesCommand}
    */
-  readonly registerTransitGatewayMulticastGroupSources: (
-    args: RegisterTransitGatewayMulticastGroupSourcesCommandInput,
+  registerTransitGatewayMulticastGroupSources(
+    args: RegisterTransitGatewayMulticastGroupSourcesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RegisterTransitGatewayMulticastGroupSourcesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RegisterTransitGatewayMulticastGroupSourcesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RejectTransitGatewayMulticastDomainAssociationsCommand}
    */
-  readonly rejectTransitGatewayMulticastDomainAssociations: (
-    args: RejectTransitGatewayMulticastDomainAssociationsCommandInput,
+  rejectTransitGatewayMulticastDomainAssociations(
+    args: RejectTransitGatewayMulticastDomainAssociationsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RejectTransitGatewayMulticastDomainAssociationsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RejectTransitGatewayMulticastDomainAssociationsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RejectTransitGatewayPeeringAttachmentCommand}
    */
-  readonly rejectTransitGatewayPeeringAttachment: (
-    args: RejectTransitGatewayPeeringAttachmentCommandInput,
+  rejectTransitGatewayPeeringAttachment(
+    args: RejectTransitGatewayPeeringAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RejectTransitGatewayPeeringAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RejectTransitGatewayPeeringAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RejectTransitGatewayVpcAttachmentCommand}
    */
-  readonly rejectTransitGatewayVpcAttachment: (
-    args: RejectTransitGatewayVpcAttachmentCommandInput,
+  rejectTransitGatewayVpcAttachment(
+    args: RejectTransitGatewayVpcAttachmentRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RejectTransitGatewayVpcAttachmentCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RejectTransitGatewayVpcAttachmentResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RejectVpcEndpointConnectionsCommand}
    */
-  readonly rejectVpcEndpointConnections: (
-    args: RejectVpcEndpointConnectionsCommandInput,
+  rejectVpcEndpointConnections(
+    args: RejectVpcEndpointConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RejectVpcEndpointConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RejectVpcEndpointConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RejectVpcPeeringConnectionCommand}
    */
-  readonly rejectVpcPeeringConnection: (
-    args: RejectVpcPeeringConnectionCommandInput,
+  rejectVpcPeeringConnection(
+    args: RejectVpcPeeringConnectionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RejectVpcPeeringConnectionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RejectVpcPeeringConnectionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReleaseAddressCommand}
    */
-  readonly releaseAddress: (
-    args: ReleaseAddressCommandInput,
+  releaseAddress(
+    args: ReleaseAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ReleaseAddressCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ReleaseHostsCommand}
    */
-  readonly releaseHosts: (
-    args: ReleaseHostsCommandInput,
+  releaseHosts(
+    args: ReleaseHostsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ReleaseHostsCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ReleaseHostsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReleaseIpamPoolAllocationCommand}
    */
-  readonly releaseIpamPoolAllocation: (
-    args: ReleaseIpamPoolAllocationCommandInput,
+  releaseIpamPoolAllocation(
+    args: ReleaseIpamPoolAllocationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReleaseIpamPoolAllocationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ReleaseIpamPoolAllocationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceIamInstanceProfileAssociationCommand}
    */
-  readonly replaceIamInstanceProfileAssociation: (
-    args: ReplaceIamInstanceProfileAssociationCommandInput,
+  replaceIamInstanceProfileAssociation(
+    args: ReplaceIamInstanceProfileAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReplaceIamInstanceProfileAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ReplaceIamInstanceProfileAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceNetworkAclAssociationCommand}
    */
-  readonly replaceNetworkAclAssociation: (
-    args: ReplaceNetworkAclAssociationCommandInput,
+  replaceNetworkAclAssociation(
+    args: ReplaceNetworkAclAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReplaceNetworkAclAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ReplaceNetworkAclAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceNetworkAclEntryCommand}
    */
-  readonly replaceNetworkAclEntry: (
-    args: ReplaceNetworkAclEntryCommandInput,
+  replaceNetworkAclEntry(
+    args: ReplaceNetworkAclEntryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReplaceNetworkAclEntryCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceRouteCommand}
    */
-  readonly replaceRoute: (
-    args: ReplaceRouteCommandInput,
+  replaceRoute(
+    args: ReplaceRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ReplaceRouteCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceRouteTableAssociationCommand}
    */
-  readonly replaceRouteTableAssociation: (
-    args: ReplaceRouteTableAssociationCommandInput,
+  replaceRouteTableAssociation(
+    args: ReplaceRouteTableAssociationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReplaceRouteTableAssociationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ReplaceRouteTableAssociationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceTransitGatewayRouteCommand}
    */
-  readonly replaceTransitGatewayRoute: (
-    args: ReplaceTransitGatewayRouteCommandInput,
+  replaceTransitGatewayRoute(
+    args: ReplaceTransitGatewayRouteRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReplaceTransitGatewayRouteCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ReplaceTransitGatewayRouteResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReplaceVpnTunnelCommand}
    */
-  readonly replaceVpnTunnel: (
-    args: ReplaceVpnTunnelCommandInput,
+  replaceVpnTunnel(
+    args: ReplaceVpnTunnelRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<ReplaceVpnTunnelCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  ReplaceVpnTunnelResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ReportInstanceStatusCommand}
    */
-  readonly reportInstanceStatus: (
-    args: ReportInstanceStatusCommandInput,
+  reportInstanceStatus(
+    args: ReportInstanceStatusRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ReportInstanceStatusCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link RequestSpotFleetCommand}
    */
-  readonly requestSpotFleet: (
-    args: RequestSpotFleetCommandInput,
+  requestSpotFleet(
+    args: RequestSpotFleetRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<RequestSpotFleetCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  RequestSpotFleetResponse,
+    | SdkError
+  >
 
   /**
    * @see {@link RequestSpotInstancesCommand}
    */
-  readonly requestSpotInstances: (
-    args: RequestSpotInstancesCommandInput,
+  requestSpotInstances(
+    args: RequestSpotInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RequestSpotInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RequestSpotInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetAddressAttributeCommand}
    */
-  readonly resetAddressAttribute: (
-    args: ResetAddressAttributeCommandInput,
+  resetAddressAttribute(
+    args: ResetAddressAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetAddressAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ResetAddressAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetEbsDefaultKmsKeyIdCommand}
    */
-  readonly resetEbsDefaultKmsKeyId: (
-    args: ResetEbsDefaultKmsKeyIdCommandInput,
+  resetEbsDefaultKmsKeyId(
+    args: ResetEbsDefaultKmsKeyIdRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetEbsDefaultKmsKeyIdCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ResetEbsDefaultKmsKeyIdResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetFpgaImageAttributeCommand}
    */
-  readonly resetFpgaImageAttribute: (
-    args: ResetFpgaImageAttributeCommandInput,
+  resetFpgaImageAttribute(
+    args: ResetFpgaImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetFpgaImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  ResetFpgaImageAttributeResult,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetImageAttributeCommand}
    */
-  readonly resetImageAttribute: (
-    args: ResetImageAttributeCommandInput,
+  resetImageAttribute(
+    args: ResetImageAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetImageAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetInstanceAttributeCommand}
    */
-  readonly resetInstanceAttribute: (
-    args: ResetInstanceAttributeCommandInput,
+  resetInstanceAttribute(
+    args: ResetInstanceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetInstanceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetNetworkInterfaceAttributeCommand}
    */
-  readonly resetNetworkInterfaceAttribute: (
-    args: ResetNetworkInterfaceAttributeCommandInput,
+  resetNetworkInterfaceAttribute(
+    args: ResetNetworkInterfaceAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetNetworkInterfaceAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link ResetSnapshotAttributeCommand}
    */
-  readonly resetSnapshotAttribute: (
-    args: ResetSnapshotAttributeCommandInput,
+  resetSnapshotAttribute(
+    args: ResetSnapshotAttributeRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetSnapshotAttributeCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link RestoreAddressToClassicCommand}
    */
-  readonly restoreAddressToClassic: (
-    args: RestoreAddressToClassicCommandInput,
+  restoreAddressToClassic(
+    args: RestoreAddressToClassicRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RestoreAddressToClassicCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RestoreAddressToClassicResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RestoreImageFromRecycleBinCommand}
    */
-  readonly restoreImageFromRecycleBin: (
-    args: RestoreImageFromRecycleBinCommandInput,
+  restoreImageFromRecycleBin(
+    args: RestoreImageFromRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RestoreImageFromRecycleBinCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RestoreImageFromRecycleBinResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RestoreManagedPrefixListVersionCommand}
    */
-  readonly restoreManagedPrefixListVersion: (
-    args: RestoreManagedPrefixListVersionCommandInput,
+  restoreManagedPrefixListVersion(
+    args: RestoreManagedPrefixListVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RestoreManagedPrefixListVersionCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RestoreManagedPrefixListVersionResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RestoreSnapshotFromRecycleBinCommand}
    */
-  readonly restoreSnapshotFromRecycleBin: (
-    args: RestoreSnapshotFromRecycleBinCommandInput,
+  restoreSnapshotFromRecycleBin(
+    args: RestoreSnapshotFromRecycleBinRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RestoreSnapshotFromRecycleBinCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RestoreSnapshotFromRecycleBinResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RestoreSnapshotTierCommand}
    */
-  readonly restoreSnapshotTier: (
-    args: RestoreSnapshotTierCommandInput,
+  restoreSnapshotTier(
+    args: RestoreSnapshotTierRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RestoreSnapshotTierCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RestoreSnapshotTierResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RevokeClientVpnIngressCommand}
    */
-  readonly revokeClientVpnIngress: (
-    args: RevokeClientVpnIngressCommandInput,
+  revokeClientVpnIngress(
+    args: RevokeClientVpnIngressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RevokeClientVpnIngressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RevokeClientVpnIngressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RevokeSecurityGroupEgressCommand}
    */
-  readonly revokeSecurityGroupEgress: (
-    args: RevokeSecurityGroupEgressCommandInput,
+  revokeSecurityGroupEgress(
+    args: RevokeSecurityGroupEgressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RevokeSecurityGroupEgressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RevokeSecurityGroupEgressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RevokeSecurityGroupIngressCommand}
    */
-  readonly revokeSecurityGroupIngress: (
-    args: RevokeSecurityGroupIngressCommandInput,
+  revokeSecurityGroupIngress(
+    args: RevokeSecurityGroupIngressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RevokeSecurityGroupIngressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RevokeSecurityGroupIngressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link RunInstancesCommand}
    */
-  readonly runInstances: (
-    args: RunInstancesCommandInput,
+  runInstances(
+    args: RunInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<RunInstancesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  Reservation,
+    | SdkError
+  >
 
   /**
    * @see {@link RunScheduledInstancesCommand}
    */
-  readonly runScheduledInstances: (
-    args: RunScheduledInstancesCommandInput,
+  runScheduledInstances(
+    args: RunScheduledInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RunScheduledInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  RunScheduledInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link SearchLocalGatewayRoutesCommand}
    */
-  readonly searchLocalGatewayRoutes: (
-    args: SearchLocalGatewayRoutesCommandInput,
+  searchLocalGatewayRoutes(
+    args: SearchLocalGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SearchLocalGatewayRoutesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  SearchLocalGatewayRoutesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link SearchTransitGatewayMulticastGroupsCommand}
    */
-  readonly searchTransitGatewayMulticastGroups: (
-    args: SearchTransitGatewayMulticastGroupsCommandInput,
+  searchTransitGatewayMulticastGroups(
+    args: SearchTransitGatewayMulticastGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SearchTransitGatewayMulticastGroupsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  SearchTransitGatewayMulticastGroupsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link SearchTransitGatewayRoutesCommand}
    */
-  readonly searchTransitGatewayRoutes: (
-    args: SearchTransitGatewayRoutesCommandInput,
+  searchTransitGatewayRoutes(
+    args: SearchTransitGatewayRoutesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SearchTransitGatewayRoutesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  SearchTransitGatewayRoutesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link SendDiagnosticInterruptCommand}
    */
-  readonly sendDiagnosticInterrupt: (
-    args: SendDiagnosticInterruptCommandInput,
+  sendDiagnosticInterrupt(
+    args: SendDiagnosticInterruptRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SendDiagnosticInterruptCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link StartInstancesCommand}
    */
-  readonly startInstances: (
-    args: StartInstancesCommandInput,
+  startInstances(
+    args: StartInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<StartInstancesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  StartInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link StartNetworkInsightsAccessScopeAnalysisCommand}
    */
-  readonly startNetworkInsightsAccessScopeAnalysis: (
-    args: StartNetworkInsightsAccessScopeAnalysisCommandInput,
+  startNetworkInsightsAccessScopeAnalysis(
+    args: StartNetworkInsightsAccessScopeAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    StartNetworkInsightsAccessScopeAnalysisCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  StartNetworkInsightsAccessScopeAnalysisResult,
+    | SdkError
+  >
 
   /**
    * @see {@link StartNetworkInsightsAnalysisCommand}
    */
-  readonly startNetworkInsightsAnalysis: (
-    args: StartNetworkInsightsAnalysisCommandInput,
+  startNetworkInsightsAnalysis(
+    args: StartNetworkInsightsAnalysisRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    StartNetworkInsightsAnalysisCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  StartNetworkInsightsAnalysisResult,
+    | SdkError
+  >
 
   /**
    * @see {@link StartVpcEndpointServicePrivateDnsVerificationCommand}
    */
-  readonly startVpcEndpointServicePrivateDnsVerification: (
-    args: StartVpcEndpointServicePrivateDnsVerificationCommandInput,
+  startVpcEndpointServicePrivateDnsVerification(
+    args: StartVpcEndpointServicePrivateDnsVerificationRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    StartVpcEndpointServicePrivateDnsVerificationCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  StartVpcEndpointServicePrivateDnsVerificationResult,
+    | SdkError
+  >
 
   /**
    * @see {@link StopInstancesCommand}
    */
-  readonly stopInstances: (
-    args: StopInstancesCommandInput,
+  stopInstances(
+    args: StopInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<StopInstancesCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  StopInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link TerminateClientVpnConnectionsCommand}
    */
-  readonly terminateClientVpnConnections: (
-    args: TerminateClientVpnConnectionsCommandInput,
+  terminateClientVpnConnections(
+    args: TerminateClientVpnConnectionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TerminateClientVpnConnectionsCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  TerminateClientVpnConnectionsResult,
+    | SdkError
+  >
 
   /**
    * @see {@link TerminateInstancesCommand}
    */
-  readonly terminateInstances: (
-    args: TerminateInstancesCommandInput,
+  terminateInstances(
+    args: TerminateInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TerminateInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  TerminateInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UnassignIpv6AddressesCommand}
    */
-  readonly unassignIpv6Addresses: (
-    args: UnassignIpv6AddressesCommandInput,
+  unassignIpv6Addresses(
+    args: UnassignIpv6AddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UnassignIpv6AddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  UnassignIpv6AddressesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UnassignPrivateIpAddressesCommand}
    */
-  readonly unassignPrivateIpAddresses: (
-    args: UnassignPrivateIpAddressesCommandInput,
+  unassignPrivateIpAddresses(
+    args: UnassignPrivateIpAddressesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UnassignPrivateIpAddressesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  void,
+    | SdkError
+  >
 
   /**
    * @see {@link UnassignPrivateNatGatewayAddressCommand}
    */
-  readonly unassignPrivateNatGatewayAddress: (
-    args: UnassignPrivateNatGatewayAddressCommandInput,
+  unassignPrivateNatGatewayAddress(
+    args: UnassignPrivateNatGatewayAddressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UnassignPrivateNatGatewayAddressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  UnassignPrivateNatGatewayAddressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UnlockSnapshotCommand}
    */
-  readonly unlockSnapshot: (
-    args: UnlockSnapshotCommandInput,
+  unlockSnapshot(
+    args: UnlockSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<UnlockSnapshotCommandOutput, SdkError | EC2ServiceError>;
+  ): Effect.Effect<
+  UnlockSnapshotResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UnmonitorInstancesCommand}
    */
-  readonly unmonitorInstances: (
-    args: UnmonitorInstancesCommandInput,
+  unmonitorInstances(
+    args: UnmonitorInstancesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UnmonitorInstancesCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  UnmonitorInstancesResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UpdateSecurityGroupRuleDescriptionsEgressCommand}
    */
-  readonly updateSecurityGroupRuleDescriptionsEgress: (
-    args: UpdateSecurityGroupRuleDescriptionsEgressCommandInput,
+  updateSecurityGroupRuleDescriptionsEgress(
+    args: UpdateSecurityGroupRuleDescriptionsEgressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateSecurityGroupRuleDescriptionsEgressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  UpdateSecurityGroupRuleDescriptionsEgressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link UpdateSecurityGroupRuleDescriptionsIngressCommand}
    */
-  readonly updateSecurityGroupRuleDescriptionsIngress: (
-    args: UpdateSecurityGroupRuleDescriptionsIngressCommandInput,
+  updateSecurityGroupRuleDescriptionsIngress(
+    args: UpdateSecurityGroupRuleDescriptionsIngressRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateSecurityGroupRuleDescriptionsIngressCommandOutput,
-    SdkError | EC2ServiceError
-  >;
+  ): Effect.Effect<
+  UpdateSecurityGroupRuleDescriptionsIngressResult,
+    | SdkError
+  >
 
   /**
    * @see {@link WithdrawByoipCidrCommand}
    */
-  readonly withdrawByoipCidr: (
-    args: WithdrawByoipCidrCommandInput,
+  withdrawByoipCidr(
+    args: WithdrawByoipCidrRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    WithdrawByoipCidrCommandOutput,
-    SdkError | EC2ServiceError
-  >;
-};
+  ): Effect.Effect<
+  WithdrawByoipCidrResult,
+    | SdkError
+  >
+}
 
 /**
  * @since 1.0.0
@@ -8955,9 +9262,9 @@ export const makeEC2Service = Effect.gen(function* (_) {
       Effect.tryPromise({
         try: () => client.send(new CommandCtor(args), options ?? {}),
         catch: (e) => {
-          if (e instanceof EC2ServiceException) {
+          if (e instanceof SdkEC2ServiceException) {
             const ServiceException = Data.tagged<
-              TaggedException<EC2ServiceException>
+              TaggedException<SdkEC2ServiceException>
             >(e.name);
 
             return ServiceException({
@@ -8989,7 +9296,10 @@ export const makeEC2Service = Effect.gen(function* (_) {
  * @since 1.0.0
  * @category layers
  */
-export const BaseEC2ServiceLayer = Layer.effect(EC2Service, makeEC2Service);
+export const BaseEC2ServiceLayer = Layer.effect(
+  EC2Service,
+  makeEC2Service,
+);
 
 /**
  * @since 1.0.0

--- a/packages/client-ec2/src/Errors.ts
+++ b/packages/client-ec2/src/Errors.ts
@@ -1,13 +1,9 @@
-import type { 
-  
-} from "@aws-sdk/client-ec2";
+import type {} from "@aws-sdk/client-ec2";
 import * as Data from "effect/Data";
 
 export type TaggedException<T extends { name: string }> = T & {
   readonly _tag: T["name"];
 };
-
-
 
 export type SdkError = TaggedException<Error & { name: "SdkError" }>;
 export const SdkError = Data.tagged<SdkError>("SdkError");

--- a/packages/client-ec2/src/Errors.ts
+++ b/packages/client-ec2/src/Errors.ts
@@ -1,13 +1,13 @@
-import type { EC2ServiceException } from "@aws-sdk/client-ec2";
+import type { 
+  
+} from "@aws-sdk/client-ec2";
 import * as Data from "effect/Data";
 
 export type TaggedException<T extends { name: string }> = T & {
   readonly _tag: T["name"];
 };
 
-export type EC2ServiceError = TaggedException<
-  EC2ServiceException & { name: "EC2ServiceError" }
->;
-export const EC2ServiceError = Data.tagged<EC2ServiceError>("EC2ServiceError");
+
+
 export type SdkError = TaggedException<Error & { name: "SdkError" }>;
 export const SdkError = Data.tagged<SdkError>("SdkError");

--- a/packages/client-ec2/test/EC2.test.ts
+++ b/packages/client-ec2/test/EC2.test.ts
@@ -27,9 +27,13 @@ describe("EC2ClientImpl", () => {
   it("default", async () => {
     clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
+    const args: DescribeInstancesCommandInput = {
+      InstanceIds: ["i-1234567890abcdef0"],
+    };
 
-    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
+    const program = Effect.flatMap(EC2Service, (service) =>
+      service.describeInstances(args),
+    );
 
     const result = await pipe(
       program,
@@ -39,15 +43,22 @@ describe("EC2ClientImpl", () => {
 
     expect(result).toEqual(Exit.succeed({}));
     expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeInstancesCommand,
+      args,
+    );
   });
 
   it("configurable", async () => {
     clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
+    const args: DescribeInstancesCommandInput = {
+      InstanceIds: ["i-1234567890abcdef0"],
+    };
 
-    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
+    const program = Effect.flatMap(EC2Service, (service) =>
+      service.describeInstances(args),
+    );
 
     const EC2ClientConfigLayer = Layer.succeed(EC2ClientInstanceConfig, {
       region: "eu-central-1",
@@ -64,15 +75,22 @@ describe("EC2ClientImpl", () => {
 
     expect(result).toEqual(Exit.succeed({}));
     expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeInstancesCommand,
+      args,
+    );
   });
 
   it("base", async () => {
     clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
+    const args: DescribeInstancesCommandInput = {
+      InstanceIds: ["i-1234567890abcdef0"],
+    };
 
-    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
+    const program = Effect.flatMap(EC2Service, (service) =>
+      service.describeInstances(args),
+    );
 
     const EC2ClientInstanceLayer = Layer.succeed(
       EC2ClientInstance,
@@ -90,15 +108,22 @@ describe("EC2ClientImpl", () => {
 
     expect(result).toEqual(Exit.succeed({}));
     expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeInstancesCommand,
+      args,
+    );
   });
 
   it("extended", async () => {
     clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
+    const args: DescribeInstancesCommandInput = {
+      InstanceIds: ["i-1234567890abcdef0"],
+    };
 
-    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
+    const program = Effect.flatMap(EC2Service, (service) =>
+      service.describeInstances(args),
+    );
 
     const EC2ClientInstanceLayer = Layer.effect(
       EC2ClientInstance,
@@ -120,15 +145,22 @@ describe("EC2ClientImpl", () => {
 
     expect(result).toEqual(Exit.succeed({}));
     expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeInstancesCommand,
+      args,
+    );
   });
 
   it("fail", async () => {
     clientMock.reset().on(DescribeInstancesCommand).rejects(new Error("test"));
 
-    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
+    const args: DescribeInstancesCommandInput = {
+      InstanceIds: ["i-1234567890abcdef0"],
+    };
 
-    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
+    const program = Effect.flatMap(EC2Service, (service) =>
+      service.describeInstances(args),
+    );
 
     const result = await pipe(
       program,
@@ -147,6 +179,9 @@ describe("EC2ClientImpl", () => {
       ),
     );
     expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeInstancesCommand,
+      args,
+    );
   });
 });

--- a/packages/client-ec2/test/EC2.test.ts
+++ b/packages/client-ec2/test/EC2.test.ts
@@ -1,6 +1,6 @@
 import {
-  type AcceptAddressTransferCommandInput,
-  AcceptAddressTransferCommand,
+  type DescribeInstancesCommandInput,
+  DescribeInstancesCommand,
   EC2Client,
 } from "@aws-sdk/client-ec2";
 import { mockClient } from "aws-sdk-client-mock";
@@ -25,13 +25,11 @@ const clientMock = mockClient(EC2Client);
 
 describe("EC2ClientImpl", () => {
   it("default", async () => {
-    clientMock.reset().on(AcceptAddressTransferCommand).resolves({});
+    clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args = {} as unknown as AcceptAddressTransferCommandInput;
+    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
 
-    const program = Effect.flatMap(EC2Service, (service) =>
-      service.acceptAddressTransfer(args),
-    );
+    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
 
     const result = await pipe(
       program,
@@ -40,24 +38,16 @@ describe("EC2ClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(
-      AcceptAddressTransferCommand,
-      1,
-    );
-    expect(clientMock).toHaveReceivedCommandWith(
-      AcceptAddressTransferCommand,
-      args,
-    );
+    expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
   });
 
   it("configurable", async () => {
-    clientMock.reset().on(AcceptAddressTransferCommand).resolves({});
+    clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args = {} as unknown as AcceptAddressTransferCommandInput;
+    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
 
-    const program = Effect.flatMap(EC2Service, (service) =>
-      service.acceptAddressTransfer(args),
-    );
+    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
 
     const EC2ClientConfigLayer = Layer.succeed(EC2ClientInstanceConfig, {
       region: "eu-central-1",
@@ -73,24 +63,16 @@ describe("EC2ClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(
-      AcceptAddressTransferCommand,
-      1,
-    );
-    expect(clientMock).toHaveReceivedCommandWith(
-      AcceptAddressTransferCommand,
-      args,
-    );
+    expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
   });
 
   it("base", async () => {
-    clientMock.reset().on(AcceptAddressTransferCommand).resolves({});
+    clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args = {} as unknown as AcceptAddressTransferCommandInput;
+    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
 
-    const program = Effect.flatMap(EC2Service, (service) =>
-      service.acceptAddressTransfer(args),
-    );
+    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
 
     const EC2ClientInstanceLayer = Layer.succeed(
       EC2ClientInstance,
@@ -107,24 +89,16 @@ describe("EC2ClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(
-      AcceptAddressTransferCommand,
-      1,
-    );
-    expect(clientMock).toHaveReceivedCommandWith(
-      AcceptAddressTransferCommand,
-      args,
-    );
+    expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
   });
 
   it("extended", async () => {
-    clientMock.reset().on(AcceptAddressTransferCommand).resolves({});
+    clientMock.reset().on(DescribeInstancesCommand).resolves({});
 
-    const args = {} as unknown as AcceptAddressTransferCommandInput;
+    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
 
-    const program = Effect.flatMap(EC2Service, (service) =>
-      service.acceptAddressTransfer(args),
-    );
+    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
 
     const EC2ClientInstanceLayer = Layer.effect(
       EC2ClientInstance,
@@ -145,27 +119,16 @@ describe("EC2ClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(
-      AcceptAddressTransferCommand,
-      1,
-    );
-    expect(clientMock).toHaveReceivedCommandWith(
-      AcceptAddressTransferCommand,
-      args,
-    );
+    expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
   });
 
   it("fail", async () => {
-    clientMock
-      .reset()
-      .on(AcceptAddressTransferCommand)
-      .rejects(new Error("test"));
+    clientMock.reset().on(DescribeInstancesCommand).rejects(new Error("test"));
 
-    const args = {} as unknown as AcceptAddressTransferCommandInput;
+    const args : DescribeInstancesCommandInput = {"InstanceIds": ["i-1234567890abcdef0"]};
 
-    const program = Effect.flatMap(EC2Service, (service) =>
-      service.acceptAddressTransfer(args),
-    );
+    const program = Effect.flatMap(EC2Service, (service) => service.describeInstances(args));
 
     const result = await pipe(
       program,
@@ -183,13 +146,7 @@ describe("EC2ClientImpl", () => {
         }),
       ),
     );
-    expect(clientMock).toHaveReceivedCommandTimes(
-      AcceptAddressTransferCommand,
-      1,
-    );
-    expect(clientMock).toHaveReceivedCommandWith(
-      AcceptAddressTransferCommand,
-      args,
-    );
+    expect(clientMock).toHaveReceivedCommandTimes(DescribeInstancesCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(DescribeInstancesCommand, args);
   });
 });

--- a/packages/client-elasticache/.projen/deps.json
+++ b/packages/client-elasticache/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-elasticache",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-elasticache/package.json
+++ b/packages/client-elasticache/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-elasticache": "^3",
+    "@aws-sdk/client-elasticache": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-elasticache/src/ElastiCacheService.ts
+++ b/packages/client-elasticache/src/ElastiCacheService.ts
@@ -2,247 +2,308 @@
  * @since 1.0.0
  */
 import {
+  ElastiCacheServiceException as SdkElastiCacheServiceException,
   AddTagsToResourceCommand,
-  type AddTagsToResourceCommandInput,
-  type AddTagsToResourceCommandOutput,
   AuthorizeCacheSecurityGroupIngressCommand,
-  type AuthorizeCacheSecurityGroupIngressCommandInput,
-  type AuthorizeCacheSecurityGroupIngressCommandOutput,
   BatchApplyUpdateActionCommand,
-  type BatchApplyUpdateActionCommandInput,
-  type BatchApplyUpdateActionCommandOutput,
   BatchStopUpdateActionCommand,
-  type BatchStopUpdateActionCommandInput,
-  type BatchStopUpdateActionCommandOutput,
   CompleteMigrationCommand,
-  type CompleteMigrationCommandInput,
-  type CompleteMigrationCommandOutput,
   CopyServerlessCacheSnapshotCommand,
-  type CopyServerlessCacheSnapshotCommandInput,
-  type CopyServerlessCacheSnapshotCommandOutput,
   CopySnapshotCommand,
-  type CopySnapshotCommandInput,
-  type CopySnapshotCommandOutput,
   CreateCacheClusterCommand,
-  type CreateCacheClusterCommandInput,
-  type CreateCacheClusterCommandOutput,
   CreateCacheParameterGroupCommand,
-  type CreateCacheParameterGroupCommandInput,
-  type CreateCacheParameterGroupCommandOutput,
   CreateCacheSecurityGroupCommand,
-  type CreateCacheSecurityGroupCommandInput,
-  type CreateCacheSecurityGroupCommandOutput,
   CreateCacheSubnetGroupCommand,
-  type CreateCacheSubnetGroupCommandInput,
-  type CreateCacheSubnetGroupCommandOutput,
   CreateGlobalReplicationGroupCommand,
-  type CreateGlobalReplicationGroupCommandInput,
-  type CreateGlobalReplicationGroupCommandOutput,
   CreateReplicationGroupCommand,
-  type CreateReplicationGroupCommandInput,
-  type CreateReplicationGroupCommandOutput,
   CreateServerlessCacheCommand,
-  type CreateServerlessCacheCommandInput,
-  type CreateServerlessCacheCommandOutput,
   CreateServerlessCacheSnapshotCommand,
-  type CreateServerlessCacheSnapshotCommandInput,
-  type CreateServerlessCacheSnapshotCommandOutput,
   CreateSnapshotCommand,
-  type CreateSnapshotCommandInput,
-  type CreateSnapshotCommandOutput,
   CreateUserCommand,
-  type CreateUserCommandInput,
-  type CreateUserCommandOutput,
   CreateUserGroupCommand,
-  type CreateUserGroupCommandInput,
-  type CreateUserGroupCommandOutput,
   DecreaseNodeGroupsInGlobalReplicationGroupCommand,
-  type DecreaseNodeGroupsInGlobalReplicationGroupCommandInput,
-  type DecreaseNodeGroupsInGlobalReplicationGroupCommandOutput,
   DecreaseReplicaCountCommand,
-  type DecreaseReplicaCountCommandInput,
-  type DecreaseReplicaCountCommandOutput,
   DeleteCacheClusterCommand,
-  type DeleteCacheClusterCommandInput,
-  type DeleteCacheClusterCommandOutput,
   DeleteCacheParameterGroupCommand,
-  type DeleteCacheParameterGroupCommandInput,
-  type DeleteCacheParameterGroupCommandOutput,
   DeleteCacheSecurityGroupCommand,
-  type DeleteCacheSecurityGroupCommandInput,
-  type DeleteCacheSecurityGroupCommandOutput,
   DeleteCacheSubnetGroupCommand,
-  type DeleteCacheSubnetGroupCommandInput,
-  type DeleteCacheSubnetGroupCommandOutput,
   DeleteGlobalReplicationGroupCommand,
-  type DeleteGlobalReplicationGroupCommandInput,
-  type DeleteGlobalReplicationGroupCommandOutput,
   DeleteReplicationGroupCommand,
-  type DeleteReplicationGroupCommandInput,
-  type DeleteReplicationGroupCommandOutput,
   DeleteServerlessCacheCommand,
-  type DeleteServerlessCacheCommandInput,
-  type DeleteServerlessCacheCommandOutput,
   DeleteServerlessCacheSnapshotCommand,
-  type DeleteServerlessCacheSnapshotCommandInput,
-  type DeleteServerlessCacheSnapshotCommandOutput,
   DeleteSnapshotCommand,
-  type DeleteSnapshotCommandInput,
-  type DeleteSnapshotCommandOutput,
   DeleteUserCommand,
-  type DeleteUserCommandInput,
-  type DeleteUserCommandOutput,
   DeleteUserGroupCommand,
-  type DeleteUserGroupCommandInput,
-  type DeleteUserGroupCommandOutput,
   DescribeCacheClustersCommand,
-  type DescribeCacheClustersCommandInput,
-  type DescribeCacheClustersCommandOutput,
   DescribeCacheEngineVersionsCommand,
-  type DescribeCacheEngineVersionsCommandInput,
-  type DescribeCacheEngineVersionsCommandOutput,
   DescribeCacheParameterGroupsCommand,
-  type DescribeCacheParameterGroupsCommandInput,
-  type DescribeCacheParameterGroupsCommandOutput,
   DescribeCacheParametersCommand,
-  type DescribeCacheParametersCommandInput,
-  type DescribeCacheParametersCommandOutput,
   DescribeCacheSecurityGroupsCommand,
-  type DescribeCacheSecurityGroupsCommandInput,
-  type DescribeCacheSecurityGroupsCommandOutput,
   DescribeCacheSubnetGroupsCommand,
-  type DescribeCacheSubnetGroupsCommandInput,
-  type DescribeCacheSubnetGroupsCommandOutput,
   DescribeEngineDefaultParametersCommand,
-  type DescribeEngineDefaultParametersCommandInput,
-  type DescribeEngineDefaultParametersCommandOutput,
   DescribeEventsCommand,
-  type DescribeEventsCommandInput,
-  type DescribeEventsCommandOutput,
   DescribeGlobalReplicationGroupsCommand,
-  type DescribeGlobalReplicationGroupsCommandInput,
-  type DescribeGlobalReplicationGroupsCommandOutput,
   DescribeReplicationGroupsCommand,
-  type DescribeReplicationGroupsCommandInput,
-  type DescribeReplicationGroupsCommandOutput,
   DescribeReservedCacheNodesCommand,
-  type DescribeReservedCacheNodesCommandInput,
-  type DescribeReservedCacheNodesCommandOutput,
   DescribeReservedCacheNodesOfferingsCommand,
-  type DescribeReservedCacheNodesOfferingsCommandInput,
-  type DescribeReservedCacheNodesOfferingsCommandOutput,
-  DescribeServerlessCachesCommand,
-  type DescribeServerlessCachesCommandInput,
-  type DescribeServerlessCachesCommandOutput,
   DescribeServerlessCacheSnapshotsCommand,
-  type DescribeServerlessCacheSnapshotsCommandInput,
-  type DescribeServerlessCacheSnapshotsCommandOutput,
+  DescribeServerlessCachesCommand,
   DescribeServiceUpdatesCommand,
-  type DescribeServiceUpdatesCommandInput,
-  type DescribeServiceUpdatesCommandOutput,
   DescribeSnapshotsCommand,
-  type DescribeSnapshotsCommandInput,
-  type DescribeSnapshotsCommandOutput,
   DescribeUpdateActionsCommand,
-  type DescribeUpdateActionsCommandInput,
-  type DescribeUpdateActionsCommandOutput,
   DescribeUserGroupsCommand,
-  type DescribeUserGroupsCommandInput,
-  type DescribeUserGroupsCommandOutput,
   DescribeUsersCommand,
-  type DescribeUsersCommandInput,
-  type DescribeUsersCommandOutput,
   DisassociateGlobalReplicationGroupCommand,
-  type DisassociateGlobalReplicationGroupCommandInput,
-  type DisassociateGlobalReplicationGroupCommandOutput,
-  ElastiCacheServiceException,
   ExportServerlessCacheSnapshotCommand,
-  type ExportServerlessCacheSnapshotCommandInput,
-  type ExportServerlessCacheSnapshotCommandOutput,
   FailoverGlobalReplicationGroupCommand,
-  type FailoverGlobalReplicationGroupCommandInput,
-  type FailoverGlobalReplicationGroupCommandOutput,
   IncreaseNodeGroupsInGlobalReplicationGroupCommand,
-  type IncreaseNodeGroupsInGlobalReplicationGroupCommandInput,
-  type IncreaseNodeGroupsInGlobalReplicationGroupCommandOutput,
   IncreaseReplicaCountCommand,
-  type IncreaseReplicaCountCommandInput,
-  type IncreaseReplicaCountCommandOutput,
   ListAllowedNodeTypeModificationsCommand,
-  type ListAllowedNodeTypeModificationsCommandInput,
-  type ListAllowedNodeTypeModificationsCommandOutput,
   ListTagsForResourceCommand,
-  type ListTagsForResourceCommandInput,
-  type ListTagsForResourceCommandOutput,
   ModifyCacheClusterCommand,
-  type ModifyCacheClusterCommandInput,
-  type ModifyCacheClusterCommandOutput,
   ModifyCacheParameterGroupCommand,
-  type ModifyCacheParameterGroupCommandInput,
-  type ModifyCacheParameterGroupCommandOutput,
   ModifyCacheSubnetGroupCommand,
-  type ModifyCacheSubnetGroupCommandInput,
-  type ModifyCacheSubnetGroupCommandOutput,
   ModifyGlobalReplicationGroupCommand,
-  type ModifyGlobalReplicationGroupCommandInput,
-  type ModifyGlobalReplicationGroupCommandOutput,
   ModifyReplicationGroupCommand,
-  type ModifyReplicationGroupCommandInput,
-  type ModifyReplicationGroupCommandOutput,
   ModifyReplicationGroupShardConfigurationCommand,
-  type ModifyReplicationGroupShardConfigurationCommandInput,
-  type ModifyReplicationGroupShardConfigurationCommandOutput,
   ModifyServerlessCacheCommand,
-  type ModifyServerlessCacheCommandInput,
-  type ModifyServerlessCacheCommandOutput,
   ModifyUserCommand,
-  type ModifyUserCommandInput,
-  type ModifyUserCommandOutput,
   ModifyUserGroupCommand,
-  type ModifyUserGroupCommandInput,
-  type ModifyUserGroupCommandOutput,
   PurchaseReservedCacheNodesOfferingCommand,
-  type PurchaseReservedCacheNodesOfferingCommandInput,
-  type PurchaseReservedCacheNodesOfferingCommandOutput,
   RebalanceSlotsInGlobalReplicationGroupCommand,
-  type RebalanceSlotsInGlobalReplicationGroupCommandInput,
-  type RebalanceSlotsInGlobalReplicationGroupCommandOutput,
   RebootCacheClusterCommand,
-  type RebootCacheClusterCommandInput,
-  type RebootCacheClusterCommandOutput,
   RemoveTagsFromResourceCommand,
-  type RemoveTagsFromResourceCommandInput,
-  type RemoveTagsFromResourceCommandOutput,
   ResetCacheParameterGroupCommand,
-  type ResetCacheParameterGroupCommandInput,
-  type ResetCacheParameterGroupCommandOutput,
   RevokeCacheSecurityGroupIngressCommand,
-  type RevokeCacheSecurityGroupIngressCommandInput,
-  type RevokeCacheSecurityGroupIngressCommandOutput,
   StartMigrationCommand,
-  type StartMigrationCommandInput,
-  type StartMigrationCommandOutput,
   TestFailoverCommand,
-  type TestFailoverCommandInput,
-  type TestFailoverCommandOutput,
   TestMigrationCommand,
-  type TestMigrationCommandInput,
-  type TestMigrationCommandOutput,
+  type AddTagsToResourceMessage,
+  type TagListMessage,
+  type AuthorizeCacheSecurityGroupIngressMessage,
+  type AuthorizeCacheSecurityGroupIngressResult,
+  type BatchApplyUpdateActionMessage,
+  type UpdateActionResultsMessage,
+  type BatchStopUpdateActionMessage,
+  type CompleteMigrationMessage,
+  type CompleteMigrationResponse,
+  type CopyServerlessCacheSnapshotRequest,
+  type CopyServerlessCacheSnapshotResponse,
+  type CopySnapshotMessage,
+  type CopySnapshotResult,
+  type CreateCacheClusterMessage,
+  type CreateCacheClusterResult,
+  type CreateCacheParameterGroupMessage,
+  type CreateCacheParameterGroupResult,
+  type CreateCacheSecurityGroupMessage,
+  type CreateCacheSecurityGroupResult,
+  type CreateCacheSubnetGroupMessage,
+  type CreateCacheSubnetGroupResult,
+  type CreateGlobalReplicationGroupMessage,
+  type CreateGlobalReplicationGroupResult,
+  type CreateReplicationGroupMessage,
+  type CreateReplicationGroupResult,
+  type CreateServerlessCacheRequest,
+  type CreateServerlessCacheResponse,
+  type CreateServerlessCacheSnapshotRequest,
+  type CreateServerlessCacheSnapshotResponse,
+  type CreateSnapshotMessage,
+  type CreateSnapshotResult,
+  type CreateUserMessage,
+  type User,
+  type CreateUserGroupMessage,
+  type UserGroup,
+  type DecreaseNodeGroupsInGlobalReplicationGroupMessage,
+  type DecreaseNodeGroupsInGlobalReplicationGroupResult,
+  type DecreaseReplicaCountMessage,
+  type DecreaseReplicaCountResult,
+  type DeleteCacheClusterMessage,
+  type DeleteCacheClusterResult,
+  type DeleteCacheParameterGroupMessage,
+  type DeleteCacheSecurityGroupMessage,
+  type DeleteCacheSubnetGroupMessage,
+  type DeleteGlobalReplicationGroupMessage,
+  type DeleteGlobalReplicationGroupResult,
+  type DeleteReplicationGroupMessage,
+  type DeleteReplicationGroupResult,
+  type DeleteServerlessCacheRequest,
+  type DeleteServerlessCacheResponse,
+  type DeleteServerlessCacheSnapshotRequest,
+  type DeleteServerlessCacheSnapshotResponse,
+  type DeleteSnapshotMessage,
+  type DeleteSnapshotResult,
+  type DeleteUserMessage,
+  type DeleteUserGroupMessage,
+  type DescribeCacheClustersMessage,
+  type CacheClusterMessage,
+  type DescribeCacheEngineVersionsMessage,
+  type CacheEngineVersionMessage,
+  type DescribeCacheParameterGroupsMessage,
+  type CacheParameterGroupsMessage,
+  type DescribeCacheParametersMessage,
+  type CacheParameterGroupDetails,
+  type DescribeCacheSecurityGroupsMessage,
+  type CacheSecurityGroupMessage,
+  type DescribeCacheSubnetGroupsMessage,
+  type CacheSubnetGroupMessage,
+  type DescribeEngineDefaultParametersMessage,
+  type DescribeEngineDefaultParametersResult,
+  type DescribeEventsMessage,
+  type EventsMessage,
+  type DescribeGlobalReplicationGroupsMessage,
+  type DescribeGlobalReplicationGroupsResult,
+  type DescribeReplicationGroupsMessage,
+  type ReplicationGroupMessage,
+  type DescribeReservedCacheNodesMessage,
+  type ReservedCacheNodeMessage,
+  type DescribeReservedCacheNodesOfferingsMessage,
+  type ReservedCacheNodesOfferingMessage,
+  type DescribeServerlessCacheSnapshotsRequest,
+  type DescribeServerlessCacheSnapshotsResponse,
+  type DescribeServerlessCachesRequest,
+  type DescribeServerlessCachesResponse,
+  type DescribeServiceUpdatesMessage,
+  type ServiceUpdatesMessage,
+  type DescribeSnapshotsMessage,
+  type DescribeSnapshotsListMessage,
+  type DescribeUpdateActionsMessage,
+  type UpdateActionsMessage,
+  type DescribeUserGroupsMessage,
+  type DescribeUserGroupsResult,
+  type DescribeUsersMessage,
+  type DescribeUsersResult,
+  type DisassociateGlobalReplicationGroupMessage,
+  type DisassociateGlobalReplicationGroupResult,
+  type ExportServerlessCacheSnapshotRequest,
+  type ExportServerlessCacheSnapshotResponse,
+  type FailoverGlobalReplicationGroupMessage,
+  type FailoverGlobalReplicationGroupResult,
+  type IncreaseNodeGroupsInGlobalReplicationGroupMessage,
+  type IncreaseNodeGroupsInGlobalReplicationGroupResult,
+  type IncreaseReplicaCountMessage,
+  type IncreaseReplicaCountResult,
+  type ListAllowedNodeTypeModificationsMessage,
+  type AllowedNodeTypeModificationsMessage,
+  type ListTagsForResourceMessage,
+  type ModifyCacheClusterMessage,
+  type ModifyCacheClusterResult,
+  type ModifyCacheParameterGroupMessage,
+  type CacheParameterGroupNameMessage,
+  type ModifyCacheSubnetGroupMessage,
+  type ModifyCacheSubnetGroupResult,
+  type ModifyGlobalReplicationGroupMessage,
+  type ModifyGlobalReplicationGroupResult,
+  type ModifyReplicationGroupMessage,
+  type ModifyReplicationGroupResult,
+  type ModifyReplicationGroupShardConfigurationMessage,
+  type ModifyReplicationGroupShardConfigurationResult,
+  type ModifyServerlessCacheRequest,
+  type ModifyServerlessCacheResponse,
+  type ModifyUserMessage,
+  type ModifyUserGroupMessage,
+  type PurchaseReservedCacheNodesOfferingMessage,
+  type PurchaseReservedCacheNodesOfferingResult,
+  type RebalanceSlotsInGlobalReplicationGroupMessage,
+  type RebalanceSlotsInGlobalReplicationGroupResult,
+  type RebootCacheClusterMessage,
+  type RebootCacheClusterResult,
+  type RemoveTagsFromResourceMessage,
+  type ResetCacheParameterGroupMessage,
+  type RevokeCacheSecurityGroupIngressMessage,
+  type RevokeCacheSecurityGroupIngressResult,
+  type StartMigrationMessage,
+  type StartMigrationResponse,
+  type TestFailoverMessage,
+  type TestFailoverResult,
+  type TestMigrationMessage,
+  type TestMigrationResponse,
 } from "@aws-sdk/client-elasticache";
-import { type HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
-import { Context, Effect, Layer, Record, Data } from "effect";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
+import { Context, Data, Effect, Layer, Record } from "effect";
 import {
   ElastiCacheClientInstance,
   ElastiCacheClientInstanceLayer,
 } from "./ElastiCacheClientInstance";
 import { DefaultElastiCacheClientConfigLayer } from "./ElastiCacheClientInstanceConfig";
 import {
-  ElastiCacheServiceError,
-  InvalidCredentialsError,
-  InvalidParameterCombinationError,
-  InvalidParameterValueError,
+  type CacheClusterNotFoundFault,
+  type CacheParameterGroupNotFoundFault,
+  type CacheSecurityGroupNotFoundFault,
+  type CacheSubnetGroupNotFoundFault,
+  type InvalidARNFault,
+  type InvalidReplicationGroupStateFault,
+  type InvalidServerlessCacheSnapshotStateFault,
+  type InvalidServerlessCacheStateFault,
+  type ReplicationGroupNotFoundFault,
+  type ReservedCacheNodeNotFoundFault,
+  type ServerlessCacheNotFoundFault,
+  type ServerlessCacheSnapshotNotFoundFault,
+  type SnapshotNotFoundFault,
+  type TagQuotaPerResourceExceeded,
+  type UserGroupNotFoundFault,
+  type UserNotFoundFault,
+  type AuthorizationAlreadyExistsFault,
+  type InvalidCacheSecurityGroupStateFault,
+  type InvalidParameterCombinationException,
+  type InvalidParameterValueException,
+  type ServiceUpdateNotFoundFault,
+  type ReplicationGroupNotUnderMigrationFault,
+  type ServerlessCacheSnapshotAlreadyExistsFault,
+  type ServerlessCacheSnapshotQuotaExceededFault,
+  type ServiceLinkedRoleNotFoundFault,
+  type InvalidSnapshotStateFault,
+  type SnapshotAlreadyExistsFault,
+  type SnapshotQuotaExceededFault,
+  type CacheClusterAlreadyExistsFault,
+  type ClusterQuotaForCustomerExceededFault,
+  type InsufficientCacheClusterCapacityFault,
+  type InvalidVPCNetworkStateFault,
+  type NodeQuotaForClusterExceededFault,
+  type NodeQuotaForCustomerExceededFault,
+  type CacheParameterGroupAlreadyExistsFault,
+  type CacheParameterGroupQuotaExceededFault,
+  type InvalidCacheParameterGroupStateFault,
+  type CacheSecurityGroupAlreadyExistsFault,
+  type CacheSecurityGroupQuotaExceededFault,
+  type CacheSubnetGroupAlreadyExistsFault,
+  type CacheSubnetGroupQuotaExceededFault,
+  type CacheSubnetQuotaExceededFault,
+  type InvalidSubnet,
+  type SubnetNotAllowedFault,
+  type GlobalReplicationGroupAlreadyExistsFault,
+  type GlobalReplicationGroupNotFoundFault,
+  type InvalidCacheClusterStateFault,
+  type InvalidGlobalReplicationGroupStateFault,
+  type InvalidUserGroupStateFault,
+  type NodeGroupsPerReplicationGroupQuotaExceededFault,
+  type ReplicationGroupAlreadyExistsFault,
+  type InvalidCredentialsException,
+  type ServerlessCacheAlreadyExistsFault,
+  type ServerlessCacheQuotaForCustomerExceededFault,
+  type SnapshotFeatureNotSupportedFault,
+  type DuplicateUserNameFault,
+  type UserAlreadyExistsFault,
+  type UserQuotaExceededFault,
+  type DefaultUserRequired,
+  type UserGroupAlreadyExistsFault,
+  type UserGroupQuotaExceededFault,
+  type NoOperationFault,
+  type CacheSubnetGroupInUse,
+  type DefaultUserAssociatedToUserGroupFault,
+  type InvalidUserStateFault,
+  type ReservedCacheNodesOfferingNotFoundFault,
+  type InvalidKMSKeyFault,
+  type SubnetInUse,
+  type ReservedCacheNodeAlreadyExistsFault,
+  type ReservedCacheNodeQuotaExceededFault,
+  type TagNotFoundFault,
+  type AuthorizationNotFoundFault,
+  type ReplicationGroupAlreadyUnderMigrationFault,
+  type APICallRateForCustomerExceededFault,
+  type NodeGroupNotFoundFault,
+  type TestFailoverNotAvailableFault,
+  type TaggedException,
   SdkError,
-  TaggedException,
 } from "./Errors";
 
 const commands = {
@@ -289,8 +350,8 @@ const commands = {
   DescribeReplicationGroupsCommand,
   DescribeReservedCacheNodesCommand,
   DescribeReservedCacheNodesOfferingsCommand,
-  DescribeServerlessCachesCommand,
   DescribeServerlessCacheSnapshotsCommand,
+  DescribeServerlessCachesCommand,
   DescribeServiceUpdatesCommand,
   DescribeSnapshotsCommand,
   DescribeUpdateActionsCommand,
@@ -327,1008 +388,1253 @@ const commands = {
  * @since 1.0.0
  * @category models
  */
-export type ElastiCacheService = {
+export interface ElastiCacheService {
   readonly _: unique symbol;
 
   /**
    * @see {@link AddTagsToResourceCommand}
    */
-  readonly addTagsToResource: (
-    args: AddTagsToResourceCommandInput,
+  addTagsToResource(
+    args: AddTagsToResourceMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AddTagsToResourceCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    TagListMessage,
+    | SdkError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | CacheSubnetGroupNotFoundFault
+    | InvalidARNFault
+    | InvalidReplicationGroupStateFault
+    | InvalidServerlessCacheSnapshotStateFault
+    | InvalidServerlessCacheStateFault
+    | ReplicationGroupNotFoundFault
+    | ReservedCacheNodeNotFoundFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | SnapshotNotFoundFault
+    | TagQuotaPerResourceExceeded
+    | UserGroupNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link AuthorizeCacheSecurityGroupIngressCommand}
    */
-  readonly authorizeCacheSecurityGroupIngress: (
-    args: AuthorizeCacheSecurityGroupIngressCommandInput,
+  authorizeCacheSecurityGroupIngress(
+    args: AuthorizeCacheSecurityGroupIngressMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | AuthorizeCacheSecurityGroupIngressCommandOutput
+  ): Effect.Effect<
+    AuthorizeCacheSecurityGroupIngressResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | AuthorizationAlreadyExistsFault
+    | CacheSecurityGroupNotFoundFault
+    | InvalidCacheSecurityGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link BatchApplyUpdateActionCommand}
    */
-  readonly batchApplyUpdateAction: (
-    args: BatchApplyUpdateActionCommandInput,
+  batchApplyUpdateAction(
+    args: BatchApplyUpdateActionMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | BatchApplyUpdateActionCommandOutput
-    | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+  ): Effect.Effect<
+    UpdateActionResultsMessage,
+    SdkError | InvalidParameterValueException | ServiceUpdateNotFoundFault
   >;
 
   /**
    * @see {@link BatchStopUpdateActionCommand}
    */
-  readonly batchStopUpdateAction: (
-    args: BatchStopUpdateActionCommandInput,
+  batchStopUpdateAction(
+    args: BatchStopUpdateActionMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | BatchStopUpdateActionCommandOutput
-    | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+  ): Effect.Effect<
+    UpdateActionResultsMessage,
+    SdkError | InvalidParameterValueException | ServiceUpdateNotFoundFault
   >;
 
   /**
    * @see {@link CompleteMigrationCommand}
    */
-  readonly completeMigration: (
-    args: CompleteMigrationCommandInput,
+  completeMigration(
+    args: CompleteMigrationMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CompleteMigrationCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    CompleteMigrationResponse,
+    | SdkError
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupNotFoundFault
+    | ReplicationGroupNotUnderMigrationFault
   >;
 
   /**
    * @see {@link CopyServerlessCacheSnapshotCommand}
    */
-  readonly copyServerlessCacheSnapshot: (
-    args: CopyServerlessCacheSnapshotCommandInput,
+  copyServerlessCacheSnapshot(
+    args: CopyServerlessCacheSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CopyServerlessCacheSnapshotCommandOutput
+  ): Effect.Effect<
+    CopyServerlessCacheSnapshotResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidServerlessCacheSnapshotStateFault
+    | ServerlessCacheSnapshotAlreadyExistsFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | ServerlessCacheSnapshotQuotaExceededFault
+    | ServiceLinkedRoleNotFoundFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CopySnapshotCommand}
    */
-  readonly copySnapshot: (
-    args: CopySnapshotCommandInput,
+  copySnapshot(
+    args: CopySnapshotMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CopySnapshotCommandOutput
+  ): Effect.Effect<
+    CopySnapshotResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidSnapshotStateFault
+    | SnapshotAlreadyExistsFault
+    | SnapshotNotFoundFault
+    | SnapshotQuotaExceededFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateCacheClusterCommand}
    */
-  readonly createCacheCluster: (
-    args: CreateCacheClusterCommandInput,
+  createCacheCluster(
+    args: CreateCacheClusterMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateCacheClusterCommandOutput
+  ): Effect.Effect<
+    CreateCacheClusterResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterAlreadyExistsFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | CacheSubnetGroupNotFoundFault
+    | ClusterQuotaForCustomerExceededFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeQuotaForClusterExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | ReplicationGroupNotFoundFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateCacheParameterGroupCommand}
    */
-  readonly createCacheParameterGroup: (
-    args: CreateCacheParameterGroupCommandInput,
+  createCacheParameterGroup(
+    args: CreateCacheParameterGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateCacheParameterGroupCommandOutput
+  ): Effect.Effect<
+    CreateCacheParameterGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupAlreadyExistsFault
+    | CacheParameterGroupQuotaExceededFault
+    | InvalidCacheParameterGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateCacheSecurityGroupCommand}
    */
-  readonly createCacheSecurityGroup: (
-    args: CreateCacheSecurityGroupCommandInput,
+  createCacheSecurityGroup(
+    args: CreateCacheSecurityGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateCacheSecurityGroupCommandOutput
+  ): Effect.Effect<
+    CreateCacheSecurityGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheSecurityGroupAlreadyExistsFault
+    | CacheSecurityGroupQuotaExceededFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateCacheSubnetGroupCommand}
    */
-  readonly createCacheSubnetGroup: (
-    args: CreateCacheSubnetGroupCommandInput,
+  createCacheSubnetGroup(
+    args: CreateCacheSubnetGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateCacheSubnetGroupCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    CreateCacheSubnetGroupResult,
+    | SdkError
+    | CacheSubnetGroupAlreadyExistsFault
+    | CacheSubnetGroupQuotaExceededFault
+    | CacheSubnetQuotaExceededFault
+    | InvalidSubnet
+    | SubnetNotAllowedFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateGlobalReplicationGroupCommand}
    */
-  readonly createGlobalReplicationGroup: (
-    args: CreateGlobalReplicationGroupCommandInput,
+  createGlobalReplicationGroup(
+    args: CreateGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    CreateGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupAlreadyExistsFault
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupNotFoundFault
+    | ServiceLinkedRoleNotFoundFault
   >;
 
   /**
    * @see {@link CreateReplicationGroupCommand}
    */
-  readonly createReplicationGroup: (
-    args: CreateReplicationGroupCommandInput,
+  createReplicationGroup(
+    args: CreateReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateReplicationGroupCommandOutput
+  ): Effect.Effect<
+    CreateReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | CacheSubnetGroupNotFoundFault
+    | ClusterQuotaForCustomerExceededFault
+    | GlobalReplicationGroupNotFoundFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidUserGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeGroupsPerReplicationGroupQuotaExceededFault
+    | NodeQuotaForClusterExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | ReplicationGroupAlreadyExistsFault
+    | TagQuotaPerResourceExceeded
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link CreateServerlessCacheCommand}
    */
-  readonly createServerlessCache: (
-    args: CreateServerlessCacheCommandInput,
+  createServerlessCache(
+    args: CreateServerlessCacheRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateServerlessCacheCommandOutput
+  ): Effect.Effect<
+    CreateServerlessCacheResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidCredentialsError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidCredentialsException
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidServerlessCacheStateFault
+    | InvalidUserGroupStateFault
+    | ServerlessCacheAlreadyExistsFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheQuotaForCustomerExceededFault
+    | ServiceLinkedRoleNotFoundFault
+    | TagQuotaPerResourceExceeded
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link CreateServerlessCacheSnapshotCommand}
    */
-  readonly createServerlessCacheSnapshot: (
-    args: CreateServerlessCacheSnapshotCommandInput,
+  createServerlessCacheSnapshot(
+    args: CreateServerlessCacheSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateServerlessCacheSnapshotCommandOutput
+  ): Effect.Effect<
+    CreateServerlessCacheSnapshotResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidServerlessCacheStateFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotAlreadyExistsFault
+    | ServerlessCacheSnapshotQuotaExceededFault
+    | ServiceLinkedRoleNotFoundFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateSnapshotCommand}
    */
-  readonly createSnapshot: (
-    args: CreateSnapshotCommandInput,
+  createSnapshot(
+    args: CreateSnapshotMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateSnapshotCommandOutput
+  ): Effect.Effect<
+    CreateSnapshotResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | InvalidCacheClusterStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupNotFoundFault
+    | SnapshotAlreadyExistsFault
+    | SnapshotFeatureNotSupportedFault
+    | SnapshotQuotaExceededFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link CreateUserCommand}
    */
-  readonly createUser: (
-    args: CreateUserCommandInput,
+  createUser(
+    args: CreateUserMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateUserCommandOutput
+  ): Effect.Effect<
+    User,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | DuplicateUserNameFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ServiceLinkedRoleNotFoundFault
+    | TagQuotaPerResourceExceeded
+    | UserAlreadyExistsFault
+    | UserQuotaExceededFault
   >;
 
   /**
    * @see {@link CreateUserGroupCommand}
    */
-  readonly createUserGroup: (
-    args: CreateUserGroupCommandInput,
+  createUserGroup(
+    args: CreateUserGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | CreateUserGroupCommandOutput
+  ): Effect.Effect<
+    UserGroup,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | DefaultUserRequired
+    | DuplicateUserNameFault
+    | InvalidParameterValueException
+    | ServiceLinkedRoleNotFoundFault
+    | TagQuotaPerResourceExceeded
+    | UserGroupAlreadyExistsFault
+    | UserGroupQuotaExceededFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link DecreaseNodeGroupsInGlobalReplicationGroupCommand}
    */
-  readonly decreaseNodeGroupsInGlobalReplicationGroup: (
-    args: DecreaseNodeGroupsInGlobalReplicationGroupCommandInput,
+  decreaseNodeGroupsInGlobalReplicationGroup(
+    args: DecreaseNodeGroupsInGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DecreaseNodeGroupsInGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    DecreaseNodeGroupsInGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DecreaseReplicaCountCommand}
    */
-  readonly decreaseReplicaCount: (
-    args: DecreaseReplicaCountCommandInput,
+  decreaseReplicaCount(
+    args: DecreaseReplicaCountMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DecreaseReplicaCountCommandOutput
+  ): Effect.Effect<
+    DecreaseReplicaCountResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | ClusterQuotaForCustomerExceededFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeGroupsPerReplicationGroupQuotaExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | NoOperationFault
+    | ReplicationGroupNotFoundFault
+    | ServiceLinkedRoleNotFoundFault
   >;
 
   /**
    * @see {@link DeleteCacheClusterCommand}
    */
-  readonly deleteCacheCluster: (
-    args: DeleteCacheClusterCommandInput,
+  deleteCacheCluster(
+    args: DeleteCacheClusterMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteCacheClusterCommandOutput
+  ): Effect.Effect<
+    DeleteCacheClusterResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | InvalidCacheClusterStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | SnapshotAlreadyExistsFault
+    | SnapshotFeatureNotSupportedFault
+    | SnapshotQuotaExceededFault
   >;
 
   /**
    * @see {@link DeleteCacheParameterGroupCommand}
    */
-  readonly deleteCacheParameterGroup: (
-    args: DeleteCacheParameterGroupCommandInput,
+  deleteCacheParameterGroup(
+    args: DeleteCacheParameterGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteCacheParameterGroupCommandOutput
+  ): Effect.Effect<
+    void,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupNotFoundFault
+    | InvalidCacheParameterGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DeleteCacheSecurityGroupCommand}
    */
-  readonly deleteCacheSecurityGroup: (
-    args: DeleteCacheSecurityGroupCommandInput,
+  deleteCacheSecurityGroup(
+    args: DeleteCacheSecurityGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteCacheSecurityGroupCommandOutput
+  ): Effect.Effect<
+    void,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheSecurityGroupNotFoundFault
+    | InvalidCacheSecurityGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DeleteCacheSubnetGroupCommand}
    */
-  readonly deleteCacheSubnetGroup: (
-    args: DeleteCacheSubnetGroupCommandInput,
+  deleteCacheSubnetGroup(
+    args: DeleteCacheSubnetGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteCacheSubnetGroupCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    void,
+    SdkError | CacheSubnetGroupInUse | CacheSubnetGroupNotFoundFault
   >;
 
   /**
    * @see {@link DeleteGlobalReplicationGroupCommand}
    */
-  readonly deleteGlobalReplicationGroup: (
-    args: DeleteGlobalReplicationGroupCommandInput,
+  deleteGlobalReplicationGroup(
+    args: DeleteGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    DeleteGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DeleteReplicationGroupCommand}
    */
-  readonly deleteReplicationGroup: (
-    args: DeleteReplicationGroupCommandInput,
+  deleteReplicationGroup(
+    args: DeleteReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteReplicationGroupCommandOutput
+  ): Effect.Effect<
+    DeleteReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupNotFoundFault
+    | SnapshotAlreadyExistsFault
+    | SnapshotFeatureNotSupportedFault
+    | SnapshotQuotaExceededFault
   >;
 
   /**
    * @see {@link DeleteServerlessCacheCommand}
    */
-  readonly deleteServerlessCache: (
-    args: DeleteServerlessCacheCommandInput,
+  deleteServerlessCache(
+    args: DeleteServerlessCacheRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteServerlessCacheCommandOutput
+  ): Effect.Effect<
+    DeleteServerlessCacheResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidCredentialsError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidCredentialsException
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidServerlessCacheStateFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotAlreadyExistsFault
+    | ServiceLinkedRoleNotFoundFault
   >;
 
   /**
    * @see {@link DeleteServerlessCacheSnapshotCommand}
    */
-  readonly deleteServerlessCacheSnapshot: (
-    args: DeleteServerlessCacheSnapshotCommandInput,
+  deleteServerlessCacheSnapshot(
+    args: DeleteServerlessCacheSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteServerlessCacheSnapshotCommandOutput
+  ): Effect.Effect<
+    DeleteServerlessCacheSnapshotResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | InvalidParameterValueException
+    | InvalidServerlessCacheSnapshotStateFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | ServiceLinkedRoleNotFoundFault
   >;
 
   /**
    * @see {@link DeleteSnapshotCommand}
    */
-  readonly deleteSnapshot: (
-    args: DeleteSnapshotCommandInput,
+  deleteSnapshot(
+    args: DeleteSnapshotMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteSnapshotCommandOutput
+  ): Effect.Effect<
+    DeleteSnapshotResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidSnapshotStateFault
+    | SnapshotNotFoundFault
   >;
 
   /**
    * @see {@link DeleteUserCommand}
    */
-  readonly deleteUser: (
-    args: DeleteUserCommandInput,
+  deleteUser(
+    args: DeleteUserMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteUserCommandOutput
+  ): Effect.Effect<
+    User,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | DefaultUserAssociatedToUserGroupFault
+    | InvalidParameterValueException
+    | InvalidUserStateFault
+    | ServiceLinkedRoleNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link DeleteUserGroupCommand}
    */
-  readonly deleteUserGroup: (
-    args: DeleteUserGroupCommandInput,
+  deleteUserGroup(
+    args: DeleteUserGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DeleteUserGroupCommandOutput
+  ): Effect.Effect<
+    UserGroup,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | InvalidParameterValueException
+    | InvalidUserGroupStateFault
+    | ServiceLinkedRoleNotFoundFault
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link DescribeCacheClustersCommand}
    */
-  readonly describeCacheClusters: (
-    args: DescribeCacheClustersCommandInput,
+  describeCacheClusters(
+    args: DescribeCacheClustersMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeCacheClustersCommandOutput
+  ): Effect.Effect<
+    CacheClusterMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeCacheEngineVersionsCommand}
    */
-  readonly describeCacheEngineVersions: (
-    args: DescribeCacheEngineVersionsCommandInput,
+  describeCacheEngineVersions(
+    args: DescribeCacheEngineVersionsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeCacheEngineVersionsCommandOutput
-    | SdkError
-    | ElastiCacheServiceError
-  >;
+  ): Effect.Effect<CacheEngineVersionMessage, SdkError>;
 
   /**
    * @see {@link DescribeCacheParameterGroupsCommand}
    */
-  readonly describeCacheParameterGroups: (
-    args: DescribeCacheParameterGroupsCommandInput,
+  describeCacheParameterGroups(
+    args: DescribeCacheParameterGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeCacheParameterGroupsCommandOutput
+  ): Effect.Effect<
+    CacheParameterGroupsMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeCacheParametersCommand}
    */
-  readonly describeCacheParameters: (
-    args: DescribeCacheParametersCommandInput,
+  describeCacheParameters(
+    args: DescribeCacheParametersMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeCacheParametersCommandOutput
+  ): Effect.Effect<
+    CacheParameterGroupDetails,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeCacheSecurityGroupsCommand}
    */
-  readonly describeCacheSecurityGroups: (
-    args: DescribeCacheSecurityGroupsCommandInput,
+  describeCacheSecurityGroups(
+    args: DescribeCacheSecurityGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeCacheSecurityGroupsCommandOutput
+  ): Effect.Effect<
+    CacheSecurityGroupMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheSecurityGroupNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeCacheSubnetGroupsCommand}
    */
-  readonly describeCacheSubnetGroups: (
-    args: DescribeCacheSubnetGroupsCommandInput,
+  describeCacheSubnetGroups(
+    args: DescribeCacheSubnetGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DescribeCacheSubnetGroupsCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    CacheSubnetGroupMessage,
+    SdkError | CacheSubnetGroupNotFoundFault
   >;
 
   /**
    * @see {@link DescribeEngineDefaultParametersCommand}
    */
-  readonly describeEngineDefaultParameters: (
-    args: DescribeEngineDefaultParametersCommandInput,
+  describeEngineDefaultParameters(
+    args: DescribeEngineDefaultParametersMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeEngineDefaultParametersCommandOutput
+  ): Effect.Effect<
+    DescribeEngineDefaultParametersResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeEventsCommand}
    */
-  readonly describeEvents: (
-    args: DescribeEventsCommandInput,
+  describeEvents(
+    args: DescribeEventsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeEventsCommandOutput
+  ): Effect.Effect<
+    EventsMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeGlobalReplicationGroupsCommand}
    */
-  readonly describeGlobalReplicationGroups: (
-    args: DescribeGlobalReplicationGroupsCommandInput,
+  describeGlobalReplicationGroups(
+    args: DescribeGlobalReplicationGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeGlobalReplicationGroupsCommandOutput
+  ): Effect.Effect<
+    DescribeGlobalReplicationGroupsResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeReplicationGroupsCommand}
    */
-  readonly describeReplicationGroups: (
-    args: DescribeReplicationGroupsCommandInput,
+  describeReplicationGroups(
+    args: DescribeReplicationGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeReplicationGroupsCommandOutput
+  ): Effect.Effect<
+    ReplicationGroupMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ReplicationGroupNotFoundFault
   >;
 
   /**
    * @see {@link DescribeReservedCacheNodesCommand}
    */
-  readonly describeReservedCacheNodes: (
-    args: DescribeReservedCacheNodesCommandInput,
+  describeReservedCacheNodes(
+    args: DescribeReservedCacheNodesMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeReservedCacheNodesCommandOutput
+  ): Effect.Effect<
+    ReservedCacheNodeMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ReservedCacheNodeNotFoundFault
   >;
 
   /**
    * @see {@link DescribeReservedCacheNodesOfferingsCommand}
    */
-  readonly describeReservedCacheNodesOfferings: (
-    args: DescribeReservedCacheNodesOfferingsCommandInput,
+  describeReservedCacheNodesOfferings(
+    args: DescribeReservedCacheNodesOfferingsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeReservedCacheNodesOfferingsCommandOutput
+  ): Effect.Effect<
+    ReservedCacheNodesOfferingMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
-  >;
-
-  /**
-   * @see {@link DescribeServerlessCachesCommand}
-   */
-  readonly describeServerlessCaches: (
-    args: DescribeServerlessCachesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeServerlessCachesCommandOutput
-    | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ReservedCacheNodesOfferingNotFoundFault
   >;
 
   /**
    * @see {@link DescribeServerlessCacheSnapshotsCommand}
    */
-  readonly describeServerlessCacheSnapshots: (
-    args: DescribeServerlessCacheSnapshotsCommandInput,
+  describeServerlessCacheSnapshots(
+    args: DescribeServerlessCacheSnapshotsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeServerlessCacheSnapshotsCommandOutput
+  ): Effect.Effect<
+    DescribeServerlessCacheSnapshotsResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotNotFoundFault
+  >;
+
+  /**
+   * @see {@link DescribeServerlessCachesCommand}
+   */
+  describeServerlessCaches(
+    args: DescribeServerlessCachesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    DescribeServerlessCachesResponse,
+    | SdkError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ServerlessCacheNotFoundFault
   >;
 
   /**
    * @see {@link DescribeServiceUpdatesCommand}
    */
-  readonly describeServiceUpdates: (
-    args: DescribeServiceUpdatesCommandInput,
+  describeServiceUpdates(
+    args: DescribeServiceUpdatesMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeServiceUpdatesCommandOutput
+  ): Effect.Effect<
+    ServiceUpdatesMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ServiceUpdateNotFoundFault
   >;
 
   /**
    * @see {@link DescribeSnapshotsCommand}
    */
-  readonly describeSnapshots: (
-    args: DescribeSnapshotsCommandInput,
+  describeSnapshots(
+    args: DescribeSnapshotsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeSnapshotsCommandOutput
+  ): Effect.Effect<
+    DescribeSnapshotsListMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | SnapshotNotFoundFault
   >;
 
   /**
    * @see {@link DescribeUpdateActionsCommand}
    */
-  readonly describeUpdateActions: (
-    args: DescribeUpdateActionsCommandInput,
+  describeUpdateActions(
+    args: DescribeUpdateActionsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeUpdateActionsCommandOutput
+  ): Effect.Effect<
+    UpdateActionsMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link DescribeUserGroupsCommand}
    */
-  readonly describeUserGroups: (
-    args: DescribeUserGroupsCommandInput,
+  describeUserGroups(
+    args: DescribeUserGroupsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeUserGroupsCommandOutput
+  ): Effect.Effect<
+    DescribeUserGroupsResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
+    | InvalidParameterCombinationException
+    | ServiceLinkedRoleNotFoundFault
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link DescribeUsersCommand}
    */
-  readonly describeUsers: (
-    args: DescribeUsersCommandInput,
+  describeUsers(
+    args: DescribeUsersMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DescribeUsersCommandOutput
+  ): Effect.Effect<
+    DescribeUsersResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
+    | InvalidParameterCombinationException
+    | ServiceLinkedRoleNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link DisassociateGlobalReplicationGroupCommand}
    */
-  readonly disassociateGlobalReplicationGroup: (
-    args: DisassociateGlobalReplicationGroupCommandInput,
+  disassociateGlobalReplicationGroup(
+    args: DisassociateGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | DisassociateGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    DisassociateGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link ExportServerlessCacheSnapshotCommand}
    */
-  readonly exportServerlessCacheSnapshot: (
-    args: ExportServerlessCacheSnapshotCommandInput,
+  exportServerlessCacheSnapshot(
+    args: ExportServerlessCacheSnapshotRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ExportServerlessCacheSnapshotCommandOutput
+  ): Effect.Effect<
+    ExportServerlessCacheSnapshotResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | InvalidParameterValueException
+    | InvalidServerlessCacheSnapshotStateFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | ServiceLinkedRoleNotFoundFault
   >;
 
   /**
    * @see {@link FailoverGlobalReplicationGroupCommand}
    */
-  readonly failoverGlobalReplicationGroup: (
-    args: FailoverGlobalReplicationGroupCommandInput,
+  failoverGlobalReplicationGroup(
+    args: FailoverGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | FailoverGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    FailoverGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link IncreaseNodeGroupsInGlobalReplicationGroupCommand}
    */
-  readonly increaseNodeGroupsInGlobalReplicationGroup: (
-    args: IncreaseNodeGroupsInGlobalReplicationGroupCommandInput,
+  increaseNodeGroupsInGlobalReplicationGroup(
+    args: IncreaseNodeGroupsInGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | IncreaseNodeGroupsInGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    IncreaseNodeGroupsInGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link IncreaseReplicaCountCommand}
    */
-  readonly increaseReplicaCount: (
-    args: IncreaseReplicaCountCommandInput,
+  increaseReplicaCount(
+    args: IncreaseReplicaCountMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | IncreaseReplicaCountCommandOutput
+  ): Effect.Effect<
+    IncreaseReplicaCountResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | ClusterQuotaForCustomerExceededFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidKMSKeyFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeGroupsPerReplicationGroupQuotaExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | NoOperationFault
+    | ReplicationGroupNotFoundFault
   >;
 
   /**
    * @see {@link ListAllowedNodeTypeModificationsCommand}
    */
-  readonly listAllowedNodeTypeModifications: (
-    args: ListAllowedNodeTypeModificationsCommandInput,
+  listAllowedNodeTypeModifications(
+    args: ListAllowedNodeTypeModificationsMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ListAllowedNodeTypeModificationsCommandOutput
+  ): Effect.Effect<
+    AllowedNodeTypeModificationsMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ReplicationGroupNotFoundFault
   >;
 
   /**
    * @see {@link ListTagsForResourceCommand}
    */
-  readonly listTagsForResource: (
-    args: ListTagsForResourceCommandInput,
+  listTagsForResource(
+    args: ListTagsForResourceMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListTagsForResourceCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    TagListMessage,
+    | SdkError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | CacheSubnetGroupNotFoundFault
+    | InvalidARNFault
+    | InvalidReplicationGroupStateFault
+    | InvalidServerlessCacheSnapshotStateFault
+    | InvalidServerlessCacheStateFault
+    | ReplicationGroupNotFoundFault
+    | ReservedCacheNodeNotFoundFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | SnapshotNotFoundFault
+    | UserGroupNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link ModifyCacheClusterCommand}
    */
-  readonly modifyCacheCluster: (
-    args: ModifyCacheClusterCommandInput,
+  modifyCacheCluster(
+    args: ModifyCacheClusterMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyCacheClusterCommandOutput
+  ): Effect.Effect<
+    ModifyCacheClusterResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidCacheSecurityGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidVPCNetworkStateFault
+    | NodeQuotaForClusterExceededFault
+    | NodeQuotaForCustomerExceededFault
   >;
 
   /**
    * @see {@link ModifyCacheParameterGroupCommand}
    */
-  readonly modifyCacheParameterGroup: (
-    args: ModifyCacheParameterGroupCommandInput,
+  modifyCacheParameterGroup(
+    args: ModifyCacheParameterGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyCacheParameterGroupCommandOutput
+  ): Effect.Effect<
+    CacheParameterGroupNameMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupNotFoundFault
+    | InvalidCacheParameterGroupStateFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link ModifyCacheSubnetGroupCommand}
    */
-  readonly modifyCacheSubnetGroup: (
-    args: ModifyCacheSubnetGroupCommandInput,
+  modifyCacheSubnetGroup(
+    args: ModifyCacheSubnetGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ModifyCacheSubnetGroupCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    ModifyCacheSubnetGroupResult,
+    | SdkError
+    | CacheSubnetGroupNotFoundFault
+    | CacheSubnetQuotaExceededFault
+    | InvalidSubnet
+    | SubnetInUse
+    | SubnetNotAllowedFault
   >;
 
   /**
    * @see {@link ModifyGlobalReplicationGroupCommand}
    */
-  readonly modifyGlobalReplicationGroup: (
-    args: ModifyGlobalReplicationGroupCommandInput,
+  modifyGlobalReplicationGroup(
+    args: ModifyGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    ModifyGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link ModifyReplicationGroupCommand}
    */
-  readonly modifyReplicationGroup: (
-    args: ModifyReplicationGroupCommandInput,
+  modifyReplicationGroup(
+    args: ModifyReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyReplicationGroupCommandOutput
+  ): Effect.Effect<
+    ModifyReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidCacheSecurityGroupStateFault
+    | InvalidKMSKeyFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | InvalidUserGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeQuotaForClusterExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | ReplicationGroupNotFoundFault
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link ModifyReplicationGroupShardConfigurationCommand}
    */
-  readonly modifyReplicationGroupShardConfiguration: (
-    args: ModifyReplicationGroupShardConfigurationCommandInput,
+  modifyReplicationGroupShardConfiguration(
+    args: ModifyReplicationGroupShardConfigurationMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyReplicationGroupShardConfigurationCommandOutput
+  ): Effect.Effect<
+    ModifyReplicationGroupShardConfigurationResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InsufficientCacheClusterCapacityFault
+    | InvalidCacheClusterStateFault
+    | InvalidKMSKeyFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | InvalidVPCNetworkStateFault
+    | NodeGroupsPerReplicationGroupQuotaExceededFault
+    | NodeQuotaForCustomerExceededFault
+    | ReplicationGroupNotFoundFault
   >;
 
   /**
    * @see {@link ModifyServerlessCacheCommand}
    */
-  readonly modifyServerlessCache: (
-    args: ModifyServerlessCacheCommandInput,
+  modifyServerlessCache(
+    args: ModifyServerlessCacheRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyServerlessCacheCommandOutput
+  ): Effect.Effect<
+    ModifyServerlessCacheResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidCredentialsError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidCredentialsException
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidServerlessCacheStateFault
+    | InvalidUserGroupStateFault
+    | ServerlessCacheNotFoundFault
+    | ServiceLinkedRoleNotFoundFault
+    | UserGroupNotFoundFault
   >;
 
   /**
    * @see {@link ModifyUserCommand}
    */
-  readonly modifyUser: (
-    args: ModifyUserCommandInput,
+  modifyUser(
+    args: ModifyUserMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyUserCommandOutput
+  ): Effect.Effect<
+    User,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidUserStateFault
+    | ServiceLinkedRoleNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link ModifyUserGroupCommand}
    */
-  readonly modifyUserGroup: (
-    args: ModifyUserGroupCommandInput,
+  modifyUserGroup(
+    args: ModifyUserGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ModifyUserGroupCommandOutput
+  ): Effect.Effect<
+    UserGroup,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | DefaultUserRequired
+    | DuplicateUserNameFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidUserGroupStateFault
+    | ServiceLinkedRoleNotFoundFault
+    | UserGroupNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link PurchaseReservedCacheNodesOfferingCommand}
    */
-  readonly purchaseReservedCacheNodesOffering: (
-    args: PurchaseReservedCacheNodesOfferingCommandInput,
+  purchaseReservedCacheNodesOffering(
+    args: PurchaseReservedCacheNodesOfferingMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | PurchaseReservedCacheNodesOfferingCommandOutput
+  ): Effect.Effect<
+    PurchaseReservedCacheNodesOfferingResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | ReservedCacheNodeAlreadyExistsFault
+    | ReservedCacheNodeQuotaExceededFault
+    | ReservedCacheNodesOfferingNotFoundFault
+    | TagQuotaPerResourceExceeded
   >;
 
   /**
    * @see {@link RebalanceSlotsInGlobalReplicationGroupCommand}
    */
-  readonly rebalanceSlotsInGlobalReplicationGroup: (
-    args: RebalanceSlotsInGlobalReplicationGroupCommandInput,
+  rebalanceSlotsInGlobalReplicationGroup(
+    args: RebalanceSlotsInGlobalReplicationGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | RebalanceSlotsInGlobalReplicationGroupCommandOutput
+  ): Effect.Effect<
+    RebalanceSlotsInGlobalReplicationGroupResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | GlobalReplicationGroupNotFoundFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link RebootCacheClusterCommand}
    */
-  readonly rebootCacheCluster: (
-    args: RebootCacheClusterCommandInput,
+  rebootCacheCluster(
+    args: RebootCacheClusterMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RebootCacheClusterCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    RebootCacheClusterResult,
+    SdkError | CacheClusterNotFoundFault | InvalidCacheClusterStateFault
   >;
 
   /**
    * @see {@link RemoveTagsFromResourceCommand}
    */
-  readonly removeTagsFromResource: (
-    args: RemoveTagsFromResourceCommandInput,
+  removeTagsFromResource(
+    args: RemoveTagsFromResourceMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RemoveTagsFromResourceCommandOutput | SdkError | ElastiCacheServiceError
+  ): Effect.Effect<
+    TagListMessage,
+    | SdkError
+    | CacheClusterNotFoundFault
+    | CacheParameterGroupNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | CacheSubnetGroupNotFoundFault
+    | InvalidARNFault
+    | InvalidReplicationGroupStateFault
+    | InvalidServerlessCacheSnapshotStateFault
+    | InvalidServerlessCacheStateFault
+    | ReplicationGroupNotFoundFault
+    | ReservedCacheNodeNotFoundFault
+    | ServerlessCacheNotFoundFault
+    | ServerlessCacheSnapshotNotFoundFault
+    | SnapshotNotFoundFault
+    | TagNotFoundFault
+    | UserGroupNotFoundFault
+    | UserNotFoundFault
   >;
 
   /**
    * @see {@link ResetCacheParameterGroupCommand}
    */
-  readonly resetCacheParameterGroup: (
-    args: ResetCacheParameterGroupCommandInput,
+  resetCacheParameterGroup(
+    args: ResetCacheParameterGroupMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | ResetCacheParameterGroupCommandOutput
+  ): Effect.Effect<
+    CacheParameterGroupNameMessage,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | CacheParameterGroupNotFoundFault
+    | InvalidCacheParameterGroupStateFault
+    | InvalidGlobalReplicationGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link RevokeCacheSecurityGroupIngressCommand}
    */
-  readonly revokeCacheSecurityGroupIngress: (
-    args: RevokeCacheSecurityGroupIngressCommandInput,
+  revokeCacheSecurityGroupIngress(
+    args: RevokeCacheSecurityGroupIngressMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | RevokeCacheSecurityGroupIngressCommandOutput
+  ): Effect.Effect<
+    RevokeCacheSecurityGroupIngressResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | AuthorizationNotFoundFault
+    | CacheSecurityGroupNotFoundFault
+    | InvalidCacheSecurityGroupStateFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
   >;
 
   /**
    * @see {@link StartMigrationCommand}
    */
-  readonly startMigration: (
-    args: StartMigrationCommandInput,
+  startMigration(
+    args: StartMigrationMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | StartMigrationCommandOutput
+  ): Effect.Effect<
+    StartMigrationResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupAlreadyUnderMigrationFault
+    | ReplicationGroupNotFoundFault
   >;
 
   /**
    * @see {@link TestFailoverCommand}
    */
-  readonly testFailover: (
-    args: TestFailoverCommandInput,
+  testFailover(
+    args: TestFailoverMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | TestFailoverCommandOutput
+  ): Effect.Effect<
+    TestFailoverResult,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterCombinationError
-    | InvalidParameterValueError
+    | APICallRateForCustomerExceededFault
+    | InvalidCacheClusterStateFault
+    | InvalidKMSKeyFault
+    | InvalidParameterCombinationException
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | NodeGroupNotFoundFault
+    | ReplicationGroupNotFoundFault
+    | TestFailoverNotAvailableFault
   >;
 
   /**
    * @see {@link TestMigrationCommand}
    */
-  readonly testMigration: (
-    args: TestMigrationCommandInput,
+  testMigration(
+    args: TestMigrationMessage,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    | TestMigrationCommandOutput
+  ): Effect.Effect<
+    TestMigrationResponse,
     | SdkError
-    | ElastiCacheServiceError
-    | InvalidParameterValueError
+    | InvalidParameterValueException
+    | InvalidReplicationGroupStateFault
+    | ReplicationGroupAlreadyUnderMigrationFault
+    | ReplicationGroupNotFoundFault
   >;
-};
+}
 
 /**
  * @since 1.0.0
@@ -1351,9 +1657,9 @@ export const makeElastiCacheService = Effect.gen(function* (_) {
       Effect.tryPromise({
         try: () => client.send(new CommandCtor(args), options ?? {}),
         catch: (e) => {
-          if (e instanceof ElastiCacheServiceException) {
+          if (e instanceof SdkElastiCacheServiceException) {
             const ServiceException = Data.tagged<
-              TaggedException<ElastiCacheServiceException>
+              TaggedException<SdkElastiCacheServiceException>
             >(e.name);
 
             return ServiceException({

--- a/packages/client-elasticache/src/Errors.ts
+++ b/packages/client-elasticache/src/Errors.ts
@@ -1,8 +1,80 @@
 import type {
-  ElastiCacheServiceException,
-  InvalidCredentialsException,
-  InvalidParameterValueException,
-  InvalidParameterCombinationException,
+  APICallRateForCustomerExceededFault as SdkAPICallRateForCustomerExceededFault,
+  AuthorizationAlreadyExistsFault as SdkAuthorizationAlreadyExistsFault,
+  AuthorizationNotFoundFault as SdkAuthorizationNotFoundFault,
+  CacheClusterAlreadyExistsFault as SdkCacheClusterAlreadyExistsFault,
+  CacheClusterNotFoundFault as SdkCacheClusterNotFoundFault,
+  CacheParameterGroupAlreadyExistsFault as SdkCacheParameterGroupAlreadyExistsFault,
+  CacheParameterGroupNotFoundFault as SdkCacheParameterGroupNotFoundFault,
+  CacheParameterGroupQuotaExceededFault as SdkCacheParameterGroupQuotaExceededFault,
+  CacheSecurityGroupAlreadyExistsFault as SdkCacheSecurityGroupAlreadyExistsFault,
+  CacheSecurityGroupNotFoundFault as SdkCacheSecurityGroupNotFoundFault,
+  CacheSecurityGroupQuotaExceededFault as SdkCacheSecurityGroupQuotaExceededFault,
+  CacheSubnetGroupAlreadyExistsFault as SdkCacheSubnetGroupAlreadyExistsFault,
+  CacheSubnetGroupInUse as SdkCacheSubnetGroupInUse,
+  CacheSubnetGroupNotFoundFault as SdkCacheSubnetGroupNotFoundFault,
+  CacheSubnetGroupQuotaExceededFault as SdkCacheSubnetGroupQuotaExceededFault,
+  CacheSubnetQuotaExceededFault as SdkCacheSubnetQuotaExceededFault,
+  ClusterQuotaForCustomerExceededFault as SdkClusterQuotaForCustomerExceededFault,
+  DefaultUserAssociatedToUserGroupFault as SdkDefaultUserAssociatedToUserGroupFault,
+  DefaultUserRequired as SdkDefaultUserRequired,
+  DuplicateUserNameFault as SdkDuplicateUserNameFault,
+  GlobalReplicationGroupAlreadyExistsFault as SdkGlobalReplicationGroupAlreadyExistsFault,
+  GlobalReplicationGroupNotFoundFault as SdkGlobalReplicationGroupNotFoundFault,
+  InsufficientCacheClusterCapacityFault as SdkInsufficientCacheClusterCapacityFault,
+  InvalidARNFault as SdkInvalidARNFault,
+  InvalidCacheClusterStateFault as SdkInvalidCacheClusterStateFault,
+  InvalidCacheParameterGroupStateFault as SdkInvalidCacheParameterGroupStateFault,
+  InvalidCacheSecurityGroupStateFault as SdkInvalidCacheSecurityGroupStateFault,
+  InvalidCredentialsException as SdkInvalidCredentialsException,
+  InvalidGlobalReplicationGroupStateFault as SdkInvalidGlobalReplicationGroupStateFault,
+  InvalidKMSKeyFault as SdkInvalidKMSKeyFault,
+  InvalidParameterCombinationException as SdkInvalidParameterCombinationException,
+  InvalidParameterValueException as SdkInvalidParameterValueException,
+  InvalidReplicationGroupStateFault as SdkInvalidReplicationGroupStateFault,
+  InvalidServerlessCacheSnapshotStateFault as SdkInvalidServerlessCacheSnapshotStateFault,
+  InvalidServerlessCacheStateFault as SdkInvalidServerlessCacheStateFault,
+  InvalidSnapshotStateFault as SdkInvalidSnapshotStateFault,
+  InvalidSubnet as SdkInvalidSubnet,
+  InvalidUserGroupStateFault as SdkInvalidUserGroupStateFault,
+  InvalidUserStateFault as SdkInvalidUserStateFault,
+  InvalidVPCNetworkStateFault as SdkInvalidVPCNetworkStateFault,
+  NoOperationFault as SdkNoOperationFault,
+  NodeGroupNotFoundFault as SdkNodeGroupNotFoundFault,
+  NodeGroupsPerReplicationGroupQuotaExceededFault as SdkNodeGroupsPerReplicationGroupQuotaExceededFault,
+  NodeQuotaForClusterExceededFault as SdkNodeQuotaForClusterExceededFault,
+  NodeQuotaForCustomerExceededFault as SdkNodeQuotaForCustomerExceededFault,
+  ReplicationGroupAlreadyExistsFault as SdkReplicationGroupAlreadyExistsFault,
+  ReplicationGroupAlreadyUnderMigrationFault as SdkReplicationGroupAlreadyUnderMigrationFault,
+  ReplicationGroupNotFoundFault as SdkReplicationGroupNotFoundFault,
+  ReplicationGroupNotUnderMigrationFault as SdkReplicationGroupNotUnderMigrationFault,
+  ReservedCacheNodeAlreadyExistsFault as SdkReservedCacheNodeAlreadyExistsFault,
+  ReservedCacheNodeNotFoundFault as SdkReservedCacheNodeNotFoundFault,
+  ReservedCacheNodeQuotaExceededFault as SdkReservedCacheNodeQuotaExceededFault,
+  ReservedCacheNodesOfferingNotFoundFault as SdkReservedCacheNodesOfferingNotFoundFault,
+  ServerlessCacheAlreadyExistsFault as SdkServerlessCacheAlreadyExistsFault,
+  ServerlessCacheNotFoundFault as SdkServerlessCacheNotFoundFault,
+  ServerlessCacheQuotaForCustomerExceededFault as SdkServerlessCacheQuotaForCustomerExceededFault,
+  ServerlessCacheSnapshotAlreadyExistsFault as SdkServerlessCacheSnapshotAlreadyExistsFault,
+  ServerlessCacheSnapshotNotFoundFault as SdkServerlessCacheSnapshotNotFoundFault,
+  ServerlessCacheSnapshotQuotaExceededFault as SdkServerlessCacheSnapshotQuotaExceededFault,
+  ServiceLinkedRoleNotFoundFault as SdkServiceLinkedRoleNotFoundFault,
+  ServiceUpdateNotFoundFault as SdkServiceUpdateNotFoundFault,
+  SnapshotAlreadyExistsFault as SdkSnapshotAlreadyExistsFault,
+  SnapshotFeatureNotSupportedFault as SdkSnapshotFeatureNotSupportedFault,
+  SnapshotNotFoundFault as SdkSnapshotNotFoundFault,
+  SnapshotQuotaExceededFault as SdkSnapshotQuotaExceededFault,
+  SubnetInUse as SdkSubnetInUse,
+  SubnetNotAllowedFault as SdkSubnetNotAllowedFault,
+  TagNotFoundFault as SdkTagNotFoundFault,
+  TagQuotaPerResourceExceeded as SdkTagQuotaPerResourceExceeded,
+  TestFailoverNotAvailableFault as SdkTestFailoverNotAvailableFault,
+  UserAlreadyExistsFault as SdkUserAlreadyExistsFault,
+  UserGroupAlreadyExistsFault as SdkUserGroupAlreadyExistsFault,
+  UserGroupNotFoundFault as SdkUserGroupNotFoundFault,
+  UserGroupQuotaExceededFault as SdkUserGroupQuotaExceededFault,
+  UserNotFoundFault as SdkUserNotFoundFault,
+  UserQuotaExceededFault as SdkUserQuotaExceededFault,
 } from "@aws-sdk/client-elasticache";
 import * as Data from "effect/Data";
 
@@ -10,18 +82,141 @@ export type TaggedException<T extends { name: string }> = T & {
   readonly _tag: T["name"];
 };
 
-export type InvalidCredentialsError =
-  TaggedException<InvalidCredentialsException>;
-export type InvalidParameterValueError =
-  TaggedException<InvalidParameterValueException>;
-export type InvalidParameterCombinationError =
-  TaggedException<InvalidParameterCombinationException>;
+export type APICallRateForCustomerExceededFault =
+  TaggedException<SdkAPICallRateForCustomerExceededFault>;
+export type AuthorizationAlreadyExistsFault =
+  TaggedException<SdkAuthorizationAlreadyExistsFault>;
+export type AuthorizationNotFoundFault =
+  TaggedException<SdkAuthorizationNotFoundFault>;
+export type CacheClusterAlreadyExistsFault =
+  TaggedException<SdkCacheClusterAlreadyExistsFault>;
+export type CacheClusterNotFoundFault =
+  TaggedException<SdkCacheClusterNotFoundFault>;
+export type CacheParameterGroupAlreadyExistsFault =
+  TaggedException<SdkCacheParameterGroupAlreadyExistsFault>;
+export type CacheParameterGroupNotFoundFault =
+  TaggedException<SdkCacheParameterGroupNotFoundFault>;
+export type CacheParameterGroupQuotaExceededFault =
+  TaggedException<SdkCacheParameterGroupQuotaExceededFault>;
+export type CacheSecurityGroupAlreadyExistsFault =
+  TaggedException<SdkCacheSecurityGroupAlreadyExistsFault>;
+export type CacheSecurityGroupNotFoundFault =
+  TaggedException<SdkCacheSecurityGroupNotFoundFault>;
+export type CacheSecurityGroupQuotaExceededFault =
+  TaggedException<SdkCacheSecurityGroupQuotaExceededFault>;
+export type CacheSubnetGroupAlreadyExistsFault =
+  TaggedException<SdkCacheSubnetGroupAlreadyExistsFault>;
+export type CacheSubnetGroupInUse = TaggedException<SdkCacheSubnetGroupInUse>;
+export type CacheSubnetGroupNotFoundFault =
+  TaggedException<SdkCacheSubnetGroupNotFoundFault>;
+export type CacheSubnetGroupQuotaExceededFault =
+  TaggedException<SdkCacheSubnetGroupQuotaExceededFault>;
+export type CacheSubnetQuotaExceededFault =
+  TaggedException<SdkCacheSubnetQuotaExceededFault>;
+export type ClusterQuotaForCustomerExceededFault =
+  TaggedException<SdkClusterQuotaForCustomerExceededFault>;
+export type DefaultUserAssociatedToUserGroupFault =
+  TaggedException<SdkDefaultUserAssociatedToUserGroupFault>;
+export type DefaultUserRequired = TaggedException<SdkDefaultUserRequired>;
+export type DuplicateUserNameFault = TaggedException<SdkDuplicateUserNameFault>;
+export type GlobalReplicationGroupAlreadyExistsFault =
+  TaggedException<SdkGlobalReplicationGroupAlreadyExistsFault>;
+export type GlobalReplicationGroupNotFoundFault =
+  TaggedException<SdkGlobalReplicationGroupNotFoundFault>;
+export type InsufficientCacheClusterCapacityFault =
+  TaggedException<SdkInsufficientCacheClusterCapacityFault>;
+export type InvalidARNFault = TaggedException<SdkInvalidARNFault>;
+export type InvalidCacheClusterStateFault =
+  TaggedException<SdkInvalidCacheClusterStateFault>;
+export type InvalidCacheParameterGroupStateFault =
+  TaggedException<SdkInvalidCacheParameterGroupStateFault>;
+export type InvalidCacheSecurityGroupStateFault =
+  TaggedException<SdkInvalidCacheSecurityGroupStateFault>;
+export type InvalidCredentialsException =
+  TaggedException<SdkInvalidCredentialsException>;
+export type InvalidGlobalReplicationGroupStateFault =
+  TaggedException<SdkInvalidGlobalReplicationGroupStateFault>;
+export type InvalidKMSKeyFault = TaggedException<SdkInvalidKMSKeyFault>;
+export type InvalidParameterCombinationException =
+  TaggedException<SdkInvalidParameterCombinationException>;
+export type InvalidParameterValueException =
+  TaggedException<SdkInvalidParameterValueException>;
+export type InvalidReplicationGroupStateFault =
+  TaggedException<SdkInvalidReplicationGroupStateFault>;
+export type InvalidServerlessCacheSnapshotStateFault =
+  TaggedException<SdkInvalidServerlessCacheSnapshotStateFault>;
+export type InvalidServerlessCacheStateFault =
+  TaggedException<SdkInvalidServerlessCacheStateFault>;
+export type InvalidSnapshotStateFault =
+  TaggedException<SdkInvalidSnapshotStateFault>;
+export type InvalidSubnet = TaggedException<SdkInvalidSubnet>;
+export type InvalidUserGroupStateFault =
+  TaggedException<SdkInvalidUserGroupStateFault>;
+export type InvalidUserStateFault = TaggedException<SdkInvalidUserStateFault>;
+export type InvalidVPCNetworkStateFault =
+  TaggedException<SdkInvalidVPCNetworkStateFault>;
+export type NoOperationFault = TaggedException<SdkNoOperationFault>;
+export type NodeGroupNotFoundFault = TaggedException<SdkNodeGroupNotFoundFault>;
+export type NodeGroupsPerReplicationGroupQuotaExceededFault =
+  TaggedException<SdkNodeGroupsPerReplicationGroupQuotaExceededFault>;
+export type NodeQuotaForClusterExceededFault =
+  TaggedException<SdkNodeQuotaForClusterExceededFault>;
+export type NodeQuotaForCustomerExceededFault =
+  TaggedException<SdkNodeQuotaForCustomerExceededFault>;
+export type ReplicationGroupAlreadyExistsFault =
+  TaggedException<SdkReplicationGroupAlreadyExistsFault>;
+export type ReplicationGroupAlreadyUnderMigrationFault =
+  TaggedException<SdkReplicationGroupAlreadyUnderMigrationFault>;
+export type ReplicationGroupNotFoundFault =
+  TaggedException<SdkReplicationGroupNotFoundFault>;
+export type ReplicationGroupNotUnderMigrationFault =
+  TaggedException<SdkReplicationGroupNotUnderMigrationFault>;
+export type ReservedCacheNodeAlreadyExistsFault =
+  TaggedException<SdkReservedCacheNodeAlreadyExistsFault>;
+export type ReservedCacheNodeNotFoundFault =
+  TaggedException<SdkReservedCacheNodeNotFoundFault>;
+export type ReservedCacheNodeQuotaExceededFault =
+  TaggedException<SdkReservedCacheNodeQuotaExceededFault>;
+export type ReservedCacheNodesOfferingNotFoundFault =
+  TaggedException<SdkReservedCacheNodesOfferingNotFoundFault>;
+export type ServerlessCacheAlreadyExistsFault =
+  TaggedException<SdkServerlessCacheAlreadyExistsFault>;
+export type ServerlessCacheNotFoundFault =
+  TaggedException<SdkServerlessCacheNotFoundFault>;
+export type ServerlessCacheQuotaForCustomerExceededFault =
+  TaggedException<SdkServerlessCacheQuotaForCustomerExceededFault>;
+export type ServerlessCacheSnapshotAlreadyExistsFault =
+  TaggedException<SdkServerlessCacheSnapshotAlreadyExistsFault>;
+export type ServerlessCacheSnapshotNotFoundFault =
+  TaggedException<SdkServerlessCacheSnapshotNotFoundFault>;
+export type ServerlessCacheSnapshotQuotaExceededFault =
+  TaggedException<SdkServerlessCacheSnapshotQuotaExceededFault>;
+export type ServiceLinkedRoleNotFoundFault =
+  TaggedException<SdkServiceLinkedRoleNotFoundFault>;
+export type ServiceUpdateNotFoundFault =
+  TaggedException<SdkServiceUpdateNotFoundFault>;
+export type SnapshotAlreadyExistsFault =
+  TaggedException<SdkSnapshotAlreadyExistsFault>;
+export type SnapshotFeatureNotSupportedFault =
+  TaggedException<SdkSnapshotFeatureNotSupportedFault>;
+export type SnapshotNotFoundFault = TaggedException<SdkSnapshotNotFoundFault>;
+export type SnapshotQuotaExceededFault =
+  TaggedException<SdkSnapshotQuotaExceededFault>;
+export type SubnetInUse = TaggedException<SdkSubnetInUse>;
+export type SubnetNotAllowedFault = TaggedException<SdkSubnetNotAllowedFault>;
+export type TagNotFoundFault = TaggedException<SdkTagNotFoundFault>;
+export type TagQuotaPerResourceExceeded =
+  TaggedException<SdkTagQuotaPerResourceExceeded>;
+export type TestFailoverNotAvailableFault =
+  TaggedException<SdkTestFailoverNotAvailableFault>;
+export type UserAlreadyExistsFault = TaggedException<SdkUserAlreadyExistsFault>;
+export type UserGroupAlreadyExistsFault =
+  TaggedException<SdkUserGroupAlreadyExistsFault>;
+export type UserGroupNotFoundFault = TaggedException<SdkUserGroupNotFoundFault>;
+export type UserGroupQuotaExceededFault =
+  TaggedException<SdkUserGroupQuotaExceededFault>;
+export type UserNotFoundFault = TaggedException<SdkUserNotFoundFault>;
+export type UserQuotaExceededFault = TaggedException<SdkUserQuotaExceededFault>;
 
-export type ElastiCacheServiceError = TaggedException<
-  ElastiCacheServiceException & { name: "ElastiCacheServiceError" }
->;
-export const ElastiCacheServiceError = Data.tagged<ElastiCacheServiceError>(
-  "ElastiCacheServiceError",
-);
 export type SdkError = TaggedException<Error & { name: "SdkError" }>;
 export const SdkError = Data.tagged<SdkError>("SdkError");

--- a/packages/client-elasticache/test/ElastiCache.test.ts
+++ b/packages/client-elasticache/test/ElastiCache.test.ts
@@ -1,0 +1,199 @@
+import {
+  type DescribeCacheClustersCommandInput,
+  DescribeCacheClustersCommand,
+  ElastiCacheClient,
+} from "@aws-sdk/client-elasticache";
+import { mockClient } from "aws-sdk-client-mock";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import { pipe } from "effect/Function";
+import * as Layer from "effect/Layer";
+import {
+  BaseElastiCacheServiceLayer,
+  DefaultElastiCacheClientConfigLayer,
+  DefaultElastiCacheServiceLayer,
+  ElastiCacheClientInstance,
+  ElastiCacheClientInstanceConfig,
+  ElastiCacheService,
+  ElastiCacheServiceLayer,
+  SdkError,
+} from "../src";
+
+import "aws-sdk-client-mock-jest";
+
+const clientMock = mockClient(ElastiCacheClient);
+
+describe("ElastiCacheClientImpl", () => {
+  it("default", async () => {
+    clientMock.reset().on(DescribeCacheClustersCommand).resolves({});
+
+    const args: DescribeCacheClustersCommandInput = { ShowCacheNodeInfo: true };
+
+    const program = Effect.flatMap(ElastiCacheService, (service) =>
+      service.describeCacheClusters(args),
+    );
+
+    const result = await pipe(
+      program,
+      Effect.provide(DefaultElastiCacheServiceLayer),
+      Effect.runPromiseExit,
+    );
+
+    expect(result).toEqual(Exit.succeed({}));
+    expect(clientMock).toHaveReceivedCommandTimes(
+      DescribeCacheClustersCommand,
+      1,
+    );
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeCacheClustersCommand,
+      args,
+    );
+  });
+
+  it("configurable", async () => {
+    clientMock.reset().on(DescribeCacheClustersCommand).resolves({});
+
+    const args: DescribeCacheClustersCommandInput = { ShowCacheNodeInfo: true };
+
+    const program = Effect.flatMap(ElastiCacheService, (service) =>
+      service.describeCacheClusters(args),
+    );
+
+    const ElastiCacheClientConfigLayer = Layer.succeed(
+      ElastiCacheClientInstanceConfig,
+      {
+        region: "eu-central-1",
+      },
+    );
+    const CustomElastiCacheServiceLayer = ElastiCacheServiceLayer.pipe(
+      Layer.provide(ElastiCacheClientConfigLayer),
+    );
+
+    const result = await pipe(
+      program,
+      Effect.provide(CustomElastiCacheServiceLayer),
+      Effect.runPromiseExit,
+    );
+
+    expect(result).toEqual(Exit.succeed({}));
+    expect(clientMock).toHaveReceivedCommandTimes(
+      DescribeCacheClustersCommand,
+      1,
+    );
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeCacheClustersCommand,
+      args,
+    );
+  });
+
+  it("base", async () => {
+    clientMock.reset().on(DescribeCacheClustersCommand).resolves({});
+
+    const args: DescribeCacheClustersCommandInput = { ShowCacheNodeInfo: true };
+
+    const program = Effect.flatMap(ElastiCacheService, (service) =>
+      service.describeCacheClusters(args),
+    );
+
+    const ElastiCacheClientInstanceLayer = Layer.succeed(
+      ElastiCacheClientInstance,
+      new ElastiCacheClient({ region: "eu-central-1" }),
+    );
+    const CustomElastiCacheServiceLayer = BaseElastiCacheServiceLayer.pipe(
+      Layer.provide(ElastiCacheClientInstanceLayer),
+    );
+
+    const result = await pipe(
+      program,
+      Effect.provide(CustomElastiCacheServiceLayer),
+      Effect.runPromiseExit,
+    );
+
+    expect(result).toEqual(Exit.succeed({}));
+    expect(clientMock).toHaveReceivedCommandTimes(
+      DescribeCacheClustersCommand,
+      1,
+    );
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeCacheClustersCommand,
+      args,
+    );
+  });
+
+  it("extended", async () => {
+    clientMock.reset().on(DescribeCacheClustersCommand).resolves({});
+
+    const args: DescribeCacheClustersCommandInput = { ShowCacheNodeInfo: true };
+
+    const program = Effect.flatMap(ElastiCacheService, (service) =>
+      service.describeCacheClusters(args),
+    );
+
+    const ElastiCacheClientInstanceLayer = Layer.effect(
+      ElastiCacheClientInstance,
+      Effect.map(
+        ElastiCacheClientInstanceConfig,
+        (config) =>
+          new ElastiCacheClient({ ...config, region: "eu-central-1" }),
+      ),
+    );
+    const CustomElastiCacheServiceLayer = BaseElastiCacheServiceLayer.pipe(
+      Layer.provide(ElastiCacheClientInstanceLayer),
+      Layer.provide(DefaultElastiCacheClientConfigLayer),
+    );
+
+    const result = await pipe(
+      program,
+      Effect.provide(CustomElastiCacheServiceLayer),
+      Effect.runPromiseExit,
+    );
+
+    expect(result).toEqual(Exit.succeed({}));
+    expect(clientMock).toHaveReceivedCommandTimes(
+      DescribeCacheClustersCommand,
+      1,
+    );
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeCacheClustersCommand,
+      args,
+    );
+  });
+
+  it("fail", async () => {
+    clientMock
+      .reset()
+      .on(DescribeCacheClustersCommand)
+      .rejects(new Error("test"));
+
+    const args: DescribeCacheClustersCommandInput = { ShowCacheNodeInfo: true };
+
+    const program = Effect.flatMap(ElastiCacheService, (service) =>
+      service.describeCacheClusters(args),
+    );
+
+    const result = await pipe(
+      program,
+      Effect.provide(DefaultElastiCacheServiceLayer),
+      Effect.runPromiseExit,
+    );
+
+    expect(result).toEqual(
+      Exit.fail(
+        SdkError({
+          ...new Error("test"),
+          name: "SdkError",
+          message: "test",
+          stack: expect.any(String),
+        }),
+      ),
+    );
+    expect(clientMock).toHaveReceivedCommandTimes(
+      DescribeCacheClustersCommand,
+      1,
+    );
+    expect(clientMock).toHaveReceivedCommandWith(
+      DescribeCacheClustersCommand,
+      args,
+    );
+  });
+});

--- a/packages/client-eventbridge/.projen/deps.json
+++ b/packages/client-eventbridge/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-eventbridge",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-eventbridge/package.json
+++ b/packages/client-eventbridge/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-eventbridge": "^3",
+    "@aws-sdk/client-eventbridge": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-iam/.projen/deps.json
+++ b/packages/client-iam/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-iam",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-iam/package.json
+++ b/packages/client-iam/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-iam": "^3",
+    "@aws-sdk/client-iam": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-iam/src/Errors.ts
+++ b/packages/client-iam/src/Errors.ts
@@ -1,32 +1,32 @@
 import type {
-  ConcurrentModificationException,
-  CredentialReportExpiredException,
-  CredentialReportNotPresentException,
-  CredentialReportNotReadyException,
-  DeleteConflictException,
-  DuplicateCertificateException,
-  DuplicateSSHPublicKeyException,
-  EntityAlreadyExistsException,
-  EntityTemporarilyUnmodifiableException,
-  IAMServiceException,
-  InvalidAuthenticationCodeException,
-  InvalidCertificateException,
-  InvalidInputException,
-  InvalidPublicKeyException,
-  InvalidUserTypeException,
-  KeyPairMismatchException,
-  LimitExceededException,
-  MalformedCertificateException,
-  MalformedPolicyDocumentException,
-  NoSuchEntityException,
-  PasswordPolicyViolationException,
-  PolicyEvaluationException,
-  PolicyNotAttachableException,
-  ReportGenerationLimitExceededException,
-  ServiceFailureException,
-  ServiceNotSupportedException,
-  UnmodifiableEntityException,
-  UnrecognizedPublicKeyEncodingException,
+  ConcurrentModificationException as SdkConcurrentModificationException,
+  CredentialReportExpiredException as SdkCredentialReportExpiredException,
+  CredentialReportNotPresentException as SdkCredentialReportNotPresentException,
+  CredentialReportNotReadyException as SdkCredentialReportNotReadyException,
+  DeleteConflictException as SdkDeleteConflictException,
+  DuplicateCertificateException as SdkDuplicateCertificateException,
+  DuplicateSSHPublicKeyException as SdkDuplicateSSHPublicKeyException,
+  EntityAlreadyExistsException as SdkEntityAlreadyExistsException,
+  EntityTemporarilyUnmodifiableException as SdkEntityTemporarilyUnmodifiableException,
+  InvalidAuthenticationCodeException as SdkInvalidAuthenticationCodeException,
+  InvalidCertificateException as SdkInvalidCertificateException,
+  InvalidInputException as SdkInvalidInputException,
+  InvalidPublicKeyException as SdkInvalidPublicKeyException,
+  InvalidUserTypeException as SdkInvalidUserTypeException,
+  KeyPairMismatchException as SdkKeyPairMismatchException,
+  LimitExceededException as SdkLimitExceededException,
+  MalformedCertificateException as SdkMalformedCertificateException,
+  MalformedPolicyDocumentException as SdkMalformedPolicyDocumentException,
+  NoSuchEntityException as SdkNoSuchEntityException,
+  OpenIdIdpCommunicationErrorException as SdkOpenIdIdpCommunicationErrorException,
+  PasswordPolicyViolationException as SdkPasswordPolicyViolationException,
+  PolicyEvaluationException as SdkPolicyEvaluationException,
+  PolicyNotAttachableException as SdkPolicyNotAttachableException,
+  ReportGenerationLimitExceededException as SdkReportGenerationLimitExceededException,
+  ServiceFailureException as SdkServiceFailureException,
+  ServiceNotSupportedException as SdkServiceNotSupportedException,
+  UnmodifiableEntityException as SdkUnmodifiableEntityException,
+  UnrecognizedPublicKeyEncodingException as SdkUnrecognizedPublicKeyEncodingException,
 } from "@aws-sdk/client-iam";
 import * as Data from "effect/Data";
 
@@ -34,55 +34,59 @@ export type TaggedException<T extends { name: string }> = T & {
   readonly _tag: T["name"];
 };
 
-export type ConcurrentModificationError =
-  TaggedException<ConcurrentModificationException>;
-export type CredentialReportExpiredError =
-  TaggedException<CredentialReportExpiredException>;
-export type CredentialReportNotPresentError =
-  TaggedException<CredentialReportNotPresentException>;
-export type CredentialReportNotReadyError =
-  TaggedException<CredentialReportNotReadyException>;
-export type DeleteConflictError = TaggedException<DeleteConflictException>;
-export type DuplicateCertificateError =
-  TaggedException<DuplicateCertificateException>;
-export type DuplicateSSHPublicKeyError =
-  TaggedException<DuplicateSSHPublicKeyException>;
-export type EntityAlreadyExistsError =
-  TaggedException<EntityAlreadyExistsException>;
-export type EntityTemporarilyUnmodifiableError =
-  TaggedException<EntityTemporarilyUnmodifiableException>;
-export type InvalidAuthenticationCodeError =
-  TaggedException<InvalidAuthenticationCodeException>;
-export type InvalidCertificateError =
-  TaggedException<InvalidCertificateException>;
-export type InvalidInputError = TaggedException<InvalidInputException>;
-export type InvalidPublicKeyError = TaggedException<InvalidPublicKeyException>;
-export type InvalidUserTypeError = TaggedException<InvalidUserTypeException>;
-export type KeyPairMismatchError = TaggedException<KeyPairMismatchException>;
-export type LimitExceededError = TaggedException<LimitExceededException>;
-export type MalformedCertificateError =
-  TaggedException<MalformedCertificateException>;
-export type MalformedPolicyDocumentError =
-  TaggedException<MalformedPolicyDocumentException>;
-export type NoSuchEntityError = TaggedException<NoSuchEntityException>;
-export type PasswordPolicyViolationError =
-  TaggedException<PasswordPolicyViolationException>;
-export type PolicyEvaluationError = TaggedException<PolicyEvaluationException>;
-export type PolicyNotAttachableError =
-  TaggedException<PolicyNotAttachableException>;
-export type ReportGenerationLimitExceededError =
-  TaggedException<ReportGenerationLimitExceededException>;
-export type ServiceFailureError = TaggedException<ServiceFailureException>;
-export type ServiceNotSupportedError =
-  TaggedException<ServiceNotSupportedException>;
-export type UnmodifiableEntityError =
-  TaggedException<UnmodifiableEntityException>;
-export type UnrecognizedPublicKeyEncodingError =
-  TaggedException<UnrecognizedPublicKeyEncodingException>;
+export type ConcurrentModificationException =
+  TaggedException<SdkConcurrentModificationException>;
+export type CredentialReportExpiredException =
+  TaggedException<SdkCredentialReportExpiredException>;
+export type CredentialReportNotPresentException =
+  TaggedException<SdkCredentialReportNotPresentException>;
+export type CredentialReportNotReadyException =
+  TaggedException<SdkCredentialReportNotReadyException>;
+export type DeleteConflictException =
+  TaggedException<SdkDeleteConflictException>;
+export type DuplicateCertificateException =
+  TaggedException<SdkDuplicateCertificateException>;
+export type DuplicateSSHPublicKeyException =
+  TaggedException<SdkDuplicateSSHPublicKeyException>;
+export type EntityAlreadyExistsException =
+  TaggedException<SdkEntityAlreadyExistsException>;
+export type EntityTemporarilyUnmodifiableException =
+  TaggedException<SdkEntityTemporarilyUnmodifiableException>;
+export type InvalidAuthenticationCodeException =
+  TaggedException<SdkInvalidAuthenticationCodeException>;
+export type InvalidCertificateException =
+  TaggedException<SdkInvalidCertificateException>;
+export type InvalidInputException = TaggedException<SdkInvalidInputException>;
+export type InvalidPublicKeyException =
+  TaggedException<SdkInvalidPublicKeyException>;
+export type InvalidUserTypeException =
+  TaggedException<SdkInvalidUserTypeException>;
+export type KeyPairMismatchException =
+  TaggedException<SdkKeyPairMismatchException>;
+export type LimitExceededException = TaggedException<SdkLimitExceededException>;
+export type MalformedCertificateException =
+  TaggedException<SdkMalformedCertificateException>;
+export type MalformedPolicyDocumentException =
+  TaggedException<SdkMalformedPolicyDocumentException>;
+export type NoSuchEntityException = TaggedException<SdkNoSuchEntityException>;
+export type OpenIdIdpCommunicationErrorException =
+  TaggedException<SdkOpenIdIdpCommunicationErrorException>;
+export type PasswordPolicyViolationException =
+  TaggedException<SdkPasswordPolicyViolationException>;
+export type PolicyEvaluationException =
+  TaggedException<SdkPolicyEvaluationException>;
+export type PolicyNotAttachableException =
+  TaggedException<SdkPolicyNotAttachableException>;
+export type ReportGenerationLimitExceededException =
+  TaggedException<SdkReportGenerationLimitExceededException>;
+export type ServiceFailureException =
+  TaggedException<SdkServiceFailureException>;
+export type ServiceNotSupportedException =
+  TaggedException<SdkServiceNotSupportedException>;
+export type UnmodifiableEntityException =
+  TaggedException<SdkUnmodifiableEntityException>;
+export type UnrecognizedPublicKeyEncodingException =
+  TaggedException<SdkUnrecognizedPublicKeyEncodingException>;
 
-export type IAMServiceError = TaggedException<
-  IAMServiceException & { name: "IAMServiceError" }
->;
-export const IAMServiceError = Data.tagged<IAMServiceError>("IAMServiceError");
 export type SdkError = TaggedException<Error & { name: "SdkError" }>;
 export const SdkError = Data.tagged<SdkError>("SdkError");

--- a/packages/client-iam/src/IAMService.ts
+++ b/packages/client-iam/src/IAMService.ts
@@ -2,518 +2,438 @@
  * @since 1.0.0
  */
 import {
-  IAMServiceException,
+  IAMServiceException as SdkIAMServiceException,
   AddClientIDToOpenIDConnectProviderCommand,
-  type AddClientIDToOpenIDConnectProviderCommandInput,
-  type AddClientIDToOpenIDConnectProviderCommandOutput,
   AddRoleToInstanceProfileCommand,
-  type AddRoleToInstanceProfileCommandInput,
-  type AddRoleToInstanceProfileCommandOutput,
   AddUserToGroupCommand,
-  type AddUserToGroupCommandInput,
-  type AddUserToGroupCommandOutput,
   AttachGroupPolicyCommand,
-  type AttachGroupPolicyCommandInput,
-  type AttachGroupPolicyCommandOutput,
   AttachRolePolicyCommand,
-  type AttachRolePolicyCommandInput,
-  type AttachRolePolicyCommandOutput,
   AttachUserPolicyCommand,
-  type AttachUserPolicyCommandInput,
-  type AttachUserPolicyCommandOutput,
   ChangePasswordCommand,
-  type ChangePasswordCommandInput,
-  type ChangePasswordCommandOutput,
   CreateAccessKeyCommand,
-  type CreateAccessKeyCommandInput,
-  type CreateAccessKeyCommandOutput,
   CreateAccountAliasCommand,
-  type CreateAccountAliasCommandInput,
-  type CreateAccountAliasCommandOutput,
   CreateGroupCommand,
-  type CreateGroupCommandInput,
-  type CreateGroupCommandOutput,
   CreateInstanceProfileCommand,
-  type CreateInstanceProfileCommandInput,
-  type CreateInstanceProfileCommandOutput,
   CreateLoginProfileCommand,
-  type CreateLoginProfileCommandInput,
-  type CreateLoginProfileCommandOutput,
   CreateOpenIDConnectProviderCommand,
-  type CreateOpenIDConnectProviderCommandInput,
-  type CreateOpenIDConnectProviderCommandOutput,
   CreatePolicyCommand,
-  type CreatePolicyCommandInput,
-  type CreatePolicyCommandOutput,
   CreatePolicyVersionCommand,
-  type CreatePolicyVersionCommandInput,
-  type CreatePolicyVersionCommandOutput,
   CreateRoleCommand,
-  type CreateRoleCommandInput,
-  type CreateRoleCommandOutput,
   CreateSAMLProviderCommand,
-  type CreateSAMLProviderCommandInput,
-  type CreateSAMLProviderCommandOutput,
   CreateServiceLinkedRoleCommand,
-  type CreateServiceLinkedRoleCommandInput,
-  type CreateServiceLinkedRoleCommandOutput,
   CreateServiceSpecificCredentialCommand,
-  type CreateServiceSpecificCredentialCommandInput,
-  type CreateServiceSpecificCredentialCommandOutput,
   CreateUserCommand,
-  type CreateUserCommandInput,
-  type CreateUserCommandOutput,
   CreateVirtualMFADeviceCommand,
-  type CreateVirtualMFADeviceCommandInput,
-  type CreateVirtualMFADeviceCommandOutput,
   DeactivateMFADeviceCommand,
-  type DeactivateMFADeviceCommandInput,
-  type DeactivateMFADeviceCommandOutput,
   DeleteAccessKeyCommand,
-  type DeleteAccessKeyCommandInput,
-  type DeleteAccessKeyCommandOutput,
   DeleteAccountAliasCommand,
-  type DeleteAccountAliasCommandInput,
-  type DeleteAccountAliasCommandOutput,
   DeleteAccountPasswordPolicyCommand,
-  type DeleteAccountPasswordPolicyCommandInput,
-  type DeleteAccountPasswordPolicyCommandOutput,
   DeleteGroupCommand,
-  type DeleteGroupCommandInput,
-  type DeleteGroupCommandOutput,
   DeleteGroupPolicyCommand,
-  type DeleteGroupPolicyCommandInput,
-  type DeleteGroupPolicyCommandOutput,
   DeleteInstanceProfileCommand,
-  type DeleteInstanceProfileCommandInput,
-  type DeleteInstanceProfileCommandOutput,
   DeleteLoginProfileCommand,
-  type DeleteLoginProfileCommandInput,
-  type DeleteLoginProfileCommandOutput,
   DeleteOpenIDConnectProviderCommand,
-  type DeleteOpenIDConnectProviderCommandInput,
-  type DeleteOpenIDConnectProviderCommandOutput,
   DeletePolicyCommand,
-  type DeletePolicyCommandInput,
-  type DeletePolicyCommandOutput,
   DeletePolicyVersionCommand,
-  type DeletePolicyVersionCommandInput,
-  type DeletePolicyVersionCommandOutput,
   DeleteRoleCommand,
-  type DeleteRoleCommandInput,
-  type DeleteRoleCommandOutput,
   DeleteRolePermissionsBoundaryCommand,
-  type DeleteRolePermissionsBoundaryCommandInput,
-  type DeleteRolePermissionsBoundaryCommandOutput,
   DeleteRolePolicyCommand,
-  type DeleteRolePolicyCommandInput,
-  type DeleteRolePolicyCommandOutput,
   DeleteSAMLProviderCommand,
-  type DeleteSAMLProviderCommandInput,
-  type DeleteSAMLProviderCommandOutput,
-  DeleteServerCertificateCommand,
-  type DeleteServerCertificateCommandInput,
-  type DeleteServerCertificateCommandOutput,
-  DeleteServiceLinkedRoleCommand,
-  type DeleteServiceLinkedRoleCommandInput,
-  type DeleteServiceLinkedRoleCommandOutput,
-  DeleteServiceSpecificCredentialCommand,
-  type DeleteServiceSpecificCredentialCommandInput,
-  type DeleteServiceSpecificCredentialCommandOutput,
-  DeleteSigningCertificateCommand,
-  type DeleteSigningCertificateCommandInput,
-  type DeleteSigningCertificateCommandOutput,
   DeleteSSHPublicKeyCommand,
-  type DeleteSSHPublicKeyCommandInput,
-  type DeleteSSHPublicKeyCommandOutput,
+  DeleteServerCertificateCommand,
+  DeleteServiceLinkedRoleCommand,
+  DeleteServiceSpecificCredentialCommand,
+  DeleteSigningCertificateCommand,
   DeleteUserCommand,
-  type DeleteUserCommandInput,
-  type DeleteUserCommandOutput,
   DeleteUserPermissionsBoundaryCommand,
-  type DeleteUserPermissionsBoundaryCommandInput,
-  type DeleteUserPermissionsBoundaryCommandOutput,
   DeleteUserPolicyCommand,
-  type DeleteUserPolicyCommandInput,
-  type DeleteUserPolicyCommandOutput,
   DeleteVirtualMFADeviceCommand,
-  type DeleteVirtualMFADeviceCommandInput,
-  type DeleteVirtualMFADeviceCommandOutput,
   DetachGroupPolicyCommand,
-  type DetachGroupPolicyCommandInput,
-  type DetachGroupPolicyCommandOutput,
   DetachRolePolicyCommand,
-  type DetachRolePolicyCommandInput,
-  type DetachRolePolicyCommandOutput,
   DetachUserPolicyCommand,
-  type DetachUserPolicyCommandInput,
-  type DetachUserPolicyCommandOutput,
   EnableMFADeviceCommand,
-  type EnableMFADeviceCommandInput,
-  type EnableMFADeviceCommandOutput,
   GenerateCredentialReportCommand,
-  type GenerateCredentialReportCommandInput,
-  type GenerateCredentialReportCommandOutput,
   GenerateOrganizationsAccessReportCommand,
-  type GenerateOrganizationsAccessReportCommandInput,
-  type GenerateOrganizationsAccessReportCommandOutput,
   GenerateServiceLastAccessedDetailsCommand,
-  type GenerateServiceLastAccessedDetailsCommandInput,
-  type GenerateServiceLastAccessedDetailsCommandOutput,
   GetAccessKeyLastUsedCommand,
-  type GetAccessKeyLastUsedCommandInput,
-  type GetAccessKeyLastUsedCommandOutput,
   GetAccountAuthorizationDetailsCommand,
-  type GetAccountAuthorizationDetailsCommandInput,
-  type GetAccountAuthorizationDetailsCommandOutput,
   GetAccountPasswordPolicyCommand,
-  type GetAccountPasswordPolicyCommandInput,
-  type GetAccountPasswordPolicyCommandOutput,
   GetAccountSummaryCommand,
-  type GetAccountSummaryCommandInput,
-  type GetAccountSummaryCommandOutput,
   GetContextKeysForCustomPolicyCommand,
-  type GetContextKeysForCustomPolicyCommandInput,
-  type GetContextKeysForCustomPolicyCommandOutput,
   GetContextKeysForPrincipalPolicyCommand,
-  type GetContextKeysForPrincipalPolicyCommandInput,
-  type GetContextKeysForPrincipalPolicyCommandOutput,
   GetCredentialReportCommand,
-  type GetCredentialReportCommandInput,
-  type GetCredentialReportCommandOutput,
   GetGroupCommand,
-  type GetGroupCommandInput,
-  type GetGroupCommandOutput,
   GetGroupPolicyCommand,
-  type GetGroupPolicyCommandInput,
-  type GetGroupPolicyCommandOutput,
   GetInstanceProfileCommand,
-  type GetInstanceProfileCommandInput,
-  type GetInstanceProfileCommandOutput,
   GetLoginProfileCommand,
-  type GetLoginProfileCommandInput,
-  type GetLoginProfileCommandOutput,
   GetMFADeviceCommand,
-  type GetMFADeviceCommandInput,
-  type GetMFADeviceCommandOutput,
   GetOpenIDConnectProviderCommand,
-  type GetOpenIDConnectProviderCommandInput,
-  type GetOpenIDConnectProviderCommandOutput,
   GetOrganizationsAccessReportCommand,
-  type GetOrganizationsAccessReportCommandInput,
-  type GetOrganizationsAccessReportCommandOutput,
   GetPolicyCommand,
-  type GetPolicyCommandInput,
-  type GetPolicyCommandOutput,
   GetPolicyVersionCommand,
-  type GetPolicyVersionCommandInput,
-  type GetPolicyVersionCommandOutput,
   GetRoleCommand,
-  type GetRoleCommandInput,
-  type GetRoleCommandOutput,
   GetRolePolicyCommand,
-  type GetRolePolicyCommandInput,
-  type GetRolePolicyCommandOutput,
   GetSAMLProviderCommand,
-  type GetSAMLProviderCommandInput,
-  type GetSAMLProviderCommandOutput,
-  GetServerCertificateCommand,
-  type GetServerCertificateCommandInput,
-  type GetServerCertificateCommandOutput,
-  GetServiceLastAccessedDetailsCommand,
-  type GetServiceLastAccessedDetailsCommandInput,
-  type GetServiceLastAccessedDetailsCommandOutput,
-  GetServiceLastAccessedDetailsWithEntitiesCommand,
-  type GetServiceLastAccessedDetailsWithEntitiesCommandInput,
-  type GetServiceLastAccessedDetailsWithEntitiesCommandOutput,
-  GetServiceLinkedRoleDeletionStatusCommand,
-  type GetServiceLinkedRoleDeletionStatusCommandInput,
-  type GetServiceLinkedRoleDeletionStatusCommandOutput,
   GetSSHPublicKeyCommand,
-  type GetSSHPublicKeyCommandInput,
-  type GetSSHPublicKeyCommandOutput,
+  GetServerCertificateCommand,
+  GetServiceLastAccessedDetailsCommand,
+  GetServiceLastAccessedDetailsWithEntitiesCommand,
+  GetServiceLinkedRoleDeletionStatusCommand,
   GetUserCommand,
-  type GetUserCommandInput,
-  type GetUserCommandOutput,
   GetUserPolicyCommand,
-  type GetUserPolicyCommandInput,
-  type GetUserPolicyCommandOutput,
   ListAccessKeysCommand,
-  type ListAccessKeysCommandInput,
-  type ListAccessKeysCommandOutput,
   ListAccountAliasesCommand,
-  type ListAccountAliasesCommandInput,
-  type ListAccountAliasesCommandOutput,
   ListAttachedGroupPoliciesCommand,
-  type ListAttachedGroupPoliciesCommandInput,
-  type ListAttachedGroupPoliciesCommandOutput,
   ListAttachedRolePoliciesCommand,
-  type ListAttachedRolePoliciesCommandInput,
-  type ListAttachedRolePoliciesCommandOutput,
   ListAttachedUserPoliciesCommand,
-  type ListAttachedUserPoliciesCommandInput,
-  type ListAttachedUserPoliciesCommandOutput,
   ListEntitiesForPolicyCommand,
-  type ListEntitiesForPolicyCommandInput,
-  type ListEntitiesForPolicyCommandOutput,
   ListGroupPoliciesCommand,
-  type ListGroupPoliciesCommandInput,
-  type ListGroupPoliciesCommandOutput,
   ListGroupsCommand,
-  type ListGroupsCommandInput,
-  type ListGroupsCommandOutput,
   ListGroupsForUserCommand,
-  type ListGroupsForUserCommandInput,
-  type ListGroupsForUserCommandOutput,
-  ListInstanceProfilesCommand,
-  type ListInstanceProfilesCommandInput,
-  type ListInstanceProfilesCommandOutput,
-  ListInstanceProfilesForRoleCommand,
-  type ListInstanceProfilesForRoleCommandInput,
-  type ListInstanceProfilesForRoleCommandOutput,
   ListInstanceProfileTagsCommand,
-  type ListInstanceProfileTagsCommandInput,
-  type ListInstanceProfileTagsCommandOutput,
-  ListMFADevicesCommand,
-  type ListMFADevicesCommandInput,
-  type ListMFADevicesCommandOutput,
+  ListInstanceProfilesCommand,
+  ListInstanceProfilesForRoleCommand,
   ListMFADeviceTagsCommand,
-  type ListMFADeviceTagsCommandInput,
-  type ListMFADeviceTagsCommandOutput,
-  ListOpenIDConnectProvidersCommand,
-  type ListOpenIDConnectProvidersCommandInput,
-  type ListOpenIDConnectProvidersCommandOutput,
+  ListMFADevicesCommand,
   ListOpenIDConnectProviderTagsCommand,
-  type ListOpenIDConnectProviderTagsCommandInput,
-  type ListOpenIDConnectProviderTagsCommandOutput,
+  ListOpenIDConnectProvidersCommand,
   ListPoliciesCommand,
-  type ListPoliciesCommandInput,
-  type ListPoliciesCommandOutput,
   ListPoliciesGrantingServiceAccessCommand,
-  type ListPoliciesGrantingServiceAccessCommandInput,
-  type ListPoliciesGrantingServiceAccessCommandOutput,
   ListPolicyTagsCommand,
-  type ListPolicyTagsCommandInput,
-  type ListPolicyTagsCommandOutput,
   ListPolicyVersionsCommand,
-  type ListPolicyVersionsCommandInput,
-  type ListPolicyVersionsCommandOutput,
   ListRolePoliciesCommand,
-  type ListRolePoliciesCommandInput,
-  type ListRolePoliciesCommandOutput,
-  ListRolesCommand,
-  type ListRolesCommandInput,
-  type ListRolesCommandOutput,
   ListRoleTagsCommand,
-  type ListRoleTagsCommandInput,
-  type ListRoleTagsCommandOutput,
-  ListSAMLProvidersCommand,
-  type ListSAMLProvidersCommandInput,
-  type ListSAMLProvidersCommandOutput,
+  ListRolesCommand,
   ListSAMLProviderTagsCommand,
-  type ListSAMLProviderTagsCommandInput,
-  type ListSAMLProviderTagsCommandOutput,
-  ListServerCertificatesCommand,
-  type ListServerCertificatesCommandInput,
-  type ListServerCertificatesCommandOutput,
-  ListServerCertificateTagsCommand,
-  type ListServerCertificateTagsCommandInput,
-  type ListServerCertificateTagsCommandOutput,
-  ListServiceSpecificCredentialsCommand,
-  type ListServiceSpecificCredentialsCommandInput,
-  type ListServiceSpecificCredentialsCommandOutput,
-  ListSigningCertificatesCommand,
-  type ListSigningCertificatesCommandInput,
-  type ListSigningCertificatesCommandOutput,
+  ListSAMLProvidersCommand,
   ListSSHPublicKeysCommand,
-  type ListSSHPublicKeysCommandInput,
-  type ListSSHPublicKeysCommandOutput,
+  ListServerCertificateTagsCommand,
+  ListServerCertificatesCommand,
+  ListServiceSpecificCredentialsCommand,
+  ListSigningCertificatesCommand,
   ListUserPoliciesCommand,
-  type ListUserPoliciesCommandInput,
-  type ListUserPoliciesCommandOutput,
-  ListUsersCommand,
-  type ListUsersCommandInput,
-  type ListUsersCommandOutput,
   ListUserTagsCommand,
-  type ListUserTagsCommandInput,
-  type ListUserTagsCommandOutput,
+  ListUsersCommand,
   ListVirtualMFADevicesCommand,
-  type ListVirtualMFADevicesCommandInput,
-  type ListVirtualMFADevicesCommandOutput,
   PutGroupPolicyCommand,
-  type PutGroupPolicyCommandInput,
-  type PutGroupPolicyCommandOutput,
   PutRolePermissionsBoundaryCommand,
-  type PutRolePermissionsBoundaryCommandInput,
-  type PutRolePermissionsBoundaryCommandOutput,
   PutRolePolicyCommand,
-  type PutRolePolicyCommandInput,
-  type PutRolePolicyCommandOutput,
   PutUserPermissionsBoundaryCommand,
-  type PutUserPermissionsBoundaryCommandInput,
-  type PutUserPermissionsBoundaryCommandOutput,
   PutUserPolicyCommand,
-  type PutUserPolicyCommandInput,
-  type PutUserPolicyCommandOutput,
   RemoveClientIDFromOpenIDConnectProviderCommand,
-  type RemoveClientIDFromOpenIDConnectProviderCommandInput,
-  type RemoveClientIDFromOpenIDConnectProviderCommandOutput,
   RemoveRoleFromInstanceProfileCommand,
-  type RemoveRoleFromInstanceProfileCommandInput,
-  type RemoveRoleFromInstanceProfileCommandOutput,
   RemoveUserFromGroupCommand,
-  type RemoveUserFromGroupCommandInput,
-  type RemoveUserFromGroupCommandOutput,
   ResetServiceSpecificCredentialCommand,
-  type ResetServiceSpecificCredentialCommandInput,
-  type ResetServiceSpecificCredentialCommandOutput,
   ResyncMFADeviceCommand,
-  type ResyncMFADeviceCommandInput,
-  type ResyncMFADeviceCommandOutput,
   SetDefaultPolicyVersionCommand,
-  type SetDefaultPolicyVersionCommandInput,
-  type SetDefaultPolicyVersionCommandOutput,
   SetSecurityTokenServicePreferencesCommand,
-  type SetSecurityTokenServicePreferencesCommandInput,
-  type SetSecurityTokenServicePreferencesCommandOutput,
   SimulateCustomPolicyCommand,
-  type SimulateCustomPolicyCommandInput,
-  type SimulateCustomPolicyCommandOutput,
   SimulatePrincipalPolicyCommand,
-  type SimulatePrincipalPolicyCommandInput,
-  type SimulatePrincipalPolicyCommandOutput,
   TagInstanceProfileCommand,
-  type TagInstanceProfileCommandInput,
-  type TagInstanceProfileCommandOutput,
   TagMFADeviceCommand,
-  type TagMFADeviceCommandInput,
-  type TagMFADeviceCommandOutput,
   TagOpenIDConnectProviderCommand,
-  type TagOpenIDConnectProviderCommandInput,
-  type TagOpenIDConnectProviderCommandOutput,
   TagPolicyCommand,
-  type TagPolicyCommandInput,
-  type TagPolicyCommandOutput,
   TagRoleCommand,
-  type TagRoleCommandInput,
-  type TagRoleCommandOutput,
   TagSAMLProviderCommand,
-  type TagSAMLProviderCommandInput,
-  type TagSAMLProviderCommandOutput,
   TagServerCertificateCommand,
-  type TagServerCertificateCommandInput,
-  type TagServerCertificateCommandOutput,
   TagUserCommand,
-  type TagUserCommandInput,
-  type TagUserCommandOutput,
   UntagInstanceProfileCommand,
-  type UntagInstanceProfileCommandInput,
-  type UntagInstanceProfileCommandOutput,
   UntagMFADeviceCommand,
-  type UntagMFADeviceCommandInput,
-  type UntagMFADeviceCommandOutput,
   UntagOpenIDConnectProviderCommand,
-  type UntagOpenIDConnectProviderCommandInput,
-  type UntagOpenIDConnectProviderCommandOutput,
   UntagPolicyCommand,
-  type UntagPolicyCommandInput,
-  type UntagPolicyCommandOutput,
   UntagRoleCommand,
-  type UntagRoleCommandInput,
-  type UntagRoleCommandOutput,
   UntagSAMLProviderCommand,
-  type UntagSAMLProviderCommandInput,
-  type UntagSAMLProviderCommandOutput,
   UntagServerCertificateCommand,
-  type UntagServerCertificateCommandInput,
-  type UntagServerCertificateCommandOutput,
   UntagUserCommand,
-  type UntagUserCommandInput,
-  type UntagUserCommandOutput,
   UpdateAccessKeyCommand,
-  type UpdateAccessKeyCommandInput,
-  type UpdateAccessKeyCommandOutput,
   UpdateAccountPasswordPolicyCommand,
-  type UpdateAccountPasswordPolicyCommandInput,
-  type UpdateAccountPasswordPolicyCommandOutput,
   UpdateAssumeRolePolicyCommand,
-  type UpdateAssumeRolePolicyCommandInput,
-  type UpdateAssumeRolePolicyCommandOutput,
   UpdateGroupCommand,
-  type UpdateGroupCommandInput,
-  type UpdateGroupCommandOutput,
   UpdateLoginProfileCommand,
-  type UpdateLoginProfileCommandInput,
-  type UpdateLoginProfileCommandOutput,
   UpdateOpenIDConnectProviderThumbprintCommand,
-  type UpdateOpenIDConnectProviderThumbprintCommandInput,
-  type UpdateOpenIDConnectProviderThumbprintCommandOutput,
   UpdateRoleCommand,
-  type UpdateRoleCommandInput,
-  type UpdateRoleCommandOutput,
   UpdateRoleDescriptionCommand,
-  type UpdateRoleDescriptionCommandInput,
-  type UpdateRoleDescriptionCommandOutput,
   UpdateSAMLProviderCommand,
-  type UpdateSAMLProviderCommandInput,
-  type UpdateSAMLProviderCommandOutput,
-  UpdateServerCertificateCommand,
-  type UpdateServerCertificateCommandInput,
-  type UpdateServerCertificateCommandOutput,
-  UpdateServiceSpecificCredentialCommand,
-  type UpdateServiceSpecificCredentialCommandInput,
-  type UpdateServiceSpecificCredentialCommandOutput,
-  UpdateSigningCertificateCommand,
-  type UpdateSigningCertificateCommandInput,
-  type UpdateSigningCertificateCommandOutput,
   UpdateSSHPublicKeyCommand,
-  type UpdateSSHPublicKeyCommandInput,
-  type UpdateSSHPublicKeyCommandOutput,
+  UpdateServerCertificateCommand,
+  UpdateServiceSpecificCredentialCommand,
+  UpdateSigningCertificateCommand,
   UpdateUserCommand,
-  type UpdateUserCommandInput,
-  type UpdateUserCommandOutput,
-  UploadServerCertificateCommand,
-  type UploadServerCertificateCommandInput,
-  type UploadServerCertificateCommandOutput,
-  UploadSigningCertificateCommand,
-  type UploadSigningCertificateCommandInput,
-  type UploadSigningCertificateCommandOutput,
   UploadSSHPublicKeyCommand,
-  type UploadSSHPublicKeyCommandInput,
-  type UploadSSHPublicKeyCommandOutput,
+  UploadServerCertificateCommand,
+  UploadSigningCertificateCommand,
+  type AddClientIDToOpenIDConnectProviderRequest,
+  type AddRoleToInstanceProfileRequest,
+  type AddUserToGroupRequest,
+  type AttachGroupPolicyRequest,
+  type AttachRolePolicyRequest,
+  type AttachUserPolicyRequest,
+  type ChangePasswordRequest,
+  type CreateAccessKeyRequest,
+  type CreateAccessKeyResponse,
+  type CreateAccountAliasRequest,
+  type CreateGroupRequest,
+  type CreateGroupResponse,
+  type CreateInstanceProfileRequest,
+  type CreateInstanceProfileResponse,
+  type CreateLoginProfileRequest,
+  type CreateLoginProfileResponse,
+  type CreateOpenIDConnectProviderRequest,
+  type CreateOpenIDConnectProviderResponse,
+  type CreatePolicyRequest,
+  type CreatePolicyResponse,
+  type CreatePolicyVersionRequest,
+  type CreatePolicyVersionResponse,
+  type CreateRoleRequest,
+  type CreateRoleResponse,
+  type CreateSAMLProviderRequest,
+  type CreateSAMLProviderResponse,
+  type CreateServiceLinkedRoleRequest,
+  type CreateServiceLinkedRoleResponse,
+  type CreateServiceSpecificCredentialRequest,
+  type CreateServiceSpecificCredentialResponse,
+  type CreateUserRequest,
+  type CreateUserResponse,
+  type CreateVirtualMFADeviceRequest,
+  type CreateVirtualMFADeviceResponse,
+  type DeactivateMFADeviceRequest,
+  type DeleteAccessKeyRequest,
+  type DeleteAccountAliasRequest,
+  type DeleteGroupRequest,
+  type DeleteGroupPolicyRequest,
+  type DeleteInstanceProfileRequest,
+  type DeleteLoginProfileRequest,
+  type DeleteOpenIDConnectProviderRequest,
+  type DeletePolicyRequest,
+  type DeletePolicyVersionRequest,
+  type DeleteRoleRequest,
+  type DeleteRolePermissionsBoundaryRequest,
+  type DeleteRolePolicyRequest,
+  type DeleteSAMLProviderRequest,
+  type DeleteSSHPublicKeyRequest,
+  type DeleteServerCertificateRequest,
+  type DeleteServiceLinkedRoleRequest,
+  type DeleteServiceLinkedRoleResponse,
+  type DeleteServiceSpecificCredentialRequest,
+  type DeleteSigningCertificateRequest,
+  type DeleteUserRequest,
+  type DeleteUserPermissionsBoundaryRequest,
+  type DeleteUserPolicyRequest,
+  type DeleteVirtualMFADeviceRequest,
+  type DetachGroupPolicyRequest,
+  type DetachRolePolicyRequest,
+  type DetachUserPolicyRequest,
+  type EnableMFADeviceRequest,
+  type GenerateCredentialReportResponse,
+  type GenerateOrganizationsAccessReportRequest,
+  type GenerateOrganizationsAccessReportResponse,
+  type GenerateServiceLastAccessedDetailsRequest,
+  type GenerateServiceLastAccessedDetailsResponse,
+  type GetAccessKeyLastUsedRequest,
+  type GetAccessKeyLastUsedResponse,
+  type GetAccountAuthorizationDetailsRequest,
+  type GetAccountAuthorizationDetailsResponse,
+  type GetAccountPasswordPolicyResponse,
+  type GetAccountSummaryResponse,
+  type GetContextKeysForCustomPolicyRequest,
+  type GetContextKeysForPolicyResponse,
+  type GetContextKeysForPrincipalPolicyRequest,
+  type GetCredentialReportResponse,
+  type GetGroupRequest,
+  type GetGroupResponse,
+  type GetGroupPolicyRequest,
+  type GetGroupPolicyResponse,
+  type GetInstanceProfileRequest,
+  type GetInstanceProfileResponse,
+  type GetLoginProfileRequest,
+  type GetLoginProfileResponse,
+  type GetMFADeviceRequest,
+  type GetMFADeviceResponse,
+  type GetOpenIDConnectProviderRequest,
+  type GetOpenIDConnectProviderResponse,
+  type GetOrganizationsAccessReportRequest,
+  type GetOrganizationsAccessReportResponse,
+  type GetPolicyRequest,
+  type GetPolicyResponse,
+  type GetPolicyVersionRequest,
+  type GetPolicyVersionResponse,
+  type GetRoleRequest,
+  type GetRoleResponse,
+  type GetRolePolicyRequest,
+  type GetRolePolicyResponse,
+  type GetSAMLProviderRequest,
+  type GetSAMLProviderResponse,
+  type GetSSHPublicKeyRequest,
+  type GetSSHPublicKeyResponse,
+  type GetServerCertificateRequest,
+  type GetServerCertificateResponse,
+  type GetServiceLastAccessedDetailsRequest,
+  type GetServiceLastAccessedDetailsResponse,
+  type GetServiceLastAccessedDetailsWithEntitiesRequest,
+  type GetServiceLastAccessedDetailsWithEntitiesResponse,
+  type GetServiceLinkedRoleDeletionStatusRequest,
+  type GetServiceLinkedRoleDeletionStatusResponse,
+  type GetUserRequest,
+  type GetUserResponse,
+  type GetUserPolicyRequest,
+  type GetUserPolicyResponse,
+  type ListAccessKeysRequest,
+  type ListAccessKeysResponse,
+  type ListAccountAliasesRequest,
+  type ListAccountAliasesResponse,
+  type ListAttachedGroupPoliciesRequest,
+  type ListAttachedGroupPoliciesResponse,
+  type ListAttachedRolePoliciesRequest,
+  type ListAttachedRolePoliciesResponse,
+  type ListAttachedUserPoliciesRequest,
+  type ListAttachedUserPoliciesResponse,
+  type ListEntitiesForPolicyRequest,
+  type ListEntitiesForPolicyResponse,
+  type ListGroupPoliciesRequest,
+  type ListGroupPoliciesResponse,
+  type ListGroupsRequest,
+  type ListGroupsResponse,
+  type ListGroupsForUserRequest,
+  type ListGroupsForUserResponse,
+  type ListInstanceProfileTagsRequest,
+  type ListInstanceProfileTagsResponse,
+  type ListInstanceProfilesRequest,
+  type ListInstanceProfilesResponse,
+  type ListInstanceProfilesForRoleRequest,
+  type ListInstanceProfilesForRoleResponse,
+  type ListMFADeviceTagsRequest,
+  type ListMFADeviceTagsResponse,
+  type ListMFADevicesRequest,
+  type ListMFADevicesResponse,
+  type ListOpenIDConnectProviderTagsRequest,
+  type ListOpenIDConnectProviderTagsResponse,
+  type ListOpenIDConnectProvidersRequest,
+  type ListOpenIDConnectProvidersResponse,
+  type ListPoliciesRequest,
+  type ListPoliciesResponse,
+  type ListPoliciesGrantingServiceAccessRequest,
+  type ListPoliciesGrantingServiceAccessResponse,
+  type ListPolicyTagsRequest,
+  type ListPolicyTagsResponse,
+  type ListPolicyVersionsRequest,
+  type ListPolicyVersionsResponse,
+  type ListRolePoliciesRequest,
+  type ListRolePoliciesResponse,
+  type ListRoleTagsRequest,
+  type ListRoleTagsResponse,
+  type ListRolesRequest,
+  type ListRolesResponse,
+  type ListSAMLProviderTagsRequest,
+  type ListSAMLProviderTagsResponse,
+  type ListSAMLProvidersRequest,
+  type ListSAMLProvidersResponse,
+  type ListSSHPublicKeysRequest,
+  type ListSSHPublicKeysResponse,
+  type ListServerCertificateTagsRequest,
+  type ListServerCertificateTagsResponse,
+  type ListServerCertificatesRequest,
+  type ListServerCertificatesResponse,
+  type ListServiceSpecificCredentialsRequest,
+  type ListServiceSpecificCredentialsResponse,
+  type ListSigningCertificatesRequest,
+  type ListSigningCertificatesResponse,
+  type ListUserPoliciesRequest,
+  type ListUserPoliciesResponse,
+  type ListUserTagsRequest,
+  type ListUserTagsResponse,
+  type ListUsersRequest,
+  type ListUsersResponse,
+  type ListVirtualMFADevicesRequest,
+  type ListVirtualMFADevicesResponse,
+  type PutGroupPolicyRequest,
+  type PutRolePermissionsBoundaryRequest,
+  type PutRolePolicyRequest,
+  type PutUserPermissionsBoundaryRequest,
+  type PutUserPolicyRequest,
+  type RemoveClientIDFromOpenIDConnectProviderRequest,
+  type RemoveRoleFromInstanceProfileRequest,
+  type RemoveUserFromGroupRequest,
+  type ResetServiceSpecificCredentialRequest,
+  type ResetServiceSpecificCredentialResponse,
+  type ResyncMFADeviceRequest,
+  type SetDefaultPolicyVersionRequest,
+  type SetSecurityTokenServicePreferencesRequest,
+  type SimulateCustomPolicyRequest,
+  type SimulatePolicyResponse,
+  type SimulatePrincipalPolicyRequest,
+  type TagInstanceProfileRequest,
+  type TagMFADeviceRequest,
+  type TagOpenIDConnectProviderRequest,
+  type TagPolicyRequest,
+  type TagRoleRequest,
+  type TagSAMLProviderRequest,
+  type TagServerCertificateRequest,
+  type TagUserRequest,
+  type UntagInstanceProfileRequest,
+  type UntagMFADeviceRequest,
+  type UntagOpenIDConnectProviderRequest,
+  type UntagPolicyRequest,
+  type UntagRoleRequest,
+  type UntagSAMLProviderRequest,
+  type UntagServerCertificateRequest,
+  type UntagUserRequest,
+  type UpdateAccessKeyRequest,
+  type UpdateAccountPasswordPolicyRequest,
+  type UpdateAssumeRolePolicyRequest,
+  type UpdateGroupRequest,
+  type UpdateLoginProfileRequest,
+  type UpdateOpenIDConnectProviderThumbprintRequest,
+  type UpdateRoleRequest,
+  type UpdateRoleResponse,
+  type UpdateRoleDescriptionRequest,
+  type UpdateRoleDescriptionResponse,
+  type UpdateSAMLProviderRequest,
+  type UpdateSAMLProviderResponse,
+  type UpdateSSHPublicKeyRequest,
+  type UpdateServerCertificateRequest,
+  type UpdateServiceSpecificCredentialRequest,
+  type UpdateSigningCertificateRequest,
+  type UpdateUserRequest,
+  type UploadSSHPublicKeyRequest,
+  type UploadSSHPublicKeyResponse,
+  type UploadServerCertificateRequest,
+  type UploadServerCertificateResponse,
+  type UploadSigningCertificateRequest,
+  type UploadSigningCertificateResponse,
 } from "@aws-sdk/client-iam";
-import { type HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
-import { Context, Effect, Layer, Record, Data } from "effect";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
+import { Context, Data, Effect, Layer, Record } from "effect";
 import {
-  IAMServiceError,
-  ConcurrentModificationError,
-  CredentialReportExpiredError,
-  CredentialReportNotPresentError,
-  CredentialReportNotReadyError,
-  DeleteConflictError,
-  DuplicateCertificateError,
-  DuplicateSSHPublicKeyError,
-  EntityAlreadyExistsError,
-  EntityTemporarilyUnmodifiableError,
-  InvalidAuthenticationCodeError,
-  InvalidCertificateError,
-  InvalidInputError,
-  InvalidPublicKeyError,
-  InvalidUserTypeError,
-  KeyPairMismatchError,
-  LimitExceededError,
-  MalformedCertificateError,
-  MalformedPolicyDocumentError,
-  NoSuchEntityError,
-  PasswordPolicyViolationError,
-  PolicyEvaluationError,
-  PolicyNotAttachableError,
-  ReportGenerationLimitExceededError,
-  ServiceFailureError,
-  ServiceNotSupportedError,
-  UnmodifiableEntityError,
-  UnrecognizedPublicKeyEncodingError,
+  type InvalidInputException,
+  type LimitExceededException,
+  type NoSuchEntityException,
+  type ServiceFailureException,
+  type EntityAlreadyExistsException,
+  type UnmodifiableEntityException,
+  type PolicyNotAttachableException,
+  type EntityTemporarilyUnmodifiableException,
+  type InvalidUserTypeException,
+  type PasswordPolicyViolationException,
+  type ConcurrentModificationException,
+  type OpenIdIdpCommunicationErrorException,
+  type MalformedPolicyDocumentException,
+  type ServiceNotSupportedException,
+  type DeleteConflictException,
+  type InvalidAuthenticationCodeException,
+  type ReportGenerationLimitExceededException,
+  type CredentialReportExpiredException,
+  type CredentialReportNotPresentException,
+  type CredentialReportNotReadyException,
+  type UnrecognizedPublicKeyEncodingException,
+  type PolicyEvaluationException,
+  type DuplicateSSHPublicKeyException,
+  type InvalidPublicKeyException,
+  type KeyPairMismatchException,
+  type MalformedCertificateException,
+  type DuplicateCertificateException,
+  type InvalidCertificateException,
+  type TaggedException,
   SdkError,
-  TaggedException,
 } from "./Errors";
 import { IAMClientInstance, IAMClientInstanceLayer } from "./IAMClientInstance";
 import { DefaultIAMClientConfigLayer } from "./IAMClientInstanceConfig";
@@ -555,11 +475,11 @@ const commands = {
   DeleteRolePermissionsBoundaryCommand,
   DeleteRolePolicyCommand,
   DeleteSAMLProviderCommand,
+  DeleteSSHPublicKeyCommand,
   DeleteServerCertificateCommand,
   DeleteServiceLinkedRoleCommand,
   DeleteServiceSpecificCredentialCommand,
   DeleteSigningCertificateCommand,
-  DeleteSSHPublicKeyCommand,
   DeleteUserCommand,
   DeleteUserPermissionsBoundaryCommand,
   DeleteUserPolicyCommand,
@@ -590,11 +510,11 @@ const commands = {
   GetRoleCommand,
   GetRolePolicyCommand,
   GetSAMLProviderCommand,
+  GetSSHPublicKeyCommand,
   GetServerCertificateCommand,
   GetServiceLastAccessedDetailsCommand,
   GetServiceLastAccessedDetailsWithEntitiesCommand,
   GetServiceLinkedRoleDeletionStatusCommand,
-  GetSSHPublicKeyCommand,
   GetUserCommand,
   GetUserPolicyCommand,
   ListAccessKeysCommand,
@@ -606,30 +526,30 @@ const commands = {
   ListGroupPoliciesCommand,
   ListGroupsCommand,
   ListGroupsForUserCommand,
+  ListInstanceProfileTagsCommand,
   ListInstanceProfilesCommand,
   ListInstanceProfilesForRoleCommand,
-  ListInstanceProfileTagsCommand,
-  ListMFADevicesCommand,
   ListMFADeviceTagsCommand,
-  ListOpenIDConnectProvidersCommand,
+  ListMFADevicesCommand,
   ListOpenIDConnectProviderTagsCommand,
+  ListOpenIDConnectProvidersCommand,
   ListPoliciesCommand,
   ListPoliciesGrantingServiceAccessCommand,
   ListPolicyTagsCommand,
   ListPolicyVersionsCommand,
   ListRolePoliciesCommand,
-  ListRolesCommand,
   ListRoleTagsCommand,
-  ListSAMLProvidersCommand,
+  ListRolesCommand,
   ListSAMLProviderTagsCommand,
-  ListServerCertificatesCommand,
+  ListSAMLProvidersCommand,
+  ListSSHPublicKeysCommand,
   ListServerCertificateTagsCommand,
+  ListServerCertificatesCommand,
   ListServiceSpecificCredentialsCommand,
   ListSigningCertificatesCommand,
-  ListSSHPublicKeysCommand,
   ListUserPoliciesCommand,
-  ListUsersCommand,
   ListUserTagsCommand,
+  ListUsersCommand,
   ListVirtualMFADevicesCommand,
   PutGroupPolicyCommand,
   PutRolePermissionsBoundaryCommand,
@@ -670,2309 +590,2168 @@ const commands = {
   UpdateRoleCommand,
   UpdateRoleDescriptionCommand,
   UpdateSAMLProviderCommand,
+  UpdateSSHPublicKeyCommand,
   UpdateServerCertificateCommand,
   UpdateServiceSpecificCredentialCommand,
   UpdateSigningCertificateCommand,
-  UpdateSSHPublicKeyCommand,
   UpdateUserCommand,
+  UploadSSHPublicKeyCommand,
   UploadServerCertificateCommand,
   UploadSigningCertificateCommand,
-  UploadSSHPublicKeyCommand,
 };
 
 /**
  * @since 1.0.0
  * @category models
  */
-export type IAMService = {
+export interface IAMService {
   readonly _: unique symbol;
 
   /**
    * @see {@link AddClientIDToOpenIDConnectProviderCommand}
    */
-  readonly addClientIDToOpenIDConnectProvider: (
-    args: AddClientIDToOpenIDConnectProviderCommandInput,
+  addClientIDToOpenIDConnectProvider(
+    args: AddClientIDToOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AddClientIDToOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link AddRoleToInstanceProfileCommand}
    */
-  readonly addRoleToInstanceProfile: (
-    args: AddRoleToInstanceProfileCommandInput,
+  addRoleToInstanceProfile(
+    args: AddRoleToInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AddRoleToInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link AddUserToGroupCommand}
    */
-  readonly addUserToGroup: (
-    args: AddUserToGroupCommandInput,
+  addUserToGroup(
+    args: AddUserToGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AddUserToGroupCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link AttachGroupPolicyCommand}
    */
-  readonly attachGroupPolicy: (
-    args: AttachGroupPolicyCommandInput,
+  attachGroupPolicy(
+    args: AttachGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachGroupPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PolicyNotAttachableError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PolicyNotAttachableException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link AttachRolePolicyCommand}
    */
-  readonly attachRolePolicy: (
-    args: AttachRolePolicyCommandInput,
+  attachRolePolicy(
+    args: AttachRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachRolePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PolicyNotAttachableError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PolicyNotAttachableException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link AttachUserPolicyCommand}
    */
-  readonly attachUserPolicy: (
-    args: AttachUserPolicyCommandInput,
+  attachUserPolicy(
+    args: AttachUserPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    AttachUserPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PolicyNotAttachableError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PolicyNotAttachableException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ChangePasswordCommand}
    */
-  readonly changePassword: (
-    args: ChangePasswordCommandInput,
+  changePassword(
+    args: ChangePasswordRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ChangePasswordCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | EntityTemporarilyUnmodifiableError
-    | InvalidUserTypeError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PasswordPolicyViolationError
-    | ServiceFailureError
+    | EntityTemporarilyUnmodifiableException
+    | InvalidUserTypeException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PasswordPolicyViolationException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateAccessKeyCommand}
    */
-  readonly createAccessKey: (
-    args: CreateAccessKeyCommandInput,
+  createAccessKey(
+    args: CreateAccessKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateAccessKeyCommandOutput,
+  ): Effect.Effect<
+    CreateAccessKeyResponse,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateAccountAliasCommand}
    */
-  readonly createAccountAlias: (
-    args: CreateAccountAliasCommandInput,
+  createAccountAlias(
+    args: CreateAccountAliasRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateAccountAliasCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateGroupCommand}
    */
-  readonly createGroup: (
-    args: CreateGroupCommandInput,
+  createGroup(
+    args: CreateGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateGroupCommandOutput,
+  ): Effect.Effect<
+    CreateGroupResponse,
     | SdkError
-    | IAMServiceError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateInstanceProfileCommand}
    */
-  readonly createInstanceProfile: (
-    args: CreateInstanceProfileCommandInput,
+  createInstanceProfile(
+    args: CreateInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    CreateInstanceProfileResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateLoginProfileCommand}
    */
-  readonly createLoginProfile: (
-    args: CreateLoginProfileCommandInput,
+  createLoginProfile(
+    args: CreateLoginProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateLoginProfileCommandOutput,
+  ): Effect.Effect<
+    CreateLoginProfileResponse,
     | SdkError
-    | IAMServiceError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PasswordPolicyViolationError
-    | ServiceFailureError
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PasswordPolicyViolationException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateOpenIDConnectProviderCommand}
    */
-  readonly createOpenIDConnectProvider: (
-    args: CreateOpenIDConnectProviderCommandInput,
+  createOpenIDConnectProvider(
+    args: CreateOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    CreateOpenIDConnectProviderResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | OpenIdIdpCommunicationErrorException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreatePolicyCommand}
    */
-  readonly createPolicy: (
-    args: CreatePolicyCommandInput,
+  createPolicy(
+    args: CreatePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreatePolicyCommandOutput,
+  ): Effect.Effect<
+    CreatePolicyResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreatePolicyVersionCommand}
    */
-  readonly createPolicyVersion: (
-    args: CreatePolicyVersionCommandInput,
+  createPolicyVersion(
+    args: CreatePolicyVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreatePolicyVersionCommandOutput,
+  ): Effect.Effect<
+    CreatePolicyVersionResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateRoleCommand}
    */
-  readonly createRole: (
-    args: CreateRoleCommandInput,
+  createRole(
+    args: CreateRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateRoleCommandOutput,
+  ): Effect.Effect<
+    CreateRoleResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateSAMLProviderCommand}
    */
-  readonly createSAMLProvider: (
-    args: CreateSAMLProviderCommandInput,
+  createSAMLProvider(
+    args: CreateSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    CreateSAMLProviderResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateServiceLinkedRoleCommand}
    */
-  readonly createServiceLinkedRole: (
-    args: CreateServiceLinkedRoleCommandInput,
+  createServiceLinkedRole(
+    args: CreateServiceLinkedRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateServiceLinkedRoleCommandOutput,
+  ): Effect.Effect<
+    CreateServiceLinkedRoleResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateServiceSpecificCredentialCommand}
    */
-  readonly createServiceSpecificCredential: (
-    args: CreateServiceSpecificCredentialCommandInput,
+  createServiceSpecificCredential(
+    args: CreateServiceSpecificCredentialRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateServiceSpecificCredentialCommandOutput,
+  ): Effect.Effect<
+    CreateServiceSpecificCredentialResponse,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceNotSupportedError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceNotSupportedException
   >;
 
   /**
    * @see {@link CreateUserCommand}
    */
-  readonly createUser: (
-    args: CreateUserCommandInput,
+  createUser(
+    args: CreateUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateUserCommandOutput,
+  ): Effect.Effect<
+    CreateUserResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link CreateVirtualMFADeviceCommand}
    */
-  readonly createVirtualMFADevice: (
-    args: CreateVirtualMFADeviceCommandInput,
+  createVirtualMFADevice(
+    args: CreateVirtualMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    CreateVirtualMFADeviceCommandOutput,
+  ): Effect.Effect<
+    CreateVirtualMFADeviceResponse,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | LimitExceededError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | LimitExceededException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeactivateMFADeviceCommand}
    */
-  readonly deactivateMFADevice: (
-    args: DeactivateMFADeviceCommandInput,
+  deactivateMFADevice(
+    args: DeactivateMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeactivateMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityTemporarilyUnmodifiableError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityTemporarilyUnmodifiableException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteAccessKeyCommand}
    */
-  readonly deleteAccessKey: (
-    args: DeleteAccessKeyCommandInput,
+  deleteAccessKey(
+    args: DeleteAccessKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteAccessKeyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteAccountAliasCommand}
    */
-  readonly deleteAccountAlias: (
-    args: DeleteAccountAliasCommandInput,
+  deleteAccountAlias(
+    args: DeleteAccountAliasRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteAccountAliasCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteAccountPasswordPolicyCommand}
    */
-  readonly deleteAccountPasswordPolicy: (
-    args: DeleteAccountPasswordPolicyCommandInput,
+  deleteAccountPasswordPolicy(
+    args: {},
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteAccountPasswordPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteGroupCommand}
    */
-  readonly deleteGroup: (
-    args: DeleteGroupCommandInput,
+  deleteGroup(
+    args: DeleteGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteGroupCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteGroupPolicyCommand}
    */
-  readonly deleteGroupPolicy: (
-    args: DeleteGroupPolicyCommandInput,
+  deleteGroupPolicy(
+    args: DeleteGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteGroupPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteInstanceProfileCommand}
    */
-  readonly deleteInstanceProfile: (
-    args: DeleteInstanceProfileCommandInput,
+  deleteInstanceProfile(
+    args: DeleteInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteLoginProfileCommand}
    */
-  readonly deleteLoginProfile: (
-    args: DeleteLoginProfileCommandInput,
+  deleteLoginProfile(
+    args: DeleteLoginProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteLoginProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | EntityTemporarilyUnmodifiableError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | EntityTemporarilyUnmodifiableException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteOpenIDConnectProviderCommand}
    */
-  readonly deleteOpenIDConnectProvider: (
-    args: DeleteOpenIDConnectProviderCommandInput,
+  deleteOpenIDConnectProvider(
+    args: DeleteOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeletePolicyCommand}
    */
-  readonly deletePolicy: (
-    args: DeletePolicyCommandInput,
+  deletePolicy(
+    args: DeletePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeletePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | DeleteConflictError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | DeleteConflictException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeletePolicyVersionCommand}
    */
-  readonly deletePolicyVersion: (
-    args: DeletePolicyVersionCommandInput,
+  deletePolicyVersion(
+    args: DeletePolicyVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeletePolicyVersionCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | DeleteConflictError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | DeleteConflictException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteRoleCommand}
    */
-  readonly deleteRole: (
-    args: DeleteRoleCommandInput,
+  deleteRole(
+    args: DeleteRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteRoleCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | ConcurrentModificationException
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link DeleteRolePermissionsBoundaryCommand}
    */
-  readonly deleteRolePermissionsBoundary: (
-    args: DeleteRolePermissionsBoundaryCommandInput,
+  deleteRolePermissionsBoundary(
+    args: DeleteRolePermissionsBoundaryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteRolePermissionsBoundaryCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link DeleteRolePolicyCommand}
    */
-  readonly deleteRolePolicy: (
-    args: DeleteRolePolicyCommandInput,
+  deleteRolePolicy(
+    args: DeleteRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteRolePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link DeleteSAMLProviderCommand}
    */
-  readonly deleteSAMLProvider: (
-    args: DeleteSAMLProviderCommandInput,
+  deleteSAMLProvider(
+    args: DeleteSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link DeleteServerCertificateCommand}
-   */
-  readonly deleteServerCertificate: (
-    args: DeleteServerCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteServerCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link DeleteServiceLinkedRoleCommand}
-   */
-  readonly deleteServiceLinkedRole: (
-    args: DeleteServiceLinkedRoleCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteServiceLinkedRoleCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link DeleteServiceSpecificCredentialCommand}
-   */
-  readonly deleteServiceSpecificCredential: (
-    args: DeleteServiceSpecificCredentialCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteServiceSpecificCredentialCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
-  >;
-
-  /**
-   * @see {@link DeleteSigningCertificateCommand}
-   */
-  readonly deleteSigningCertificate: (
-    args: DeleteSigningCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSigningCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteSSHPublicKeyCommand}
    */
-  readonly deleteSSHPublicKey: (
-    args: DeleteSSHPublicKeyCommandInput,
+  deleteSSHPublicKey(
+    args: DeleteSSHPublicKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteSSHPublicKeyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
+  ): Effect.Effect<void, SdkError | NoSuchEntityException>;
+
+  /**
+   * @see {@link DeleteServerCertificateCommand}
+   */
+  deleteServerCertificate(
+    args: DeleteServerCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    void,
+    | SdkError
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link DeleteServiceLinkedRoleCommand}
+   */
+  deleteServiceLinkedRole(
+    args: DeleteServiceLinkedRoleRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    DeleteServiceLinkedRoleResponse,
+    | SdkError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link DeleteServiceSpecificCredentialCommand}
+   */
+  deleteServiceSpecificCredential(
+    args: DeleteServiceSpecificCredentialRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<void, SdkError | NoSuchEntityException>;
+
+  /**
+   * @see {@link DeleteSigningCertificateCommand}
+   */
+  deleteSigningCertificate(
+    args: DeleteSigningCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    void,
+    | SdkError
+    | ConcurrentModificationException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteUserCommand}
    */
-  readonly deleteUser: (
-    args: DeleteUserCommandInput,
+  deleteUser(
+    args: DeleteUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteUserCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteUserPermissionsBoundaryCommand}
    */
-  readonly deleteUserPermissionsBoundary: (
-    args: DeleteUserPermissionsBoundaryCommandInput,
+  deleteUserPermissionsBoundary(
+    args: DeleteUserPermissionsBoundaryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteUserPermissionsBoundaryCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    void,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteUserPolicyCommand}
    */
-  readonly deleteUserPolicy: (
-    args: DeleteUserPolicyCommandInput,
+  deleteUserPolicy(
+    args: DeleteUserPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteUserPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DeleteVirtualMFADeviceCommand}
    */
-  readonly deleteVirtualMFADevice: (
-    args: DeleteVirtualMFADeviceCommandInput,
+  deleteVirtualMFADevice(
+    args: DeleteVirtualMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DeleteVirtualMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | DeleteConflictError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | DeleteConflictException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DetachGroupPolicyCommand}
    */
-  readonly detachGroupPolicy: (
-    args: DetachGroupPolicyCommandInput,
+  detachGroupPolicy(
+    args: DetachGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachGroupPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link DetachRolePolicyCommand}
    */
-  readonly detachRolePolicy: (
-    args: DetachRolePolicyCommandInput,
+  detachRolePolicy(
+    args: DetachRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachRolePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link DetachUserPolicyCommand}
    */
-  readonly detachUserPolicy: (
-    args: DetachUserPolicyCommandInput,
+  detachUserPolicy(
+    args: DetachUserPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    DetachUserPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link EnableMFADeviceCommand}
    */
-  readonly enableMFADevice: (
-    args: EnableMFADeviceCommandInput,
+  enableMFADevice(
+    args: EnableMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    EnableMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | EntityTemporarilyUnmodifiableError
-    | InvalidAuthenticationCodeError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | EntityTemporarilyUnmodifiableException
+    | InvalidAuthenticationCodeException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GenerateCredentialReportCommand}
    */
-  readonly generateCredentialReport: (
-    args: GenerateCredentialReportCommandInput,
+  generateCredentialReport(
+    args: {},
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GenerateCredentialReportCommandOutput,
-    SdkError | IAMServiceError | LimitExceededError | ServiceFailureError
+  ): Effect.Effect<
+    GenerateCredentialReportResponse,
+    SdkError | LimitExceededException | ServiceFailureException
   >;
 
   /**
    * @see {@link GenerateOrganizationsAccessReportCommand}
    */
-  readonly generateOrganizationsAccessReport: (
-    args: GenerateOrganizationsAccessReportCommandInput,
+  generateOrganizationsAccessReport(
+    args: GenerateOrganizationsAccessReportRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GenerateOrganizationsAccessReportCommandOutput,
-    SdkError | IAMServiceError | ReportGenerationLimitExceededError
+  ): Effect.Effect<
+    GenerateOrganizationsAccessReportResponse,
+    SdkError | ReportGenerationLimitExceededException
   >;
 
   /**
    * @see {@link GenerateServiceLastAccessedDetailsCommand}
    */
-  readonly generateServiceLastAccessedDetails: (
-    args: GenerateServiceLastAccessedDetailsCommandInput,
+  generateServiceLastAccessedDetails(
+    args: GenerateServiceLastAccessedDetailsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GenerateServiceLastAccessedDetailsCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | NoSuchEntityError
+  ): Effect.Effect<
+    GenerateServiceLastAccessedDetailsResponse,
+    SdkError | InvalidInputException | NoSuchEntityException
   >;
 
   /**
    * @see {@link GetAccessKeyLastUsedCommand}
    */
-  readonly getAccessKeyLastUsed: (
-    args: GetAccessKeyLastUsedCommandInput,
+  getAccessKeyLastUsed(
+    args: GetAccessKeyLastUsedRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAccessKeyLastUsedCommandOutput,
-    SdkError | IAMServiceError
-  >;
+  ): Effect.Effect<GetAccessKeyLastUsedResponse, SdkError>;
 
   /**
    * @see {@link GetAccountAuthorizationDetailsCommand}
    */
-  readonly getAccountAuthorizationDetails: (
-    args: GetAccountAuthorizationDetailsCommandInput,
+  getAccountAuthorizationDetails(
+    args: GetAccountAuthorizationDetailsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAccountAuthorizationDetailsCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    GetAccountAuthorizationDetailsResponse,
+    SdkError | ServiceFailureException
   >;
 
   /**
    * @see {@link GetAccountPasswordPolicyCommand}
    */
-  readonly getAccountPasswordPolicy: (
-    args: GetAccountPasswordPolicyCommandInput,
+  getAccountPasswordPolicy(
+    args: {},
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAccountPasswordPolicyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetAccountPasswordPolicyResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetAccountSummaryCommand}
    */
-  readonly getAccountSummary: (
-    args: GetAccountSummaryCommandInput,
+  getAccountSummary(
+    args: {},
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetAccountSummaryCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    GetAccountSummaryResponse,
+    SdkError | ServiceFailureException
   >;
 
   /**
    * @see {@link GetContextKeysForCustomPolicyCommand}
    */
-  readonly getContextKeysForCustomPolicy: (
-    args: GetContextKeysForCustomPolicyCommandInput,
+  getContextKeysForCustomPolicy(
+    args: GetContextKeysForCustomPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetContextKeysForCustomPolicyCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError
+  ): Effect.Effect<
+    GetContextKeysForPolicyResponse,
+    SdkError | InvalidInputException
   >;
 
   /**
    * @see {@link GetContextKeysForPrincipalPolicyCommand}
    */
-  readonly getContextKeysForPrincipalPolicy: (
-    args: GetContextKeysForPrincipalPolicyCommandInput,
+  getContextKeysForPrincipalPolicy(
+    args: GetContextKeysForPrincipalPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetContextKeysForPrincipalPolicyCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | NoSuchEntityError
+  ): Effect.Effect<
+    GetContextKeysForPolicyResponse,
+    SdkError | InvalidInputException | NoSuchEntityException
   >;
 
   /**
    * @see {@link GetCredentialReportCommand}
    */
-  readonly getCredentialReport: (
-    args: GetCredentialReportCommandInput,
+  getCredentialReport(
+    args: {},
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetCredentialReportCommandOutput,
+  ): Effect.Effect<
+    GetCredentialReportResponse,
     | SdkError
-    | IAMServiceError
-    | CredentialReportExpiredError
-    | CredentialReportNotPresentError
-    | CredentialReportNotReadyError
-    | ServiceFailureError
+    | CredentialReportExpiredException
+    | CredentialReportNotPresentException
+    | CredentialReportNotReadyException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetGroupCommand}
    */
-  readonly getGroup: (
-    args: GetGroupCommandInput,
+  getGroup(
+    args: GetGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetGroupCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetGroupResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetGroupPolicyCommand}
    */
-  readonly getGroupPolicy: (
-    args: GetGroupPolicyCommandInput,
+  getGroupPolicy(
+    args: GetGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetGroupPolicyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetGroupPolicyResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetInstanceProfileCommand}
    */
-  readonly getInstanceProfile: (
-    args: GetInstanceProfileCommandInput,
+  getInstanceProfile(
+    args: GetInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetInstanceProfileCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetInstanceProfileResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetLoginProfileCommand}
    */
-  readonly getLoginProfile: (
-    args: GetLoginProfileCommandInput,
+  getLoginProfile(
+    args: GetLoginProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetLoginProfileCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetLoginProfileResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetMFADeviceCommand}
    */
-  readonly getMFADevice: (
-    args: GetMFADeviceCommandInput,
+  getMFADevice(
+    args: GetMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetMFADeviceCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetMFADeviceResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetOpenIDConnectProviderCommand}
    */
-  readonly getOpenIDConnectProvider: (
-    args: GetOpenIDConnectProviderCommandInput,
+  getOpenIDConnectProvider(
+    args: GetOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    GetOpenIDConnectProviderResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetOrganizationsAccessReportCommand}
    */
-  readonly getOrganizationsAccessReport: (
-    args: GetOrganizationsAccessReportCommandInput,
+  getOrganizationsAccessReport(
+    args: GetOrganizationsAccessReportRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetOrganizationsAccessReportCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
+  ): Effect.Effect<
+    GetOrganizationsAccessReportResponse,
+    SdkError | NoSuchEntityException
   >;
 
   /**
    * @see {@link GetPolicyCommand}
    */
-  readonly getPolicy: (
-    args: GetPolicyCommandInput,
+  getPolicy(
+    args: GetPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetPolicyCommandOutput,
+  ): Effect.Effect<
+    GetPolicyResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetPolicyVersionCommand}
    */
-  readonly getPolicyVersion: (
-    args: GetPolicyVersionCommandInput,
+  getPolicyVersion(
+    args: GetPolicyVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetPolicyVersionCommandOutput,
+  ): Effect.Effect<
+    GetPolicyVersionResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetRoleCommand}
    */
-  readonly getRole: (
-    args: GetRoleCommandInput,
+  getRole(
+    args: GetRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetRoleCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetRoleResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetRolePolicyCommand}
    */
-  readonly getRolePolicy: (
-    args: GetRolePolicyCommandInput,
+  getRolePolicy(
+    args: GetRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetRolePolicyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetRolePolicyResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetSAMLProviderCommand}
    */
-  readonly getSAMLProvider: (
-    args: GetSAMLProviderCommandInput,
+  getSAMLProvider(
+    args: GetSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    GetSAMLProviderResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link GetServerCertificateCommand}
-   */
-  readonly getServerCertificate: (
-    args: GetServerCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetServerCertificateCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link GetServiceLastAccessedDetailsCommand}
-   */
-  readonly getServiceLastAccessedDetails: (
-    args: GetServiceLastAccessedDetailsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetServiceLastAccessedDetailsCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | NoSuchEntityError
-  >;
-
-  /**
-   * @see {@link GetServiceLastAccessedDetailsWithEntitiesCommand}
-   */
-  readonly getServiceLastAccessedDetailsWithEntities: (
-    args: GetServiceLastAccessedDetailsWithEntitiesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetServiceLastAccessedDetailsWithEntitiesCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | NoSuchEntityError
-  >;
-
-  /**
-   * @see {@link GetServiceLinkedRoleDeletionStatusCommand}
-   */
-  readonly getServiceLinkedRoleDeletionStatus: (
-    args: GetServiceLinkedRoleDeletionStatusCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetServiceLinkedRoleDeletionStatusCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetSSHPublicKeyCommand}
    */
-  readonly getSSHPublicKey: (
-    args: GetSSHPublicKeyCommandInput,
+  getSSHPublicKey(
+    args: GetSSHPublicKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetSSHPublicKeyCommandOutput,
+  ): Effect.Effect<
+    GetSSHPublicKeyResponse,
+    SdkError | NoSuchEntityException | UnrecognizedPublicKeyEncodingException
+  >;
+
+  /**
+   * @see {@link GetServerCertificateCommand}
+   */
+  getServerCertificate(
+    args: GetServerCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    GetServerCertificateResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link GetServiceLastAccessedDetailsCommand}
+   */
+  getServiceLastAccessedDetails(
+    args: GetServiceLastAccessedDetailsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    GetServiceLastAccessedDetailsResponse,
+    SdkError | InvalidInputException | NoSuchEntityException
+  >;
+
+  /**
+   * @see {@link GetServiceLastAccessedDetailsWithEntitiesCommand}
+   */
+  getServiceLastAccessedDetailsWithEntities(
+    args: GetServiceLastAccessedDetailsWithEntitiesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    GetServiceLastAccessedDetailsWithEntitiesResponse,
+    SdkError | InvalidInputException | NoSuchEntityException
+  >;
+
+  /**
+   * @see {@link GetServiceLinkedRoleDeletionStatusCommand}
+   */
+  getServiceLinkedRoleDeletionStatus(
+    args: GetServiceLinkedRoleDeletionStatusRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    GetServiceLinkedRoleDeletionStatusResponse,
     | SdkError
-    | IAMServiceError
-    | NoSuchEntityError
-    | UnrecognizedPublicKeyEncodingError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link GetUserCommand}
    */
-  readonly getUser: (
-    args: GetUserCommandInput,
+  getUser(
+    args: GetUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetUserCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetUserResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link GetUserPolicyCommand}
    */
-  readonly getUserPolicy: (
-    args: GetUserPolicyCommandInput,
+  getUserPolicy(
+    args: GetUserPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    GetUserPolicyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    GetUserPolicyResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListAccessKeysCommand}
    */
-  readonly listAccessKeys: (
-    args: ListAccessKeysCommandInput,
+  listAccessKeys(
+    args: ListAccessKeysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListAccessKeysCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListAccessKeysResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListAccountAliasesCommand}
    */
-  readonly listAccountAliases: (
-    args: ListAccountAliasesCommandInput,
+  listAccountAliases(
+    args: ListAccountAliasesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListAccountAliasesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    ListAccountAliasesResponse,
+    SdkError | ServiceFailureException
   >;
 
   /**
    * @see {@link ListAttachedGroupPoliciesCommand}
    */
-  readonly listAttachedGroupPolicies: (
-    args: ListAttachedGroupPoliciesCommandInput,
+  listAttachedGroupPolicies(
+    args: ListAttachedGroupPoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListAttachedGroupPoliciesCommandOutput,
+  ): Effect.Effect<
+    ListAttachedGroupPoliciesResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListAttachedRolePoliciesCommand}
    */
-  readonly listAttachedRolePolicies: (
-    args: ListAttachedRolePoliciesCommandInput,
+  listAttachedRolePolicies(
+    args: ListAttachedRolePoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListAttachedRolePoliciesCommandOutput,
+  ): Effect.Effect<
+    ListAttachedRolePoliciesResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListAttachedUserPoliciesCommand}
    */
-  readonly listAttachedUserPolicies: (
-    args: ListAttachedUserPoliciesCommandInput,
+  listAttachedUserPolicies(
+    args: ListAttachedUserPoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListAttachedUserPoliciesCommandOutput,
+  ): Effect.Effect<
+    ListAttachedUserPoliciesResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListEntitiesForPolicyCommand}
    */
-  readonly listEntitiesForPolicy: (
-    args: ListEntitiesForPolicyCommandInput,
+  listEntitiesForPolicy(
+    args: ListEntitiesForPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListEntitiesForPolicyCommandOutput,
+  ): Effect.Effect<
+    ListEntitiesForPolicyResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListGroupPoliciesCommand}
    */
-  readonly listGroupPolicies: (
-    args: ListGroupPoliciesCommandInput,
+  listGroupPolicies(
+    args: ListGroupPoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListGroupPoliciesCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListGroupPoliciesResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListGroupsCommand}
    */
-  readonly listGroups: (
-    args: ListGroupsCommandInput,
+  listGroups(
+    args: ListGroupsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListGroupsCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
+  ): Effect.Effect<ListGroupsResponse, SdkError | ServiceFailureException>;
 
   /**
    * @see {@link ListGroupsForUserCommand}
    */
-  readonly listGroupsForUser: (
-    args: ListGroupsForUserCommandInput,
+  listGroupsForUser(
+    args: ListGroupsForUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListGroupsForUserCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListInstanceProfilesCommand}
-   */
-  readonly listInstanceProfiles: (
-    args: ListInstanceProfilesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListInstanceProfilesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListInstanceProfilesForRoleCommand}
-   */
-  readonly listInstanceProfilesForRole: (
-    args: ListInstanceProfilesForRoleCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListInstanceProfilesForRoleCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListGroupsForUserResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListInstanceProfileTagsCommand}
    */
-  readonly listInstanceProfileTags: (
-    args: ListInstanceProfileTagsCommandInput,
+  listInstanceProfileTags(
+    args: ListInstanceProfileTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListInstanceProfileTagsCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListInstanceProfileTagsResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
-   * @see {@link ListMFADevicesCommand}
+   * @see {@link ListInstanceProfilesCommand}
    */
-  readonly listMFADevices: (
-    args: ListMFADevicesCommandInput,
+  listInstanceProfiles(
+    args: ListInstanceProfilesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListMFADevicesCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListInstanceProfilesResponse,
+    SdkError | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link ListInstanceProfilesForRoleCommand}
+   */
+  listInstanceProfilesForRole(
+    args: ListInstanceProfilesForRoleRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListInstanceProfilesForRoleResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListMFADeviceTagsCommand}
    */
-  readonly listMFADeviceTags: (
-    args: ListMFADeviceTagsCommandInput,
+  listMFADeviceTags(
+    args: ListMFADeviceTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListMFADeviceTagsCommandOutput,
+  ): Effect.Effect<
+    ListMFADeviceTagsResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
-   * @see {@link ListOpenIDConnectProvidersCommand}
+   * @see {@link ListMFADevicesCommand}
    */
-  readonly listOpenIDConnectProviders: (
-    args: ListOpenIDConnectProvidersCommandInput,
+  listMFADevices(
+    args: ListMFADevicesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListOpenIDConnectProvidersCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    ListMFADevicesResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListOpenIDConnectProviderTagsCommand}
    */
-  readonly listOpenIDConnectProviderTags: (
-    args: ListOpenIDConnectProviderTagsCommandInput,
+  listOpenIDConnectProviderTags(
+    args: ListOpenIDConnectProviderTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListOpenIDConnectProviderTagsCommandOutput,
+  ): Effect.Effect<
+    ListOpenIDConnectProviderTagsResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link ListOpenIDConnectProvidersCommand}
+   */
+  listOpenIDConnectProviders(
+    args: ListOpenIDConnectProvidersRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListOpenIDConnectProvidersResponse,
+    SdkError | ServiceFailureException
   >;
 
   /**
    * @see {@link ListPoliciesCommand}
    */
-  readonly listPolicies: (
-    args: ListPoliciesCommandInput,
+  listPolicies(
+    args: ListPoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListPoliciesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
+  ): Effect.Effect<ListPoliciesResponse, SdkError | ServiceFailureException>;
 
   /**
    * @see {@link ListPoliciesGrantingServiceAccessCommand}
    */
-  readonly listPoliciesGrantingServiceAccess: (
-    args: ListPoliciesGrantingServiceAccessCommandInput,
+  listPoliciesGrantingServiceAccess(
+    args: ListPoliciesGrantingServiceAccessRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListPoliciesGrantingServiceAccessCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | NoSuchEntityError
+  ): Effect.Effect<
+    ListPoliciesGrantingServiceAccessResponse,
+    SdkError | InvalidInputException | NoSuchEntityException
   >;
 
   /**
    * @see {@link ListPolicyTagsCommand}
    */
-  readonly listPolicyTags: (
-    args: ListPolicyTagsCommandInput,
+  listPolicyTags(
+    args: ListPolicyTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListPolicyTagsCommandOutput,
+  ): Effect.Effect<
+    ListPolicyTagsResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListPolicyVersionsCommand}
    */
-  readonly listPolicyVersions: (
-    args: ListPolicyVersionsCommandInput,
+  listPolicyVersions(
+    args: ListPolicyVersionsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListPolicyVersionsCommandOutput,
+  ): Effect.Effect<
+    ListPolicyVersionsResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListRolePoliciesCommand}
    */
-  readonly listRolePolicies: (
-    args: ListRolePoliciesCommandInput,
+  listRolePolicies(
+    args: ListRolePoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListRolePoliciesCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListRolesCommand}
-   */
-  readonly listRoles: (
-    args: ListRolesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListRolesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    ListRolePoliciesResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListRoleTagsCommand}
    */
-  readonly listRoleTags: (
-    args: ListRoleTagsCommandInput,
+  listRoleTags(
+    args: ListRoleTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListRoleTagsCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListRoleTagsResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link ListRolesCommand}
+   */
+  listRoles(
+    args: ListRolesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<ListRolesResponse, SdkError | ServiceFailureException>;
+
+  /**
+   * @see {@link ListSAMLProviderTagsCommand}
+   */
+  listSAMLProviderTags(
+    args: ListSAMLProviderTagsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListSAMLProviderTagsResponse,
+    | SdkError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ListSAMLProvidersCommand}
    */
-  readonly listSAMLProviders: (
-    args: ListSAMLProvidersCommandInput,
+  listSAMLProviders(
+    args: ListSAMLProvidersRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListSAMLProvidersCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListSAMLProviderTagsCommand}
-   */
-  readonly listSAMLProviderTags: (
-    args: ListSAMLProviderTagsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListSAMLProviderTagsCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListServerCertificatesCommand}
-   */
-  readonly listServerCertificates: (
-    args: ListServerCertificatesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListServerCertificatesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListServerCertificateTagsCommand}
-   */
-  readonly listServerCertificateTags: (
-    args: ListServerCertificateTagsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListServerCertificateTagsCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListServiceSpecificCredentialsCommand}
-   */
-  readonly listServiceSpecificCredentials: (
-    args: ListServiceSpecificCredentialsCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListServiceSpecificCredentialsCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceNotSupportedError
-  >;
-
-  /**
-   * @see {@link ListSigningCertificatesCommand}
-   */
-  readonly listSigningCertificates: (
-    args: ListSigningCertificatesCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListSigningCertificatesCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListSAMLProvidersResponse,
+    SdkError | ServiceFailureException
   >;
 
   /**
    * @see {@link ListSSHPublicKeysCommand}
    */
-  readonly listSSHPublicKeys: (
-    args: ListSSHPublicKeysCommandInput,
+  listSSHPublicKeys(
+    args: ListSSHPublicKeysRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListSSHPublicKeysCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
+  ): Effect.Effect<ListSSHPublicKeysResponse, SdkError | NoSuchEntityException>;
+
+  /**
+   * @see {@link ListServerCertificateTagsCommand}
+   */
+  listServerCertificateTags(
+    args: ListServerCertificateTagsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListServerCertificateTagsResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link ListServerCertificatesCommand}
+   */
+  listServerCertificates(
+    args: ListServerCertificatesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListServerCertificatesResponse,
+    SdkError | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link ListServiceSpecificCredentialsCommand}
+   */
+  listServiceSpecificCredentials(
+    args: ListServiceSpecificCredentialsRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListServiceSpecificCredentialsResponse,
+    SdkError | NoSuchEntityException | ServiceNotSupportedException
+  >;
+
+  /**
+   * @see {@link ListSigningCertificatesCommand}
+   */
+  listSigningCertificates(
+    args: ListSigningCertificatesRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    ListSigningCertificatesResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListUserPoliciesCommand}
    */
-  readonly listUserPolicies: (
-    args: ListUserPoliciesCommandInput,
+  listUserPolicies(
+    args: ListUserPoliciesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListUserPoliciesCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link ListUsersCommand}
-   */
-  readonly listUsers: (
-    args: ListUsersCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListUsersCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
+  ): Effect.Effect<
+    ListUserPoliciesResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
 
   /**
    * @see {@link ListUserTagsCommand}
    */
-  readonly listUserTags: (
-    args: ListUserTagsCommandInput,
+  listUserTags(
+    args: ListUserTagsRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListUserTagsCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError | ServiceFailureError
+  ): Effect.Effect<
+    ListUserTagsResponse,
+    SdkError | NoSuchEntityException | ServiceFailureException
   >;
+
+  /**
+   * @see {@link ListUsersCommand}
+   */
+  listUsers(
+    args: ListUsersRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<ListUsersResponse, SdkError | ServiceFailureException>;
 
   /**
    * @see {@link ListVirtualMFADevicesCommand}
    */
-  readonly listVirtualMFADevices: (
-    args: ListVirtualMFADevicesCommandInput,
+  listVirtualMFADevices(
+    args: ListVirtualMFADevicesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ListVirtualMFADevicesCommandOutput,
-    SdkError | IAMServiceError
-  >;
+  ): Effect.Effect<ListVirtualMFADevicesResponse, SdkError>;
 
   /**
    * @see {@link PutGroupPolicyCommand}
    */
-  readonly putGroupPolicy: (
-    args: PutGroupPolicyCommandInput,
+  putGroupPolicy(
+    args: PutGroupPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PutGroupPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link PutRolePermissionsBoundaryCommand}
    */
-  readonly putRolePermissionsBoundary: (
-    args: PutRolePermissionsBoundaryCommandInput,
+  putRolePermissionsBoundary(
+    args: PutRolePermissionsBoundaryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PutRolePermissionsBoundaryCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | PolicyNotAttachableError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | InvalidInputException
+    | NoSuchEntityException
+    | PolicyNotAttachableException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link PutRolePolicyCommand}
    */
-  readonly putRolePolicy: (
-    args: PutRolePolicyCommandInput,
+  putRolePolicy(
+    args: PutRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PutRolePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link PutUserPermissionsBoundaryCommand}
    */
-  readonly putUserPermissionsBoundary: (
-    args: PutUserPermissionsBoundaryCommandInput,
+  putUserPermissionsBoundary(
+    args: PutUserPermissionsBoundaryRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PutUserPermissionsBoundaryCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | PolicyNotAttachableError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | PolicyNotAttachableException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link PutUserPolicyCommand}
    */
-  readonly putUserPolicy: (
-    args: PutUserPolicyCommandInput,
+  putUserPolicy(
+    args: PutUserPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    PutUserPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link RemoveClientIDFromOpenIDConnectProviderCommand}
    */
-  readonly removeClientIDFromOpenIDConnectProvider: (
-    args: RemoveClientIDFromOpenIDConnectProviderCommandInput,
+  removeClientIDFromOpenIDConnectProvider(
+    args: RemoveClientIDFromOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RemoveClientIDFromOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link RemoveRoleFromInstanceProfileCommand}
    */
-  readonly removeRoleFromInstanceProfile: (
-    args: RemoveRoleFromInstanceProfileCommandInput,
+  removeRoleFromInstanceProfile(
+    args: RemoveRoleFromInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RemoveRoleFromInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link RemoveUserFromGroupCommand}
    */
-  readonly removeUserFromGroup: (
-    args: RemoveUserFromGroupCommandInput,
+  removeUserFromGroup(
+    args: RemoveUserFromGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    RemoveUserFromGroupCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link ResetServiceSpecificCredentialCommand}
    */
-  readonly resetServiceSpecificCredential: (
-    args: ResetServiceSpecificCredentialCommandInput,
+  resetServiceSpecificCredential(
+    args: ResetServiceSpecificCredentialRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResetServiceSpecificCredentialCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
+  ): Effect.Effect<
+    ResetServiceSpecificCredentialResponse,
+    SdkError | NoSuchEntityException
   >;
 
   /**
    * @see {@link ResyncMFADeviceCommand}
    */
-  readonly resyncMFADevice: (
-    args: ResyncMFADeviceCommandInput,
+  resyncMFADevice(
+    args: ResyncMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    ResyncMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidAuthenticationCodeError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidAuthenticationCodeException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link SetDefaultPolicyVersionCommand}
    */
-  readonly setDefaultPolicyVersion: (
-    args: SetDefaultPolicyVersionCommandInput,
+  setDefaultPolicyVersion(
+    args: SetDefaultPolicyVersionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SetDefaultPolicyVersionCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link SetSecurityTokenServicePreferencesCommand}
    */
-  readonly setSecurityTokenServicePreferences: (
-    args: SetSecurityTokenServicePreferencesCommandInput,
+  setSecurityTokenServicePreferences(
+    args: SetSecurityTokenServicePreferencesRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SetSecurityTokenServicePreferencesCommandOutput,
-    SdkError | IAMServiceError | ServiceFailureError
-  >;
+  ): Effect.Effect<void, SdkError | ServiceFailureException>;
 
   /**
    * @see {@link SimulateCustomPolicyCommand}
    */
-  readonly simulateCustomPolicy: (
-    args: SimulateCustomPolicyCommandInput,
+  simulateCustomPolicy(
+    args: SimulateCustomPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SimulateCustomPolicyCommandOutput,
-    SdkError | IAMServiceError | InvalidInputError | PolicyEvaluationError
+  ): Effect.Effect<
+    SimulatePolicyResponse,
+    SdkError | InvalidInputException | PolicyEvaluationException
   >;
 
   /**
    * @see {@link SimulatePrincipalPolicyCommand}
    */
-  readonly simulatePrincipalPolicy: (
-    args: SimulatePrincipalPolicyCommandInput,
+  simulatePrincipalPolicy(
+    args: SimulatePrincipalPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    SimulatePrincipalPolicyCommandOutput,
+  ): Effect.Effect<
+    SimulatePolicyResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | PolicyEvaluationError
+    | InvalidInputException
+    | NoSuchEntityException
+    | PolicyEvaluationException
   >;
 
   /**
    * @see {@link TagInstanceProfileCommand}
    */
-  readonly tagInstanceProfile: (
-    args: TagInstanceProfileCommandInput,
+  tagInstanceProfile(
+    args: TagInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagMFADeviceCommand}
    */
-  readonly tagMFADevice: (
-    args: TagMFADeviceCommandInput,
+  tagMFADevice(
+    args: TagMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagOpenIDConnectProviderCommand}
    */
-  readonly tagOpenIDConnectProvider: (
-    args: TagOpenIDConnectProviderCommandInput,
+  tagOpenIDConnectProvider(
+    args: TagOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagPolicyCommand}
    */
-  readonly tagPolicy: (
-    args: TagPolicyCommandInput,
+  tagPolicy(
+    args: TagPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagRoleCommand}
    */
-  readonly tagRole: (
-    args: TagRoleCommandInput,
+  tagRole(
+    args: TagRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagRoleCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagSAMLProviderCommand}
    */
-  readonly tagSAMLProvider: (
-    args: TagSAMLProviderCommandInput,
+  tagSAMLProvider(
+    args: TagSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagServerCertificateCommand}
    */
-  readonly tagServerCertificate: (
-    args: TagServerCertificateCommandInput,
+  tagServerCertificate(
+    args: TagServerCertificateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagServerCertificateCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link TagUserCommand}
    */
-  readonly tagUser: (
-    args: TagUserCommandInput,
+  tagUser(
+    args: TagUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    TagUserCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagInstanceProfileCommand}
    */
-  readonly untagInstanceProfile: (
-    args: UntagInstanceProfileCommandInput,
+  untagInstanceProfile(
+    args: UntagInstanceProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagInstanceProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagMFADeviceCommand}
    */
-  readonly untagMFADevice: (
-    args: UntagMFADeviceCommandInput,
+  untagMFADevice(
+    args: UntagMFADeviceRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagMFADeviceCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagOpenIDConnectProviderCommand}
    */
-  readonly untagOpenIDConnectProvider: (
-    args: UntagOpenIDConnectProviderCommandInput,
+  untagOpenIDConnectProvider(
+    args: UntagOpenIDConnectProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagOpenIDConnectProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagPolicyCommand}
    */
-  readonly untagPolicy: (
-    args: UntagPolicyCommandInput,
+  untagPolicy(
+    args: UntagPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagRoleCommand}
    */
-  readonly untagRole: (
-    args: UntagRoleCommandInput,
+  untagRole(
+    args: UntagRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagRoleCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagSAMLProviderCommand}
    */
-  readonly untagSAMLProvider: (
-    args: UntagSAMLProviderCommandInput,
+  untagSAMLProvider(
+    args: UntagSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagServerCertificateCommand}
    */
-  readonly untagServerCertificate: (
-    args: UntagServerCertificateCommandInput,
+  untagServerCertificate(
+    args: UntagServerCertificateRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagServerCertificateCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UntagUserCommand}
    */
-  readonly untagUser: (
-    args: UntagUserCommandInput,
+  untagUser(
+    args: UntagUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UntagUserCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateAccessKeyCommand}
    */
-  readonly updateAccessKey: (
-    args: UpdateAccessKeyCommandInput,
+  updateAccessKey(
+    args: UpdateAccessKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateAccessKeyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateAccountPasswordPolicyCommand}
    */
-  readonly updateAccountPasswordPolicy: (
-    args: UpdateAccountPasswordPolicyCommandInput,
+  updateAccountPasswordPolicy(
+    args: UpdateAccountPasswordPolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateAccountPasswordPolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateAssumeRolePolicyCommand}
    */
-  readonly updateAssumeRolePolicy: (
-    args: UpdateAssumeRolePolicyCommandInput,
+  updateAssumeRolePolicy(
+    args: UpdateAssumeRolePolicyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateAssumeRolePolicyCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | MalformedPolicyDocumentError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | LimitExceededException
+    | MalformedPolicyDocumentException
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link UpdateGroupCommand}
    */
-  readonly updateGroup: (
-    args: UpdateGroupCommandInput,
+  updateGroup(
+    args: UpdateGroupRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateGroupCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateLoginProfileCommand}
    */
-  readonly updateLoginProfile: (
-    args: UpdateLoginProfileCommandInput,
+  updateLoginProfile(
+    args: UpdateLoginProfileRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateLoginProfileCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | EntityTemporarilyUnmodifiableError
-    | LimitExceededError
-    | NoSuchEntityError
-    | PasswordPolicyViolationError
-    | ServiceFailureError
+    | EntityTemporarilyUnmodifiableException
+    | LimitExceededException
+    | NoSuchEntityException
+    | PasswordPolicyViolationException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateOpenIDConnectProviderThumbprintCommand}
    */
-  readonly updateOpenIDConnectProviderThumbprint: (
-    args: UpdateOpenIDConnectProviderThumbprintCommandInput,
+  updateOpenIDConnectProviderThumbprint(
+    args: UpdateOpenIDConnectProviderThumbprintRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateOpenIDConnectProviderThumbprintCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateRoleCommand}
    */
-  readonly updateRole: (
-    args: UpdateRoleCommandInput,
+  updateRole(
+    args: UpdateRoleRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateRoleCommandOutput,
+  ): Effect.Effect<
+    UpdateRoleResponse,
     | SdkError
-    | IAMServiceError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link UpdateRoleDescriptionCommand}
    */
-  readonly updateRoleDescription: (
-    args: UpdateRoleDescriptionCommandInput,
+  updateRoleDescription(
+    args: UpdateRoleDescriptionRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateRoleDescriptionCommandOutput,
+  ): Effect.Effect<
+    UpdateRoleDescriptionResponse,
     | SdkError
-    | IAMServiceError
-    | NoSuchEntityError
-    | ServiceFailureError
-    | UnmodifiableEntityError
+    | NoSuchEntityException
+    | ServiceFailureException
+    | UnmodifiableEntityException
   >;
 
   /**
    * @see {@link UpdateSAMLProviderCommand}
    */
-  readonly updateSAMLProvider: (
-    args: UpdateSAMLProviderCommandInput,
+  updateSAMLProvider(
+    args: UpdateSAMLProviderRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateSAMLProviderCommandOutput,
+  ): Effect.Effect<
+    UpdateSAMLProviderResponse,
     | SdkError
-    | IAMServiceError
-    | InvalidInputError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link UpdateServerCertificateCommand}
-   */
-  readonly updateServerCertificate: (
-    args: UpdateServerCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateServerCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | EntityAlreadyExistsError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link UpdateServiceSpecificCredentialCommand}
-   */
-  readonly updateServiceSpecificCredential: (
-    args: UpdateServiceSpecificCredentialCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateServiceSpecificCredentialCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
-  >;
-
-  /**
-   * @see {@link UpdateSigningCertificateCommand}
-   */
-  readonly updateSigningCertificate: (
-    args: UpdateSigningCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateSigningCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | InvalidInputException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateSSHPublicKeyCommand}
    */
-  readonly updateSSHPublicKey: (
-    args: UpdateSSHPublicKeyCommandInput,
+  updateSSHPublicKey(
+    args: UpdateSSHPublicKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateSSHPublicKeyCommandOutput,
-    SdkError | IAMServiceError | NoSuchEntityError
+  ): Effect.Effect<void, SdkError | NoSuchEntityException>;
+
+  /**
+   * @see {@link UpdateServerCertificateCommand}
+   */
+  updateServerCertificate(
+    args: UpdateServerCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    void,
+    | SdkError
+    | EntityAlreadyExistsException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link UpdateServiceSpecificCredentialCommand}
+   */
+  updateServiceSpecificCredential(
+    args: UpdateServiceSpecificCredentialRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<void, SdkError | NoSuchEntityException>;
+
+  /**
+   * @see {@link UpdateSigningCertificateCommand}
+   */
+  updateSigningCertificate(
+    args: UpdateSigningCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    void,
+    | SdkError
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UpdateUserCommand}
    */
-  readonly updateUser: (
-    args: UpdateUserCommandInput,
+  updateUser(
+    args: UpdateUserRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UpdateUserCommandOutput,
+  ): Effect.Effect<
+    void,
     | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | EntityTemporarilyUnmodifiableError
-    | LimitExceededError
-    | NoSuchEntityError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link UploadServerCertificateCommand}
-   */
-  readonly uploadServerCertificate: (
-    args: UploadServerCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UploadServerCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | EntityAlreadyExistsError
-    | InvalidInputError
-    | KeyPairMismatchError
-    | LimitExceededError
-    | MalformedCertificateError
-    | ServiceFailureError
-  >;
-
-  /**
-   * @see {@link UploadSigningCertificateCommand}
-   */
-  readonly uploadSigningCertificate: (
-    args: UploadSigningCertificateCommandInput,
-    options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UploadSigningCertificateCommandOutput,
-    | SdkError
-    | IAMServiceError
-    | ConcurrentModificationError
-    | DuplicateCertificateError
-    | EntityAlreadyExistsError
-    | InvalidCertificateError
-    | LimitExceededError
-    | MalformedCertificateError
-    | NoSuchEntityError
-    | ServiceFailureError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | EntityTemporarilyUnmodifiableException
+    | LimitExceededException
+    | NoSuchEntityException
+    | ServiceFailureException
   >;
 
   /**
    * @see {@link UploadSSHPublicKeyCommand}
    */
-  readonly uploadSSHPublicKey: (
-    args: UploadSSHPublicKeyCommandInput,
+  uploadSSHPublicKey(
+    args: UploadSSHPublicKeyRequest,
     options?: __HttpHandlerOptions,
-  ) => Effect.Effect<
-    UploadSSHPublicKeyCommandOutput,
+  ): Effect.Effect<
+    UploadSSHPublicKeyResponse,
     | SdkError
-    | IAMServiceError
-    | DuplicateSSHPublicKeyError
-    | InvalidPublicKeyError
-    | LimitExceededError
-    | NoSuchEntityError
-    | UnrecognizedPublicKeyEncodingError
+    | DuplicateSSHPublicKeyException
+    | InvalidPublicKeyException
+    | LimitExceededException
+    | NoSuchEntityException
+    | UnrecognizedPublicKeyEncodingException
   >;
-};
+
+  /**
+   * @see {@link UploadServerCertificateCommand}
+   */
+  uploadServerCertificate(
+    args: UploadServerCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    UploadServerCertificateResponse,
+    | SdkError
+    | ConcurrentModificationException
+    | EntityAlreadyExistsException
+    | InvalidInputException
+    | KeyPairMismatchException
+    | LimitExceededException
+    | MalformedCertificateException
+    | ServiceFailureException
+  >;
+
+  /**
+   * @see {@link UploadSigningCertificateCommand}
+   */
+  uploadSigningCertificate(
+    args: UploadSigningCertificateRequest,
+    options?: __HttpHandlerOptions,
+  ): Effect.Effect<
+    UploadSigningCertificateResponse,
+    | SdkError
+    | ConcurrentModificationException
+    | DuplicateCertificateException
+    | EntityAlreadyExistsException
+    | InvalidCertificateException
+    | LimitExceededException
+    | MalformedCertificateException
+    | NoSuchEntityException
+    | ServiceFailureException
+  >;
+}
 
 /**
  * @since 1.0.0
@@ -2995,9 +2774,9 @@ export const makeIAMService = Effect.gen(function* (_) {
       Effect.tryPromise({
         try: () => client.send(new CommandCtor(args), options ?? {}),
         catch: (e) => {
-          if (e instanceof IAMServiceException) {
+          if (e instanceof SdkIAMServiceException) {
             const ServiceException = Data.tagged<
-              TaggedException<IAMServiceException>
+              TaggedException<SdkIAMServiceException>
             >(e.name);
 
             return ServiceException({

--- a/packages/client-iam/test/IAM.test.ts
+++ b/packages/client-iam/test/IAM.test.ts
@@ -1,6 +1,6 @@
 import {
-  type CreateRoleCommandInput,
-  CreateRoleCommand,
+  type ListGroupsCommandInput,
+  ListGroupsCommand,
   IAMClient,
 } from "@aws-sdk/client-iam";
 import { mockClient } from "aws-sdk-client-mock";
@@ -25,12 +25,12 @@ const clientMock = mockClient(IAMClient);
 
 describe("IAMClientImpl", () => {
   it("default", async () => {
-    clientMock.reset().on(CreateRoleCommand).resolves({});
+    clientMock.reset().on(ListGroupsCommand).resolves({});
 
-    const args = {} as unknown as CreateRoleCommandInput;
+    const args: ListGroupsCommandInput = { PathPrefix: "admin/" };
 
     const program = Effect.flatMap(IAMService, (service) =>
-      service.createRole(args),
+      service.listGroups(args),
     );
 
     const result = await pipe(
@@ -40,17 +40,17 @@ describe("IAMClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(CreateRoleCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(CreateRoleCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(ListGroupsCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(ListGroupsCommand, args);
   });
 
   it("configurable", async () => {
-    clientMock.reset().on(CreateRoleCommand).resolves({});
+    clientMock.reset().on(ListGroupsCommand).resolves({});
 
-    const args = {} as unknown as CreateRoleCommandInput;
+    const args: ListGroupsCommandInput = { PathPrefix: "admin/" };
 
     const program = Effect.flatMap(IAMService, (service) =>
-      service.createRole(args),
+      service.listGroups(args),
     );
 
     const IAMClientConfigLayer = Layer.succeed(IAMClientInstanceConfig, {
@@ -67,17 +67,17 @@ describe("IAMClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(CreateRoleCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(CreateRoleCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(ListGroupsCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(ListGroupsCommand, args);
   });
 
   it("base", async () => {
-    clientMock.reset().on(CreateRoleCommand).resolves({});
+    clientMock.reset().on(ListGroupsCommand).resolves({});
 
-    const args = {} as unknown as CreateRoleCommandInput;
+    const args: ListGroupsCommandInput = { PathPrefix: "admin/" };
 
     const program = Effect.flatMap(IAMService, (service) =>
-      service.createRole(args),
+      service.listGroups(args),
     );
 
     const IAMClientInstanceLayer = Layer.succeed(
@@ -95,17 +95,17 @@ describe("IAMClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(CreateRoleCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(CreateRoleCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(ListGroupsCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(ListGroupsCommand, args);
   });
 
   it("extended", async () => {
-    clientMock.reset().on(CreateRoleCommand).resolves({});
+    clientMock.reset().on(ListGroupsCommand).resolves({});
 
-    const args = {} as unknown as CreateRoleCommandInput;
+    const args: ListGroupsCommandInput = { PathPrefix: "admin/" };
 
     const program = Effect.flatMap(IAMService, (service) =>
-      service.createRole(args),
+      service.listGroups(args),
     );
 
     const IAMClientInstanceLayer = Layer.effect(
@@ -127,17 +127,17 @@ describe("IAMClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(clientMock).toHaveReceivedCommandTimes(CreateRoleCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(CreateRoleCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(ListGroupsCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(ListGroupsCommand, args);
   });
 
   it("fail", async () => {
-    clientMock.reset().on(CreateRoleCommand).rejects(new Error("test"));
+    clientMock.reset().on(ListGroupsCommand).rejects(new Error("test"));
 
-    const args = {} as unknown as CreateRoleCommandInput;
+    const args: ListGroupsCommandInput = { PathPrefix: "admin/" };
 
     const program = Effect.flatMap(IAMService, (service) =>
-      service.createRole(args),
+      service.listGroups(args),
     );
 
     const result = await pipe(
@@ -156,7 +156,7 @@ describe("IAMClientImpl", () => {
         }),
       ),
     );
-    expect(clientMock).toHaveReceivedCommandTimes(CreateRoleCommand, 1);
-    expect(clientMock).toHaveReceivedCommandWith(CreateRoleCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(ListGroupsCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(ListGroupsCommand, args);
   });
 });

--- a/packages/client-lambda/.projen/deps.json
+++ b/packages/client-lambda/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-lambda",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-lambda/package.json
+++ b/packages/client-lambda/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-lambda": "^3",
+    "@aws-sdk/client-lambda": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-s3/.projen/deps.json
+++ b/packages/client-s3/.projen/deps.json
@@ -70,12 +70,12 @@
     },
     {
       "name": "@aws-sdk/client-s3",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {
       "name": "@aws-sdk/s3-request-presigner",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-s3/package.json
+++ b/packages/client-s3/package.json
@@ -39,8 +39,8 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3",
-    "@aws-sdk/s3-request-presigner": "^3",
+    "@aws-sdk/client-s3": "^3.556.0",
+    "@aws-sdk/s3-request-presigner": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-sfn/.projen/deps.json
+++ b/packages/client-sfn/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-sfn",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-sfn/package.json
+++ b/packages/client-sfn/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-sfn": "^3",
+    "@aws-sdk/client-sfn": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-sns/.projen/deps.json
+++ b/packages/client-sns/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-sns",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-sns/package.json
+++ b/packages/client-sns/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-sns": "^3",
+    "@aws-sdk/client-sns": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/client-sns/src/Errors.ts
+++ b/packages/client-sns/src/Errors.ts
@@ -1,36 +1,38 @@
 import type {
-  AuthorizationErrorException,
-  BatchEntryIdsNotDistinctException,
-  BatchRequestTooLongException,
-  ConcurrentAccessException,
-  EmptyBatchRequestException,
-  EndpointDisabledException,
-  FilterPolicyLimitExceededException,
-  InternalErrorException,
-  InvalidBatchEntryIdException,
-  InvalidParameterException,
-  InvalidParameterValueException,
-  InvalidSecurityException,
-  KMSAccessDeniedException,
-  KMSDisabledException,
-  KMSInvalidStateException,
-  KMSNotFoundException,
-  KMSOptInRequired,
-  KMSThrottlingException,
-  NotFoundException,
-  OptedOutException,
-  PlatformApplicationDisabledException,
-  ResourceNotFoundException,
-  StaleTagException,
-  SubscriptionLimitExceededException,
-  TagLimitExceededException,
-  TagPolicyException,
-  ThrottledException,
-  TooManyEntriesInBatchRequestException,
-  TopicLimitExceededException,
-  UserErrorException,
-  ValidationException,
-  VerificationException,
+  AuthorizationErrorException as SdkAuthorizationErrorException,
+  BatchEntryIdsNotDistinctException as SdkBatchEntryIdsNotDistinctException,
+  BatchRequestTooLongException as SdkBatchRequestTooLongException,
+  ConcurrentAccessException as SdkConcurrentAccessException,
+  EmptyBatchRequestException as SdkEmptyBatchRequestException,
+  EndpointDisabledException as SdkEndpointDisabledException,
+  FilterPolicyLimitExceededException as SdkFilterPolicyLimitExceededException,
+  InternalErrorException as SdkInternalErrorException,
+  InvalidBatchEntryIdException as SdkInvalidBatchEntryIdException,
+  InvalidParameterException as SdkInvalidParameterException,
+  InvalidParameterValueException as SdkInvalidParameterValueException,
+  InvalidSecurityException as SdkInvalidSecurityException,
+  InvalidStateException as SdkInvalidStateException,
+  KMSAccessDeniedException as SdkKMSAccessDeniedException,
+  KMSDisabledException as SdkKMSDisabledException,
+  KMSInvalidStateException as SdkKMSInvalidStateException,
+  KMSNotFoundException as SdkKMSNotFoundException,
+  KMSOptInRequired as SdkKMSOptInRequired,
+  KMSThrottlingException as SdkKMSThrottlingException,
+  NotFoundException as SdkNotFoundException,
+  OptedOutException as SdkOptedOutException,
+  PlatformApplicationDisabledException as SdkPlatformApplicationDisabledException,
+  ReplayLimitExceededException as SdkReplayLimitExceededException,
+  ResourceNotFoundException as SdkResourceNotFoundException,
+  StaleTagException as SdkStaleTagException,
+  SubscriptionLimitExceededException as SdkSubscriptionLimitExceededException,
+  TagLimitExceededException as SdkTagLimitExceededException,
+  TagPolicyException as SdkTagPolicyException,
+  ThrottledException as SdkThrottledException,
+  TooManyEntriesInBatchRequestException as SdkTooManyEntriesInBatchRequestException,
+  TopicLimitExceededException as SdkTopicLimitExceededException,
+  UserErrorException as SdkUserErrorException,
+  ValidationException as SdkValidationException,
+  VerificationException as SdkVerificationException,
 } from "@aws-sdk/client-sns";
 import * as Data from "effect/Data";
 
@@ -38,47 +40,60 @@ export type TaggedException<T extends { name: string }> = T & {
   readonly _tag: T["name"];
 };
 
-export type AuthorizationError = TaggedException<AuthorizationErrorException>;
-export type BatchEntryIdsNotDistinctError =
-  TaggedException<BatchEntryIdsNotDistinctException>;
-export type BatchRequestTooLongError =
-  TaggedException<BatchRequestTooLongException>;
-export type ConcurrentAccessError = TaggedException<ConcurrentAccessException>;
-export type EmptyBatchRequestError =
-  TaggedException<EmptyBatchRequestException>;
-export type EndpointDisabledError = TaggedException<EndpointDisabledException>;
-export type FilterPolicyLimitExceededError =
-  TaggedException<FilterPolicyLimitExceededException>;
-export type InternalError = TaggedException<InternalErrorException>;
-export type InvalidBatchEntryIdError =
-  TaggedException<InvalidBatchEntryIdException>;
-export type InvalidParameterError = TaggedException<InvalidParameterException>;
-export type InvalidParameterValueError =
-  TaggedException<InvalidParameterValueException>;
-export type InvalidSecurityError = TaggedException<InvalidSecurityException>;
-export type KMSAccessDeniedError = TaggedException<KMSAccessDeniedException>;
-export type KMSDisabledError = TaggedException<KMSDisabledException>;
-export type KMSInvalidStateError = TaggedException<KMSInvalidStateException>;
-export type KMSNotFoundError = TaggedException<KMSNotFoundException>;
-export type KMSOptInRequiredError = TaggedException<KMSOptInRequired>;
-export type KMSThrottlingError = TaggedException<KMSThrottlingException>;
-export type NotFoundError = TaggedException<NotFoundException>;
-export type OptedOutError = TaggedException<OptedOutException>;
-export type PlatformApplicationDisabledError =
-  TaggedException<PlatformApplicationDisabledException>;
-export type ResourceNotFoundError = TaggedException<ResourceNotFoundException>;
-export type StaleTagError = TaggedException<StaleTagException>;
-export type SubscriptionLimitExceededError =
-  TaggedException<SubscriptionLimitExceededException>;
-export type TagLimitExceededError = TaggedException<TagLimitExceededException>;
-export type TagPolicyError = TaggedException<TagPolicyException>;
-export type ThrottledError = TaggedException<ThrottledException>;
-export type TooManyEntriesInBatchRequestError =
-  TaggedException<TooManyEntriesInBatchRequestException>;
-export type TopicLimitExceededError =
-  TaggedException<TopicLimitExceededException>;
-export type UserError = TaggedException<UserErrorException>;
-export type ValidationError = TaggedException<ValidationException>;
-export type VerificationError = TaggedException<VerificationException>;
+export type AuthorizationErrorException =
+  TaggedException<SdkAuthorizationErrorException>;
+export type BatchEntryIdsNotDistinctException =
+  TaggedException<SdkBatchEntryIdsNotDistinctException>;
+export type BatchRequestTooLongException =
+  TaggedException<SdkBatchRequestTooLongException>;
+export type ConcurrentAccessException =
+  TaggedException<SdkConcurrentAccessException>;
+export type EmptyBatchRequestException =
+  TaggedException<SdkEmptyBatchRequestException>;
+export type EndpointDisabledException =
+  TaggedException<SdkEndpointDisabledException>;
+export type FilterPolicyLimitExceededException =
+  TaggedException<SdkFilterPolicyLimitExceededException>;
+export type InternalErrorException = TaggedException<SdkInternalErrorException>;
+export type InvalidBatchEntryIdException =
+  TaggedException<SdkInvalidBatchEntryIdException>;
+export type InvalidParameterException =
+  TaggedException<SdkInvalidParameterException>;
+export type InvalidParameterValueException =
+  TaggedException<SdkInvalidParameterValueException>;
+export type InvalidSecurityException =
+  TaggedException<SdkInvalidSecurityException>;
+export type InvalidStateException = TaggedException<SdkInvalidStateException>;
+export type KMSAccessDeniedException =
+  TaggedException<SdkKMSAccessDeniedException>;
+export type KMSDisabledException = TaggedException<SdkKMSDisabledException>;
+export type KMSInvalidStateException =
+  TaggedException<SdkKMSInvalidStateException>;
+export type KMSNotFoundException = TaggedException<SdkKMSNotFoundException>;
+export type KMSOptInRequired = TaggedException<SdkKMSOptInRequired>;
+export type KMSThrottlingException = TaggedException<SdkKMSThrottlingException>;
+export type NotFoundException = TaggedException<SdkNotFoundException>;
+export type OptedOutException = TaggedException<SdkOptedOutException>;
+export type PlatformApplicationDisabledException =
+  TaggedException<SdkPlatformApplicationDisabledException>;
+export type ReplayLimitExceededException =
+  TaggedException<SdkReplayLimitExceededException>;
+export type ResourceNotFoundException =
+  TaggedException<SdkResourceNotFoundException>;
+export type StaleTagException = TaggedException<SdkStaleTagException>;
+export type SubscriptionLimitExceededException =
+  TaggedException<SdkSubscriptionLimitExceededException>;
+export type TagLimitExceededException =
+  TaggedException<SdkTagLimitExceededException>;
+export type TagPolicyException = TaggedException<SdkTagPolicyException>;
+export type ThrottledException = TaggedException<SdkThrottledException>;
+export type TooManyEntriesInBatchRequestException =
+  TaggedException<SdkTooManyEntriesInBatchRequestException>;
+export type TopicLimitExceededException =
+  TaggedException<SdkTopicLimitExceededException>;
+export type UserErrorException = TaggedException<SdkUserErrorException>;
+export type ValidationException = TaggedException<SdkValidationException>;
+export type VerificationException = TaggedException<SdkVerificationException>;
+
 export type SdkError = TaggedException<Error & { name: "SdkError" }>;
 export const SdkError = Data.tagged<SdkError>("SdkError");

--- a/packages/client-sns/src/SNSClientInstanceConfig.ts
+++ b/packages/client-sns/src/SNSClientInstanceConfig.ts
@@ -26,11 +26,21 @@ export const makeDefaultSNSClientInstanceConfig: Effect.Effect<SNSClientConfig> 
 
     return {
       logger: {
-        info: (m) => Effect.logInfo(m).pipe(runSync),
-        warn: (m) => Effect.logWarning(m).pipe(runSync),
-        error: (m) => Effect.logError(m).pipe(runSync),
-        debug: (m) => Effect.logDebug(m).pipe(runSync),
-        trace: (m) => Effect.logTrace(m).pipe(runSync),
+        info(m) {
+          Effect.logInfo(m).pipe(runSync);
+        },
+        warn(m) {
+          Effect.logWarning(m).pipe(runSync);
+        },
+        error(m) {
+          Effect.logError(m).pipe(runSync);
+        },
+        debug(m) {
+          Effect.logDebug(m).pipe(runSync);
+        },
+        trace(m) {
+          Effect.logTrace(m).pipe(runSync);
+        },
       },
     };
   });

--- a/packages/client-sns/src/SNSService.ts
+++ b/packages/client-sns/src/SNSService.ts
@@ -2,171 +2,162 @@
  * @since 1.0.0
  */
 import {
+  SNSServiceException as SdkSNSServiceException,
   AddPermissionCommand,
-  AddPermissionCommandInput,
-  AddPermissionCommandOutput,
   CheckIfPhoneNumberIsOptedOutCommand,
-  CheckIfPhoneNumberIsOptedOutCommandInput,
-  CheckIfPhoneNumberIsOptedOutCommandOutput,
   ConfirmSubscriptionCommand,
-  ConfirmSubscriptionCommandInput,
-  ConfirmSubscriptionCommandOutput,
   CreatePlatformApplicationCommand,
-  CreatePlatformApplicationCommandInput,
-  CreatePlatformApplicationCommandOutput,
   CreatePlatformEndpointCommand,
-  CreatePlatformEndpointCommandInput,
-  CreatePlatformEndpointCommandOutput,
   CreateSMSSandboxPhoneNumberCommand,
-  CreateSMSSandboxPhoneNumberCommandInput,
-  CreateSMSSandboxPhoneNumberCommandOutput,
   CreateTopicCommand,
-  CreateTopicCommandInput,
-  CreateTopicCommandOutput,
   DeleteEndpointCommand,
-  DeleteEndpointCommandInput,
-  DeleteEndpointCommandOutput,
   DeletePlatformApplicationCommand,
-  DeletePlatformApplicationCommandInput,
-  DeletePlatformApplicationCommandOutput,
   DeleteSMSSandboxPhoneNumberCommand,
-  DeleteSMSSandboxPhoneNumberCommandInput,
-  DeleteSMSSandboxPhoneNumberCommandOutput,
   DeleteTopicCommand,
-  DeleteTopicCommandInput,
-  DeleteTopicCommandOutput,
   GetDataProtectionPolicyCommand,
-  GetDataProtectionPolicyCommandInput,
-  GetDataProtectionPolicyCommandOutput,
   GetEndpointAttributesCommand,
-  GetEndpointAttributesCommandInput,
-  GetEndpointAttributesCommandOutput,
   GetPlatformApplicationAttributesCommand,
-  GetPlatformApplicationAttributesCommandInput,
-  GetPlatformApplicationAttributesCommandOutput,
   GetSMSAttributesCommand,
-  GetSMSAttributesCommandInput,
-  GetSMSAttributesCommandOutput,
   GetSMSSandboxAccountStatusCommand,
-  GetSMSSandboxAccountStatusCommandInput,
-  GetSMSSandboxAccountStatusCommandOutput,
   GetSubscriptionAttributesCommand,
-  GetSubscriptionAttributesCommandInput,
-  GetSubscriptionAttributesCommandOutput,
   GetTopicAttributesCommand,
-  GetTopicAttributesCommandInput,
-  GetTopicAttributesCommandOutput,
   ListEndpointsByPlatformApplicationCommand,
-  ListEndpointsByPlatformApplicationCommandInput,
-  ListEndpointsByPlatformApplicationCommandOutput,
   ListOriginationNumbersCommand,
-  ListOriginationNumbersCommandInput,
-  ListOriginationNumbersCommandOutput,
   ListPhoneNumbersOptedOutCommand,
-  ListPhoneNumbersOptedOutCommandInput,
-  ListPhoneNumbersOptedOutCommandOutput,
   ListPlatformApplicationsCommand,
-  ListPlatformApplicationsCommandInput,
-  ListPlatformApplicationsCommandOutput,
   ListSMSSandboxPhoneNumbersCommand,
-  ListSMSSandboxPhoneNumbersCommandInput,
-  ListSMSSandboxPhoneNumbersCommandOutput,
-  ListSubscriptionsByTopicCommand,
-  ListSubscriptionsByTopicCommandInput,
-  ListSubscriptionsByTopicCommandOutput,
   ListSubscriptionsCommand,
-  ListSubscriptionsCommandInput,
-  ListSubscriptionsCommandOutput,
+  ListSubscriptionsByTopicCommand,
   ListTagsForResourceCommand,
-  ListTagsForResourceCommandInput,
-  ListTagsForResourceCommandOutput,
   ListTopicsCommand,
-  ListTopicsCommandInput,
-  ListTopicsCommandOutput,
   OptInPhoneNumberCommand,
-  OptInPhoneNumberCommandInput,
-  OptInPhoneNumberCommandOutput,
-  PublishBatchCommand,
-  PublishBatchCommandInput,
-  PublishBatchCommandOutput,
   PublishCommand,
-  PublishCommandInput,
-  PublishCommandOutput,
+  PublishBatchCommand,
   PutDataProtectionPolicyCommand,
-  PutDataProtectionPolicyCommandInput,
-  PutDataProtectionPolicyCommandOutput,
   RemovePermissionCommand,
-  RemovePermissionCommandInput,
-  RemovePermissionCommandOutput,
-  SNSServiceException,
   SetEndpointAttributesCommand,
-  SetEndpointAttributesCommandInput,
-  SetEndpointAttributesCommandOutput,
   SetPlatformApplicationAttributesCommand,
-  SetPlatformApplicationAttributesCommandInput,
-  SetPlatformApplicationAttributesCommandOutput,
   SetSMSAttributesCommand,
-  SetSMSAttributesCommandInput,
-  SetSMSAttributesCommandOutput,
   SetSubscriptionAttributesCommand,
-  SetSubscriptionAttributesCommandInput,
-  SetSubscriptionAttributesCommandOutput,
   SetTopicAttributesCommand,
-  SetTopicAttributesCommandInput,
-  SetTopicAttributesCommandOutput,
   SubscribeCommand,
-  SubscribeCommandInput,
-  SubscribeCommandOutput,
   TagResourceCommand,
-  TagResourceCommandInput,
-  TagResourceCommandOutput,
   UnsubscribeCommand,
-  UnsubscribeCommandInput,
-  UnsubscribeCommandOutput,
   UntagResourceCommand,
-  UntagResourceCommandInput,
-  UntagResourceCommandOutput,
   VerifySMSSandboxPhoneNumberCommand,
-  VerifySMSSandboxPhoneNumberCommandInput,
-  VerifySMSSandboxPhoneNumberCommandOutput,
+  type AddPermissionInput,
+  type CheckIfPhoneNumberIsOptedOutInput,
+  type CheckIfPhoneNumberIsOptedOutResponse,
+  type ConfirmSubscriptionInput,
+  type ConfirmSubscriptionResponse,
+  type CreatePlatformApplicationInput,
+  type CreatePlatformApplicationResponse,
+  type CreatePlatformEndpointInput,
+  type CreateEndpointResponse,
+  type CreateSMSSandboxPhoneNumberInput,
+  type CreateSMSSandboxPhoneNumberResult,
+  type CreateTopicInput,
+  type CreateTopicResponse,
+  type DeleteEndpointInput,
+  type DeletePlatformApplicationInput,
+  type DeleteSMSSandboxPhoneNumberInput,
+  type DeleteSMSSandboxPhoneNumberResult,
+  type DeleteTopicInput,
+  type GetDataProtectionPolicyInput,
+  type GetDataProtectionPolicyResponse,
+  type GetEndpointAttributesInput,
+  type GetEndpointAttributesResponse,
+  type GetPlatformApplicationAttributesInput,
+  type GetPlatformApplicationAttributesResponse,
+  type GetSMSAttributesInput,
+  type GetSMSAttributesResponse,
+  type GetSMSSandboxAccountStatusInput,
+  type GetSMSSandboxAccountStatusResult,
+  type GetSubscriptionAttributesInput,
+  type GetSubscriptionAttributesResponse,
+  type GetTopicAttributesInput,
+  type GetTopicAttributesResponse,
+  type ListEndpointsByPlatformApplicationInput,
+  type ListEndpointsByPlatformApplicationResponse,
+  type ListOriginationNumbersRequest,
+  type ListOriginationNumbersResult,
+  type ListPhoneNumbersOptedOutInput,
+  type ListPhoneNumbersOptedOutResponse,
+  type ListPlatformApplicationsInput,
+  type ListPlatformApplicationsResponse,
+  type ListSMSSandboxPhoneNumbersInput,
+  type ListSMSSandboxPhoneNumbersResult,
+  type ListSubscriptionsInput,
+  type ListSubscriptionsResponse,
+  type ListSubscriptionsByTopicInput,
+  type ListSubscriptionsByTopicResponse,
+  type ListTagsForResourceRequest,
+  type ListTagsForResourceResponse,
+  type ListTopicsInput,
+  type ListTopicsResponse,
+  type OptInPhoneNumberInput,
+  type OptInPhoneNumberResponse,
+  type PublishInput,
+  type PublishResponse,
+  type PublishBatchInput,
+  type PublishBatchResponse,
+  type PutDataProtectionPolicyInput,
+  type RemovePermissionInput,
+  type SetEndpointAttributesInput,
+  type SetPlatformApplicationAttributesInput,
+  type SetSMSAttributesInput,
+  type SetSMSAttributesResponse,
+  type SetSubscriptionAttributesInput,
+  type SetTopicAttributesInput,
+  type SubscribeInput,
+  type SubscribeResponse,
+  type TagResourceRequest,
+  type TagResourceResponse,
+  type UnsubscribeInput,
+  type UntagResourceRequest,
+  type UntagResourceResponse,
+  type VerifySMSSandboxPhoneNumberInput,
+  type VerifySMSSandboxPhoneNumberResult,
 } from "@aws-sdk/client-sns";
-import { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
+import type { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
 import { Context, Data, Effect, Layer, Record } from "effect";
 import {
-  AuthorizationError,
-  BatchEntryIdsNotDistinctError,
-  BatchRequestTooLongError,
-  ConcurrentAccessError,
-  EmptyBatchRequestError,
-  EndpointDisabledError,
-  FilterPolicyLimitExceededError,
-  InternalError,
-  InvalidBatchEntryIdError,
-  InvalidParameterError,
-  InvalidParameterValueError,
-  InvalidSecurityError,
-  KMSAccessDeniedError,
-  KMSDisabledError,
-  KMSInvalidStateError,
-  KMSNotFoundError,
-  KMSOptInRequiredError,
-  KMSThrottlingError,
-  NotFoundError,
-  OptedOutError,
-  PlatformApplicationDisabledError,
-  ResourceNotFoundError,
+  type AuthorizationErrorException,
+  type InternalErrorException,
+  type InvalidParameterException,
+  type NotFoundException,
+  type ThrottledException,
+  type FilterPolicyLimitExceededException,
+  type ReplayLimitExceededException,
+  type SubscriptionLimitExceededException,
+  type OptedOutException,
+  type UserErrorException,
+  type ConcurrentAccessException,
+  type InvalidSecurityException,
+  type StaleTagException,
+  type TagLimitExceededException,
+  type TagPolicyException,
+  type TopicLimitExceededException,
+  type ResourceNotFoundException,
+  type InvalidStateException,
+  type ValidationException,
+  type EndpointDisabledException,
+  type InvalidParameterValueException,
+  type KMSAccessDeniedException,
+  type KMSDisabledException,
+  type KMSInvalidStateException,
+  type KMSNotFoundException,
+  type KMSOptInRequired,
+  type KMSThrottlingException,
+  type PlatformApplicationDisabledException,
+  type BatchEntryIdsNotDistinctException,
+  type BatchRequestTooLongException,
+  type EmptyBatchRequestException,
+  type InvalidBatchEntryIdException,
+  type TooManyEntriesInBatchRequestException,
+  type VerificationException,
+  type TaggedException,
   SdkError,
-  StaleTagError,
-  SubscriptionLimitExceededError,
-  TagLimitExceededError,
-  TagPolicyError,
-  TaggedException,
-  ThrottledError,
-  TooManyEntriesInBatchRequestError,
-  TopicLimitExceededError,
-  UserError,
-  ValidationError,
-  VerificationError,
 } from "./Errors";
 import { SNSClientInstance, SNSClientInstanceLayer } from "./SNSClientInstance";
 import { DefaultSNSClientConfigLayer } from "./SNSClientInstanceConfig";
@@ -227,663 +218,688 @@ export interface SNSService {
    * @see {@link AddPermissionCommand}
    */
   addPermission(
-    args: AddPermissionCommandInput,
+    args: AddPermissionInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    AddPermissionCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link CheckIfPhoneNumberIsOptedOutCommand}
    */
   checkIfPhoneNumberIsOptedOut(
-    args: CheckIfPhoneNumberIsOptedOutCommandInput,
+    args: CheckIfPhoneNumberIsOptedOutInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    CheckIfPhoneNumberIsOptedOutCommandOutput,
+    CheckIfPhoneNumberIsOptedOutResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
   >;
 
   /**
    * @see {@link ConfirmSubscriptionCommand}
    */
   confirmSubscription(
-    args: ConfirmSubscriptionCommandInput,
+    args: ConfirmSubscriptionInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ConfirmSubscriptionCommandOutput,
+    ConfirmSubscriptionResponse,
     | SdkError
-    | AuthorizationError
-    | FilterPolicyLimitExceededError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
-    | SubscriptionLimitExceededError
+    | AuthorizationErrorException
+    | FilterPolicyLimitExceededException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
+    | ReplayLimitExceededException
+    | SubscriptionLimitExceededException
   >;
 
   /**
    * @see {@link CreatePlatformApplicationCommand}
    */
   createPlatformApplication(
-    args: CreatePlatformApplicationCommandInput,
+    args: CreatePlatformApplicationInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    CreatePlatformApplicationCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    CreatePlatformApplicationResponse,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link CreatePlatformEndpointCommand}
    */
   createPlatformEndpoint(
-    args: CreatePlatformEndpointCommandInput,
+    args: CreatePlatformEndpointInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    CreatePlatformEndpointCommandOutput,
+    CreateEndpointResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link CreateSMSSandboxPhoneNumberCommand}
    */
   createSMSSandboxPhoneNumber(
-    args: CreateSMSSandboxPhoneNumberCommandInput,
+    args: CreateSMSSandboxPhoneNumberInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    CreateSMSSandboxPhoneNumberCommandOutput,
+    CreateSMSSandboxPhoneNumberResult,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | OptedOutError
-    | ThrottledError
-    | UserError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | OptedOutException
+    | ThrottledException
+    | UserErrorException
   >;
 
   /**
    * @see {@link CreateTopicCommand}
    */
   createTopic(
-    args: CreateTopicCommandInput,
+    args: CreateTopicInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    CreateTopicCommandOutput,
+    CreateTopicResponse,
     | SdkError
-    | AuthorizationError
-    | ConcurrentAccessError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | StaleTagError
-    | TagLimitExceededError
-    | TagPolicyError
-    | TopicLimitExceededError
+    | AuthorizationErrorException
+    | ConcurrentAccessException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | StaleTagException
+    | TagLimitExceededException
+    | TagPolicyException
+    | TopicLimitExceededException
   >;
 
   /**
    * @see {@link DeleteEndpointCommand}
    */
   deleteEndpoint(
-    args: DeleteEndpointCommandInput,
+    args: DeleteEndpointInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    DeleteEndpointCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    void,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link DeletePlatformApplicationCommand}
    */
   deletePlatformApplication(
-    args: DeletePlatformApplicationCommandInput,
+    args: DeletePlatformApplicationInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    DeletePlatformApplicationCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    void,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link DeleteSMSSandboxPhoneNumberCommand}
    */
   deleteSMSSandboxPhoneNumber(
-    args: DeleteSMSSandboxPhoneNumberCommandInput,
+    args: DeleteSMSSandboxPhoneNumberInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    DeleteSMSSandboxPhoneNumberCommandOutput,
+    DeleteSMSSandboxPhoneNumberResult,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | ThrottledError
-    | UserError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | ThrottledException
+    | UserErrorException
   >;
 
   /**
    * @see {@link DeleteTopicCommand}
    */
   deleteTopic(
-    args: DeleteTopicCommandInput,
+    args: DeleteTopicInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    DeleteTopicCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | ConcurrentAccessError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
-    | StaleTagError
-    | TagPolicyError
+    | AuthorizationErrorException
+    | ConcurrentAccessException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidStateException
+    | NotFoundException
+    | StaleTagException
+    | TagPolicyException
   >;
 
   /**
    * @see {@link GetDataProtectionPolicyCommand}
    */
   getDataProtectionPolicy(
-    args: GetDataProtectionPolicyCommandInput,
+    args: GetDataProtectionPolicyInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetDataProtectionPolicyCommandOutput,
+    GetDataProtectionPolicyResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
   >;
 
   /**
    * @see {@link GetEndpointAttributesCommand}
    */
   getEndpointAttributes(
-    args: GetEndpointAttributesCommandInput,
+    args: GetEndpointAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetEndpointAttributesCommandOutput,
+    GetEndpointAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link GetPlatformApplicationAttributesCommand}
    */
   getPlatformApplicationAttributes(
-    args: GetPlatformApplicationAttributesCommandInput,
+    args: GetPlatformApplicationAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetPlatformApplicationAttributesCommandOutput,
+    GetPlatformApplicationAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link GetSMSAttributesCommand}
    */
   getSMSAttributes(
-    args: GetSMSAttributesCommandInput,
+    args: GetSMSAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetSMSAttributesCommandOutput,
+    GetSMSAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
   >;
 
   /**
    * @see {@link GetSMSSandboxAccountStatusCommand}
    */
   getSMSSandboxAccountStatus(
-    args: GetSMSSandboxAccountStatusCommandInput,
+    args: GetSMSSandboxAccountStatusInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetSMSSandboxAccountStatusCommandOutput,
-    SdkError | AuthorizationError | InternalError | ThrottledError
+    GetSMSSandboxAccountStatusResult,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | ThrottledException
   >;
 
   /**
    * @see {@link GetSubscriptionAttributesCommand}
    */
   getSubscriptionAttributes(
-    args: GetSubscriptionAttributesCommandInput,
+    args: GetSubscriptionAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetSubscriptionAttributesCommandOutput,
+    GetSubscriptionAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link GetTopicAttributesCommand}
    */
   getTopicAttributes(
-    args: GetTopicAttributesCommandInput,
+    args: GetTopicAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    GetTopicAttributesCommandOutput,
+    GetTopicAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
   >;
 
   /**
    * @see {@link ListEndpointsByPlatformApplicationCommand}
    */
   listEndpointsByPlatformApplication(
-    args: ListEndpointsByPlatformApplicationCommandInput,
+    args: ListEndpointsByPlatformApplicationInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListEndpointsByPlatformApplicationCommandOutput,
+    ListEndpointsByPlatformApplicationResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link ListOriginationNumbersCommand}
    */
   listOriginationNumbers(
-    args: ListOriginationNumbersCommandInput,
+    args: ListOriginationNumbersRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListOriginationNumbersCommandOutput,
+    ListOriginationNumbersResult,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
-    | ValidationError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
+    | ValidationException
   >;
 
   /**
    * @see {@link ListPhoneNumbersOptedOutCommand}
    */
   listPhoneNumbersOptedOut(
-    args: ListPhoneNumbersOptedOutCommandInput,
+    args: ListPhoneNumbersOptedOutInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListPhoneNumbersOptedOutCommandOutput,
+    ListPhoneNumbersOptedOutResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
   >;
 
   /**
    * @see {@link ListPlatformApplicationsCommand}
    */
   listPlatformApplications(
-    args: ListPlatformApplicationsCommandInput,
+    args: ListPlatformApplicationsInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListPlatformApplicationsCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    ListPlatformApplicationsResponse,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link ListSMSSandboxPhoneNumbersCommand}
    */
   listSMSSandboxPhoneNumbers(
-    args: ListSMSSandboxPhoneNumbersCommandInput,
+    args: ListSMSSandboxPhoneNumbersInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListSMSSandboxPhoneNumbersCommandOutput,
+    ListSMSSandboxPhoneNumbersResult,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | ThrottledException
   >;
 
   /**
    * @see {@link ListSubscriptionsCommand}
    */
   listSubscriptions(
-    args: ListSubscriptionsCommandInput,
+    args: ListSubscriptionsInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListSubscriptionsCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    ListSubscriptionsResponse,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link ListSubscriptionsByTopicCommand}
    */
   listSubscriptionsByTopic(
-    args: ListSubscriptionsByTopicCommandInput,
+    args: ListSubscriptionsByTopicInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListSubscriptionsByTopicCommandOutput,
+    ListSubscriptionsByTopicResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link ListTagsForResourceCommand}
    */
   listTagsForResource(
-    args: ListTagsForResourceCommandInput,
+    args: ListTagsForResourceRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListTagsForResourceCommandOutput,
+    ListTagsForResourceResponse,
     | SdkError
-    | AuthorizationError
-    | ConcurrentAccessError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | TagPolicyError
+    | AuthorizationErrorException
+    | ConcurrentAccessException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | TagPolicyException
   >;
 
   /**
    * @see {@link ListTopicsCommand}
    */
   listTopics(
-    args: ListTopicsCommandInput,
+    args: ListTopicsInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    ListTopicsCommandOutput,
-    SdkError | AuthorizationError | InternalError | InvalidParameterError
+    ListTopicsResponse,
+    | SdkError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
   >;
 
   /**
    * @see {@link OptInPhoneNumberCommand}
    */
   optInPhoneNumber(
-    args: OptInPhoneNumberCommandInput,
+    args: OptInPhoneNumberInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    OptInPhoneNumberCommandOutput,
+    OptInPhoneNumberResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
   >;
 
   /**
    * @see {@link PublishCommand}
    */
   publish(
-    args: PublishCommandInput,
+    args: PublishInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    PublishCommandOutput,
+    PublishResponse,
     | SdkError
-    | AuthorizationError
-    | EndpointDisabledError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | KMSAccessDeniedError
-    | KMSDisabledError
-    | KMSInvalidStateError
-    | KMSNotFoundError
-    | KMSOptInRequiredError
-    | KMSThrottlingError
-    | NotFoundError
-    | InvalidParameterValueError
-    | PlatformApplicationDisabledError
-    | ValidationError
+    | AuthorizationErrorException
+    | EndpointDisabledException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidParameterValueException
+    | InvalidSecurityException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | KMSOptInRequired
+    | KMSThrottlingException
+    | NotFoundException
+    | PlatformApplicationDisabledException
+    | ValidationException
   >;
 
   /**
    * @see {@link PublishBatchCommand}
    */
   publishBatch(
-    args: PublishBatchCommandInput,
+    args: PublishBatchInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    PublishBatchCommandOutput,
+    PublishBatchResponse,
     | SdkError
-    | AuthorizationError
-    | BatchEntryIdsNotDistinctError
-    | BatchRequestTooLongError
-    | EmptyBatchRequestError
-    | EndpointDisabledError
-    | InternalError
-    | InvalidBatchEntryIdError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | KMSAccessDeniedError
-    | KMSDisabledError
-    | KMSInvalidStateError
-    | KMSNotFoundError
-    | KMSOptInRequiredError
-    | KMSThrottlingError
-    | NotFoundError
-    | InvalidParameterValueError
-    | PlatformApplicationDisabledError
-    | TooManyEntriesInBatchRequestError
-    | ValidationError
+    | AuthorizationErrorException
+    | BatchEntryIdsNotDistinctException
+    | BatchRequestTooLongException
+    | EmptyBatchRequestException
+    | EndpointDisabledException
+    | InternalErrorException
+    | InvalidBatchEntryIdException
+    | InvalidParameterException
+    | InvalidParameterValueException
+    | InvalidSecurityException
+    | KMSAccessDeniedException
+    | KMSDisabledException
+    | KMSInvalidStateException
+    | KMSNotFoundException
+    | KMSOptInRequired
+    | KMSThrottlingException
+    | NotFoundException
+    | PlatformApplicationDisabledException
+    | TooManyEntriesInBatchRequestException
+    | ValidationException
   >;
 
   /**
    * @see {@link PutDataProtectionPolicyCommand}
    */
   putDataProtectionPolicy(
-    args: PutDataProtectionPolicyCommandInput,
+    args: PutDataProtectionPolicyInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    PutDataProtectionPolicyCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
   >;
 
   /**
    * @see {@link RemovePermissionCommand}
    */
   removePermission(
-    args: RemovePermissionCommandInput,
+    args: RemovePermissionInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    RemovePermissionCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link SetEndpointAttributesCommand}
    */
   setEndpointAttributes(
-    args: SetEndpointAttributesCommandInput,
+    args: SetEndpointAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SetEndpointAttributesCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link SetPlatformApplicationAttributesCommand}
    */
   setPlatformApplicationAttributes(
-    args: SetPlatformApplicationAttributesCommandInput,
+    args: SetPlatformApplicationAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SetPlatformApplicationAttributesCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
   >;
 
   /**
    * @see {@link SetSMSAttributesCommand}
    */
   setSMSAttributes(
-    args: SetSMSAttributesCommandInput,
+    args: SetSMSAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SetSMSAttributesCommandOutput,
+    SetSMSAttributesResponse,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ThrottledError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ThrottledException
   >;
 
   /**
    * @see {@link SetSubscriptionAttributesCommand}
    */
   setSubscriptionAttributes(
-    args: SetSubscriptionAttributesCommandInput,
+    args: SetSubscriptionAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SetSubscriptionAttributesCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | FilterPolicyLimitExceededError
-    | InternalError
-    | InvalidParameterError
-    | NotFoundError
+    | AuthorizationErrorException
+    | FilterPolicyLimitExceededException
+    | InternalErrorException
+    | InvalidParameterException
+    | NotFoundException
+    | ReplayLimitExceededException
   >;
 
   /**
    * @see {@link SetTopicAttributesCommand}
    */
   setTopicAttributes(
-    args: SetTopicAttributesCommandInput,
+    args: SetTopicAttributesInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SetTopicAttributesCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
   >;
 
   /**
    * @see {@link SubscribeCommand}
    */
   subscribe(
-    args: SubscribeCommandInput,
+    args: SubscribeInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    SubscribeCommandOutput,
+    SubscribeResponse,
     | SdkError
-    | AuthorizationError
-    | FilterPolicyLimitExceededError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
-    | SubscriptionLimitExceededError
+    | AuthorizationErrorException
+    | FilterPolicyLimitExceededException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
+    | ReplayLimitExceededException
+    | SubscriptionLimitExceededException
   >;
 
   /**
    * @see {@link TagResourceCommand}
    */
   tagResource(
-    args: TagResourceCommandInput,
+    args: TagResourceRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    TagResourceCommandOutput,
+    TagResourceResponse,
     | SdkError
-    | AuthorizationError
-    | ConcurrentAccessError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | StaleTagError
-    | TagLimitExceededError
-    | TagPolicyError
+    | AuthorizationErrorException
+    | ConcurrentAccessException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | StaleTagException
+    | TagLimitExceededException
+    | TagPolicyException
   >;
 
   /**
    * @see {@link UnsubscribeCommand}
    */
   unsubscribe(
-    args: UnsubscribeCommandInput,
+    args: UnsubscribeInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    UnsubscribeCommandOutput,
+    void,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | InvalidSecurityError
-    | NotFoundError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | InvalidSecurityException
+    | NotFoundException
   >;
 
   /**
    * @see {@link UntagResourceCommand}
    */
   untagResource(
-    args: UntagResourceCommandInput,
+    args: UntagResourceRequest,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    UntagResourceCommandOutput,
+    UntagResourceResponse,
     | SdkError
-    | AuthorizationError
-    | ConcurrentAccessError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | StaleTagError
-    | TagLimitExceededError
-    | TagPolicyError
+    | AuthorizationErrorException
+    | ConcurrentAccessException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | StaleTagException
+    | TagLimitExceededException
+    | TagPolicyException
   >;
 
   /**
    * @see {@link VerifySMSSandboxPhoneNumberCommand}
    */
   verifySMSSandboxPhoneNumber(
-    args: VerifySMSSandboxPhoneNumberCommandInput,
+    args: VerifySMSSandboxPhoneNumberInput,
     options?: __HttpHandlerOptions,
   ): Effect.Effect<
-    VerifySMSSandboxPhoneNumberCommandOutput,
+    VerifySMSSandboxPhoneNumberResult,
     | SdkError
-    | AuthorizationError
-    | InternalError
-    | InvalidParameterError
-    | ResourceNotFoundError
-    | ThrottledError
-    | VerificationError
+    | AuthorizationErrorException
+    | InternalErrorException
+    | InvalidParameterException
+    | ResourceNotFoundException
+    | ThrottledException
+    | VerificationException
   >;
 }
 
@@ -908,9 +924,9 @@ export const makeSNSService = Effect.gen(function* (_) {
       Effect.tryPromise({
         try: () => client.send(new CommandCtor(args), options ?? {}),
         catch: (e) => {
-          if (e instanceof SNSServiceException) {
+          if (e instanceof SdkSNSServiceException) {
             const ServiceException = Data.tagged<
-              TaggedException<SNSServiceException>
+              TaggedException<SdkSNSServiceException>
             >(e.name);
 
             return ServiceException({

--- a/packages/client-sns/test/SNS.test.ts
+++ b/packages/client-sns/test/SNS.test.ts
@@ -1,6 +1,6 @@
 import {
+  type PublishCommandInput,
   PublishCommand,
-  PublishCommandInput,
   SNSClient,
 } from "@aws-sdk/client-sns";
 import { mockClient } from "aws-sdk-client-mock";
@@ -21,16 +21,17 @@ import {
 
 import "aws-sdk-client-mock-jest";
 
-const snsMock = mockClient(SNSClient);
-const { publish } = Effect.serviceFunctions(SNSService);
+const clientMock = mockClient(SNSClient);
 
 describe("SNSClientImpl", () => {
   it("default", async () => {
-    snsMock.reset().on(PublishCommand).resolves({});
+    clientMock.reset().on(PublishCommand).resolves({});
 
     const args: PublishCommandInput = { TopicArn: "test", Message: "test" };
 
-    const program = publish(args);
+    const program = Effect.flatMap(SNSService, (service) =>
+      service.publish(args),
+    );
 
     const result = await pipe(
       program,
@@ -39,16 +40,18 @@ describe("SNSClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
-    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(PublishCommand, args);
   });
 
   it("configurable", async () => {
-    snsMock.reset().on(PublishCommand).resolves({});
+    clientMock.reset().on(PublishCommand).resolves({});
 
     const args: PublishCommandInput = { TopicArn: "test", Message: "test" };
 
-    const program = publish(args);
+    const program = Effect.flatMap(SNSService, (service) =>
+      service.publish(args),
+    );
 
     const SNSClientConfigLayer = Layer.succeed(SNSClientInstanceConfig, {
       region: "eu-central-1",
@@ -64,16 +67,18 @@ describe("SNSClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
-    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(PublishCommand, args);
   });
 
   it("base", async () => {
-    snsMock.reset().on(PublishCommand).resolves({});
+    clientMock.reset().on(PublishCommand).resolves({});
 
     const args: PublishCommandInput = { TopicArn: "test", Message: "test" };
 
-    const program = publish(args);
+    const program = Effect.flatMap(SNSService, (service) =>
+      service.publish(args),
+    );
 
     const SNSClientInstanceLayer = Layer.succeed(
       SNSClientInstance,
@@ -90,16 +95,18 @@ describe("SNSClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
-    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(PublishCommand, args);
   });
 
   it("extended", async () => {
-    snsMock.reset().on(PublishCommand).resolves({});
+    clientMock.reset().on(PublishCommand).resolves({});
 
     const args: PublishCommandInput = { TopicArn: "test", Message: "test" };
 
-    const program = publish(args);
+    const program = Effect.flatMap(SNSService, (service) =>
+      service.publish(args),
+    );
 
     const SNSClientInstanceLayer = Layer.effect(
       SNSClientInstance,
@@ -120,16 +127,18 @@ describe("SNSClientImpl", () => {
     );
 
     expect(result).toEqual(Exit.succeed({}));
-    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
-    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(PublishCommand, args);
   });
 
   it("fail", async () => {
-    snsMock.reset().on(PublishCommand).rejects(new Error("test"));
+    clientMock.reset().on(PublishCommand).rejects(new Error("test"));
 
     const args: PublishCommandInput = { TopicArn: "test", Message: "test" };
 
-    const program = publish(args, { requestTimeout: 1000 });
+    const program = Effect.flatMap(SNSService, (service) =>
+      service.publish(args),
+    );
 
     const result = await pipe(
       program,
@@ -147,7 +156,7 @@ describe("SNSClientImpl", () => {
         }),
       ),
     );
-    expect(snsMock).toHaveReceivedCommandTimes(PublishCommand, 1);
-    expect(snsMock).toHaveReceivedCommandWith(PublishCommand, args);
+    expect(clientMock).toHaveReceivedCommandTimes(PublishCommand, 1);
+    expect(clientMock).toHaveReceivedCommandWith(PublishCommand, args);
   });
 });

--- a/packages/client-sqs/.projen/deps.json
+++ b/packages/client-sqs/.projen/deps.json
@@ -70,7 +70,7 @@
     },
     {
       "name": "@aws-sdk/client-sqs",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/client-sqs/package.json
+++ b/packages/client-sqs/package.json
@@ -39,7 +39,7 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-sqs": "^3",
+    "@aws-sdk/client-sqs": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/packages/lib-dynamodb/.projen/deps.json
+++ b/packages/lib-dynamodb/.projen/deps.json
@@ -74,12 +74,12 @@
     },
     {
       "name": "@aws-sdk/client-dynamodb",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {
       "name": "@aws-sdk/lib-dynamodb",
-      "version": "^3",
+      "version": "^3.556.0",
       "type": "runtime"
     },
     {

--- a/packages/lib-dynamodb/package.json
+++ b/packages/lib-dynamodb/package.json
@@ -41,8 +41,8 @@
     "effect": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3",
-    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-dynamodb": "^3.556.0",
+    "@aws-sdk/lib-dynamodb": "^3.556.0",
     "@aws-sdk/types": "^3"
   },
   "main": "lib/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
   packages/client-api-gateway-management-api:
     dependencies:
       '@aws-sdk/client-apigatewaymanagementapi':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -148,7 +148,7 @@ importers:
   packages/client-dynamodb:
     dependencies:
       '@aws-sdk/client-dynamodb':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -203,7 +203,7 @@ importers:
   packages/client-ec2:
     dependencies:
       '@aws-sdk/client-ec2':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.557.0
       '@aws-sdk/types':
         specifier: ^3
@@ -258,7 +258,7 @@ importers:
   packages/client-elasticache:
     dependencies:
       '@aws-sdk/client-elasticache':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -313,7 +313,7 @@ importers:
   packages/client-eventbridge:
     dependencies:
       '@aws-sdk/client-eventbridge':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -368,7 +368,7 @@ importers:
   packages/client-iam:
     dependencies:
       '@aws-sdk/client-iam':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -423,7 +423,7 @@ importers:
   packages/client-lambda:
     dependencies:
       '@aws-sdk/client-lambda':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -478,10 +478,10 @@ importers:
   packages/client-s3:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/s3-request-presigner':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -536,7 +536,7 @@ importers:
   packages/client-sfn:
     dependencies:
       '@aws-sdk/client-sfn':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -591,7 +591,7 @@ importers:
   packages/client-sns:
     dependencies:
       '@aws-sdk/client-sns':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -646,7 +646,7 @@ importers:
   packages/client-sqs:
     dependencies:
       '@aws-sdk/client-sqs':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
@@ -746,10 +746,10 @@ importers:
   packages/lib-dynamodb:
     dependencies:
       '@aws-sdk/client-dynamodb':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0
       '@aws-sdk/lib-dynamodb':
-        specifier: ^3
+        specifier: ^3.556.0
         version: 3.556.0(@aws-sdk/client-dynamodb@3.556.0)
       '@aws-sdk/types':
         specifier: ^3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@aws-cdk/aws-cognito-identitypool-alpha':
         specifier: latest
-        version: 2.131.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0)
+        version: 2.137.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0)
       aws-cdk-lib:
         specifier: ^2.126.0
         version: 2.126.0(constructs@10.3.0)
@@ -31,7 +31,7 @@ importers:
     devDependencies:
       '@aws/pdk':
         specifier: ^0
-        version: 0.23.31(@aws-cdk/aws-cognito-identitypool-alpha@2.131.0-alpha.0)(aws-cdk-lib@2.126.0)(cdk-nag@2.28.27)(constructs@10.3.0)(projen@0.79.27)
+        version: 0.23.31(@aws-cdk/aws-cognito-identitypool-alpha@2.137.0-alpha.0)(aws-cdk-lib@2.126.0)(cdk-nag@2.28.27)(constructs@10.3.0)(projen@0.79.27)
       '@changesets/changelog-github':
         specifier: ^0.4.8
         version: 0.4.8
@@ -67,13 +67,13 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       nx:
         specifier: 16.0.0
         version: 16.0.0
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -94,10 +94,10 @@ importers:
     dependencies:
       '@aws-sdk/client-apigatewaymanagementapi':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -134,10 +134,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -149,10 +149,10 @@ importers:
     dependencies:
       '@aws-sdk/client-dynamodb':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -189,10 +189,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -204,10 +204,10 @@ importers:
     dependencies:
       '@aws-sdk/client-ec2':
         specifier: ^3
-        version: 3.533.0
+        version: 3.557.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -244,10 +244,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.2.4
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -259,10 +259,10 @@ importers:
     dependencies:
       '@aws-sdk/client-elasticache':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -299,10 +299,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.2.4
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -314,10 +314,10 @@ importers:
     dependencies:
       '@aws-sdk/client-eventbridge':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -354,10 +354,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -369,10 +369,10 @@ importers:
     dependencies:
       '@aws-sdk/client-iam':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -409,10 +409,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -424,10 +424,10 @@ importers:
     dependencies:
       '@aws-sdk/client-lambda':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -464,10 +464,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -479,13 +479,13 @@ importers:
     dependencies:
       '@aws-sdk/client-s3':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/s3-request-presigner':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -522,10 +522,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -537,10 +537,10 @@ importers:
     dependencies:
       '@aws-sdk/client-sfn':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -577,10 +577,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -592,10 +592,10 @@ importers:
     dependencies:
       '@aws-sdk/client-sns':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -632,10 +632,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -647,10 +647,10 @@ importers:
     dependencies:
       '@aws-sdk/client-sqs':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@types/node':
         specifier: ^18
@@ -687,10 +687,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -732,10 +732,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -747,13 +747,13 @@ importers:
     dependencies:
       '@aws-sdk/client-dynamodb':
         specifier: ^3
-        version: 3.533.0
+        version: 3.556.0
       '@aws-sdk/lib-dynamodb':
         specifier: ^3
-        version: 3.533.0(@aws-sdk/client-dynamodb@3.533.0)
+        version: 3.556.0(@aws-sdk/client-dynamodb@3.556.0)
       '@aws-sdk/types':
         specifier: ^3
-        version: 3.533.0
+        version: 3.535.0
     devDependencies:
       '@effect-aws/client-dynamodb':
         specifier: 1.2.0
@@ -793,10 +793,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -842,10 +842,10 @@ importers:
         version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.49.0)
       eslint-plugin-prettier:
         specifier: ^5.0.0
-        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4)
+        version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5)
       prettier:
         specifier: ^3.0.3
-        version: 3.2.4
+        version: 3.2.5
       projen:
         specifier: ^0.79.24
         version: 0.79.27(constructs@10.3.0)
@@ -869,11 +869,11 @@ packages:
   /@aws-cdk/asset-node-proxy-agent-v6@2.0.1:
     resolution: {integrity: sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==}
 
-  /@aws-cdk/aws-cognito-identitypool-alpha@2.131.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0):
-    resolution: {integrity: sha512-8dXyElW94uuSDbP2ERp90BkQ9qDuXW38p+ArjSEg/zzQo8PGFq6UMeAigBfgygPoP2N72CRZhaM8nGdtI9bv/A==}
+  /@aws-cdk/aws-cognito-identitypool-alpha@2.137.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0):
+    resolution: {integrity: sha512-oxevIjXTpkfhjFiIFfIzqL7yV2IGojIbNY9RPCG93zeu5bX8p4aesKkJSmf7gKOav6NVchQBt7ar7fiDf+HDnA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
-      aws-cdk-lib: ^2.131.0
+      aws-cdk-lib: ^2.137.0
       constructs: ^10.0.0
     dependencies:
       aws-cdk-lib: 2.126.0(constructs@10.3.0)
@@ -883,7 +883,7 @@ packages:
     resolution: {integrity: sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.533.0
+      '@aws-sdk/types': 3.535.0
       tslib: 1.14.1
     dev: false
 
@@ -891,7 +891,7 @@ packages:
     resolution: {integrity: sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.533.0
+      '@aws-sdk/types': 3.535.0
       tslib: 1.14.1
     dev: false
 
@@ -907,8 +907,8 @@ packages:
       '@aws-crypto/ie11-detection': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-locate-window': 3.495.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-locate-window': 3.535.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     dev: false
@@ -920,8 +920,8 @@ packages:
       '@aws-crypto/sha256-js': 3.0.0
       '@aws-crypto/supports-web-crypto': 3.0.0
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-locate-window': 3.495.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-locate-window': 3.535.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     dev: false
@@ -930,7 +930,7 @@ packages:
     resolution: {integrity: sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==}
     dependencies:
       '@aws-crypto/util': 3.0.0
-      '@aws-sdk/types': 3.533.0
+      '@aws-sdk/types': 3.535.0
       tslib: 1.14.1
     dev: false
 
@@ -943,7 +943,7 @@ packages:
   /@aws-crypto/util@3.0.0:
     resolution: {integrity: sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==}
     dependencies:
-      '@aws-sdk/types': 3.533.0
+      '@aws-sdk/types': 3.535.0
       '@aws-sdk/util-utf8-browser': 3.259.0
       tslib: 1.14.1
     dev: false
@@ -964,1129 +964,1129 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
-  /@aws-sdk/client-apigatewaymanagementapi@3.533.0:
-    resolution: {integrity: sha512-hizMoyzBiTFNe3GBR7zNm80cTx7PTrFFSIySgPoZ4KUAMQe4y6TPv1ULNZaODmDHFJ2QQLX9UG17CKk833oy1g==}
+  /@aws-sdk/client-apigatewaymanagementapi@3.556.0:
+    resolution: {integrity: sha512-XgDWSmOBXcJ5FpxLeoOuLseP6YUvRs6Po72kcPVCRfc2JkQEjJcEbHkW9KxAvkGYdMz+91GprgmJvxyrh2Pi1A==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-dynamodb@3.533.0:
-    resolution: {integrity: sha512-2rg4EcdwaJZV9edhGyH1oZLH9fNkAfkofq5D2b7zpKuR+Pt1jsmvok22Tfh3NZknNBkWrGKzFubZAqcCMyVIMw==}
+  /@aws-sdk/client-dynamodb@3.556.0:
+    resolution: {integrity: sha512-Msb/LxTbboX/v5HlR5zcMJ9JI61X83yI6pqsL85CcFrEuzAi+QqSmt84sT9sYU263RKkmo8Py4WazM7uIGs+mw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-endpoint-discovery': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
-      tslib: 2.6.2
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/client-ec2@3.533.0:
-    resolution: {integrity: sha512-I/eM/W85HQ/w1APgiOKWULeaEXh7pDI061zGhz+3w07sbp8AWx4f7n9xPU4lESjHbxigFb4fstq7a3WjOtmSfA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-crypto/sha256-browser': 3.0.0
-      '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-sdk-ec2': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-endpoint-discovery': 3.535.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
       tslib: 2.6.2
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-elasticache@3.533.0:
-    resolution: {integrity: sha512-kB6rpW+9UfZ322vMeNW8XSUlFNaeF4SHbPPkNvuL2c8p0ApHbgHPMfAVKbml0E9GQS6tengXPEmsYBhcPiJZ5g==}
+  /@aws-sdk/client-ec2@3.557.0:
+    resolution: {integrity: sha512-A7wf51WbvPvavhNgZCbzVcm3/11b909U7q/dTZUBizetgccFY1EFLRnderVeS9aj4BzDnqsN9vJk3VIEplklqw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-sdk-ec2': 3.556.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
+      tslib: 2.6.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/client-elasticache@3.556.0:
+    resolution: {integrity: sha512-pdbkv4QKpumsK1WSM0w32XXUlYpTAOQTqcR40ePai4WgdUyF1VY5PZW7eGMBiKSdVymhpShbYh2IEJypnEay2w==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-crypto/sha256-browser': 3.0.0
+      '@aws-crypto/sha256-js': 3.0.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-eventbridge@3.533.0:
-    resolution: {integrity: sha512-kspDwDO2oelNTuMC3JbRcRKZ4ikfTBExbmkOSq+gAgIsv57fl2ItK4BICd+zzC/jX/j8Ee2ohj5I9Drc+Ri2NQ==}
+  /@aws-sdk/client-eventbridge@3.556.0:
+    resolution: {integrity: sha512-Rx3NaRpsMcUdNIOerb8yrmeMKkLOEuK80TYtr/uBWnCUgnwfl69yf7Z5unwvO/7ZswGy7HCN4L/JOtQAWWTQpw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-signing': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/signature-v4-multi-region': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-signing': 3.556.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/signature-v4-multi-region': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-iam@3.533.0:
-    resolution: {integrity: sha512-G16AJ3bF1xlomuqKzAXB7v//AVcj24B4F23qKIk9BtUfRmzCLHkSs09L0HLB9S9ToWC73FfwO/C0Nybmz8SB0g==}
+  /@aws-sdk/client-iam@3.556.0:
+    resolution: {integrity: sha512-avZ8JDUC2+ma85Ep+ekMNxioKab1iYCaY+QBNQjCsFfilaNVxq2XAodqdOrqd3n8sdYCuIgYi7Oh5nQ1ztHHWw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-lambda@3.533.0:
-    resolution: {integrity: sha512-FsgR44DdLhpD+cd5cbddtNNbOKaPWGpjIMGXscx/f162NhX3rKisxPp+jGtU8mf7np3LmIQR3i4Q9+/vhVnKgQ==}
+  /@aws-sdk/client-lambda@3.556.0:
+    resolution: {integrity: sha512-HrsdCySeoHA1WTxzOT42ct+Se71ncwRv+vJ3Le6NmUV9oRQ6h7Bw7OYliB5wadP8GHWV7egbbvR+Dy8SwuENvw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/eventstream-serde-browser': 2.1.4
-      '@smithy/eventstream-serde-config-resolver': 2.1.4
-      '@smithy/eventstream-serde-node': 2.1.4
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-stream': 2.1.5
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/eventstream-serde-browser': 2.2.0
+      '@smithy/eventstream-serde-config-resolver': 2.2.0
+      '@smithy/eventstream-serde-node': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-stream': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-s3@3.533.0:
-    resolution: {integrity: sha512-KkzRS3Dt+dmNBe0a627RGr5aFqI+xw5UhqB+8Gr4r6Xy1/8sMGE+AXKVl/sYVbRQo/9aSCBak71baGE3XCm/pQ==}
+  /@aws-sdk/client-s3@3.556.0:
+    resolution: {integrity: sha512-6WF9Kuzz1/8zqX8hKBpqj9+FYwQ5uTsVcOKpTW94AMX2qtIeVRlwlnNnYyywWo61yqD3g59CMNHcqSsaqAwglg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha1-browser': 3.0.0
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-bucket-endpoint': 3.533.0
-      '@aws-sdk/middleware-expect-continue': 3.533.0
-      '@aws-sdk/middleware-flexible-checksums': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-location-constraint': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-sdk-s3': 3.533.0
-      '@aws-sdk/middleware-signing': 3.533.0
-      '@aws-sdk/middleware-ssec': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/signature-v4-multi-region': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@aws-sdk/xml-builder': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/eventstream-serde-browser': 2.1.4
-      '@smithy/eventstream-serde-config-resolver': 2.1.4
-      '@smithy/eventstream-serde-node': 2.1.4
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-blob-browser': 2.1.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/hash-stream-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/md5-js': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-stream': 2.1.5
-      '@smithy/util-utf8': 2.2.0
-      '@smithy/util-waiter': 2.1.4
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-bucket-endpoint': 3.535.0
+      '@aws-sdk/middleware-expect-continue': 3.535.0
+      '@aws-sdk/middleware-flexible-checksums': 3.535.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-location-constraint': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-sdk-s3': 3.556.0
+      '@aws-sdk/middleware-signing': 3.556.0
+      '@aws-sdk/middleware-ssec': 3.537.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/signature-v4-multi-region': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@aws-sdk/xml-builder': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/eventstream-serde-browser': 2.2.0
+      '@smithy/eventstream-serde-config-resolver': 2.2.0
+      '@smithy/eventstream-serde-node': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-blob-browser': 2.2.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/hash-stream-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/md5-js': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-stream': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      '@smithy/util-waiter': 2.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sfn@3.533.0:
-    resolution: {integrity: sha512-Rgfct0cydlP/0yrO2GL7Z7zvHPUDP5k49MngERKfe9bjsFYyHaYSpB+FQ+mVo7kVADrtJmSOyTkoTolDtnyn8Q==}
+  /@aws-sdk/client-sfn@3.556.0:
+    resolution: {integrity: sha512-zsXtsHA4mR8iHfAPYFQPPyF9gxZTq4r9/cOCuNkd+OS472THkldIZJ+QaqCNT6Va03zgGqyMxO0TrsClmqM/1Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
       uuid: 9.0.1
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sns@3.533.0:
-    resolution: {integrity: sha512-jUQtrXQYxqfFSbNnquDpnI4dUxvh/ZXpsEdBu+Bu6gsyCLD7oUNoa1kdnIzJl+YdG4L4vSBb/GKC8OTfjcSHMw==}
+  /@aws-sdk/client-sns@3.556.0:
+    resolution: {integrity: sha512-vtsTxCBy7m3GtP6kY2ws/b/lKnmyczaKWnD2x3BMSLnJfzSn4H849XDNr4Eke5EuCjU6hDGe+i4n8ehX9AEUDw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sqs@3.533.0:
-    resolution: {integrity: sha512-BfCfAyysW9yn7dUdnkByukbYJa5Pqkwy4MIM7o+wz8D5TFROzfJgSCwSXfYDd4a/dtZPRSKwk3p8IQfJDP+Fyw==}
+  /@aws-sdk/client-sqs@3.556.0:
+    resolution: {integrity: sha512-Lz6IsuznAkFgU2SYKAb0r0PxkvzQv53/IeqOi/k58jC0rWzOit362519lqJHJ9MNt28NeWrD8CYwYoGB1J4N+Q==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-sdk-sqs': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/md5-js': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-sdk-sqs': 3.552.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/md5-js': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sso-oidc@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-jxG+L81bcuH6JJkls+VSRsOTpixvNEQ8clpUglal/XC+qiV09yZUnOi+Fxf2q7OAB7bfM9DB3Wy8YwbhaR2wYg==}
+  /@aws-sdk/client-sso-oidc@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-AXKd2TB6nNrksu+OfmHl8uI07PdgzOo4o8AxoRO8SHlwoMAGvcT9optDGVSYoVfgOKTymCoE7h8/UoUfPc11wQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@aws-sdk/credential-provider-node': ^3.533.0
+      '@aws-sdk/credential-provider-node': ^3.556.0
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sso@3.533.0:
-    resolution: {integrity: sha512-qO+PCEM3fGS/3uBJQjQ01oAI+ashN0CHTJF8X0h3ycVsv3VAAYrpZigpylOOgv7c253s7VrSwjvdKIE8yTbelw==}
+  /@aws-sdk/client-sso@3.556.0:
+    resolution: {integrity: sha512-unXdWS7uvHqCcOyC1de+Fr8m3F2vMg2m24GPea0bg7rVGTYmiyn9mhUX11VCt+ozydrw+F50FQwL6OqoqPocmw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-sts@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-Z/z76T/pEq0DsBpoyWSMQdS7R6IRpq2ZV6dfZwr+HZ2vho2Icd70nIxwiNzZxaV16aVIhu5/l/5v5Ns9ZCfyOA==}
+  /@aws-sdk/client-sts@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-TsK3js7Suh9xEmC886aY+bv0KdLLYtzrcmVt6sJ/W6EnDXYQhBuKYFhp03NrN2+vSvMGpqJwR62DyfKe1G0QzQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      '@aws-sdk/credential-provider-node': ^3.533.0
+      '@aws-sdk/credential-provider-node': ^3.556.0
     dependencies:
       '@aws-crypto/sha256-browser': 3.0.0
       '@aws-crypto/sha256-js': 3.0.0
-      '@aws-sdk/core': 3.533.0
-      '@aws-sdk/credential-provider-node': 3.533.0
-      '@aws-sdk/middleware-host-header': 3.533.0
-      '@aws-sdk/middleware-logger': 3.533.0
-      '@aws-sdk/middleware-recursion-detection': 3.533.0
-      '@aws-sdk/middleware-user-agent': 3.533.0
-      '@aws-sdk/region-config-resolver': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@aws-sdk/util-user-agent-browser': 3.533.0
-      '@aws-sdk/util-user-agent-node': 3.533.0
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/core': 1.3.8
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/hash-node': 2.1.4
-      '@smithy/invalid-dependency': 2.1.4
-      '@smithy/middleware-content-length': 2.1.4
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-body-length-browser': 2.1.1
-      '@smithy/util-body-length-node': 2.2.2
-      '@smithy/util-defaults-mode-browser': 2.1.7
-      '@smithy/util-defaults-mode-node': 2.2.7
-      '@smithy/util-endpoints': 1.1.5
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/core': 3.556.0
+      '@aws-sdk/credential-provider-node': 3.556.0
+      '@aws-sdk/middleware-host-header': 3.535.0
+      '@aws-sdk/middleware-logger': 3.535.0
+      '@aws-sdk/middleware-recursion-detection': 3.535.0
+      '@aws-sdk/middleware-user-agent': 3.540.0
+      '@aws-sdk/region-config-resolver': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@aws-sdk/util-user-agent-browser': 3.535.0
+      '@aws-sdk/util-user-agent-node': 3.535.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/core': 1.4.2
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/hash-node': 2.2.0
+      '@smithy/invalid-dependency': 2.2.0
+      '@smithy/middleware-content-length': 2.2.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-body-length-browser': 2.2.0
+      '@smithy/util-body-length-node': 2.3.0
+      '@smithy/util-defaults-mode-browser': 2.2.1
+      '@smithy/util-defaults-mode-node': 2.3.1
+      '@smithy/util-endpoints': 1.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - aws-crt
     dev: false
 
-  /@aws-sdk/core@3.533.0:
-    resolution: {integrity: sha512-m3jq9WJbIvlDOnN5KG5U/org1MwOwXzfyU2Rr/48rRey6/+kNSm5QzYZMT0Htsk8V5Ukp325dzs/XR8DyO9uMQ==}
+  /@aws-sdk/core@3.556.0:
+    resolution: {integrity: sha512-vJaSaHw2kPQlo11j/Rzuz0gk1tEaKdz+2ser0f0qZ5vwFlANjt08m/frU17ctnVKC1s58bxpctO/1P894fHLrA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/core': 1.3.8
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/signature-v4': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@smithy/core': 1.4.2
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       fast-xml-parser: 4.2.5
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-env@3.533.0:
-    resolution: {integrity: sha512-opj7hfcCeNosSmxfJkJr0Af0aSxlqwkdCPlLEvOTwbHmdkovD+SyEpaI4/0ild0syZDMifuJAU6I6K0ukbcm3g==}
+  /@aws-sdk/credential-provider-env@3.535.0:
+    resolution: {integrity: sha512-XppwO8c0GCGSAvdzyJOhbtktSEaShg14VJKg8mpMa1XcgqzmcqqHQjtDWbx5rZheY1VdpXZhpEzJkB6LpQejpA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-http@3.533.0:
-    resolution: {integrity: sha512-m5z3V9MRO77t1CF312QKaQSfYG2MM/USqZ1Jj6srb+kJBX+GuVXbkc0+NwrpG5+j8Iukgxy1tms+0p3Wjatu6A==}
+  /@aws-sdk/credential-provider-http@3.552.0:
+    resolution: {integrity: sha512-vsmu7Cz1i45pFEqzVb4JcFmAmVnWFNLsGheZc8SCptlqCO5voETrZZILHYIl4cjKkSDk3pblBOf0PhyjqWW6WQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/property-provider': 2.1.4
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-stream': 2.1.5
+      '@aws-sdk/types': 3.535.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-stream': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/credential-provider-ini@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-xQ7TMY+j99zxOph+LJJhGPIav6RpydESZgIp5cp/pFY4Liwe5e84M7SaCgkFLck2HE9s7MhP42c8xmC6u9PIuw==}
+  /@aws-sdk/credential-provider-ini@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-0Nz4ErOlXhe3muxWYMbPwRMgfKmVbBp36BAE2uv/z5wTbfdBkcgUwaflEvlKCLUTdHzuZsQk+BFS/gVyaUeOuA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/credential-provider-env': 3.533.0
-      '@aws-sdk/credential-provider-process': 3.533.0
-      '@aws-sdk/credential-provider-sso': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/credential-provider-web-identity': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/types': 3.533.0
-      '@smithy/credential-provider-imds': 2.2.6
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - '@aws-sdk/credential-provider-node'
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/credential-provider-node@3.533.0:
-    resolution: {integrity: sha512-Tn2grwFfFDLV5Hr8sZvZY5pjEmDUOm/e+ipnyxxCBB/K7t2ru2R4jG/RUa6+dZXSH/pi+TNte9cYq/Lx2Szjlw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/credential-provider-env': 3.533.0
-      '@aws-sdk/credential-provider-http': 3.533.0
-      '@aws-sdk/credential-provider-ini': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/credential-provider-process': 3.533.0
-      '@aws-sdk/credential-provider-sso': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/credential-provider-web-identity': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/types': 3.533.0
-      '@smithy/credential-provider-imds': 2.2.6
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    transitivePeerDependencies:
-      - aws-crt
-    dev: false
-
-  /@aws-sdk/credential-provider-process@3.533.0:
-    resolution: {integrity: sha512-9Iuhp8dhMqEv7kPsZlc9KFhC5XvuB/jFv3IZoTtRgbACW4cdxng7OwJEWdeZGrcjy9x40Tc2DT9KcmCE895KpQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@aws-sdk/credential-provider-sso@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-1zPZQnFUoZ0fWuLPW2X2L3jPKyd+qW8VzFO1k26oX1KJuiEZJzoYbfap08soy6vhFI+n4NfsAgvoA1IMsqG0Pg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@aws-sdk/client-sso': 3.533.0
-      '@aws-sdk/token-providers': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
     dev: false
 
-  /@aws-sdk/credential-provider-web-identity@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-utemXrFmvFxBvX+WCznlh5wGdXRIfwEyeNIDFs+WLRn8NIR/6gqCipi7rlC9ZbFFkBhkCTssa6+ruXG+kUQcMg==}
+  /@aws-sdk/credential-provider-node@3.556.0:
+    resolution: {integrity: sha512-s1xVtKjyGc60O8qcNIzS1X3H+pWEwEfZ7TgNznVDNyuXvLrlNWiAcigPWGl2aAkc8tGcsSG0Qpyw2KYC939LFg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sts': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/types': 2.11.0
+      '@aws-sdk/credential-provider-env': 3.535.0
+      '@aws-sdk/credential-provider-http': 3.552.0
+      '@aws-sdk/credential-provider-ini': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-process': 3.535.0
+      '@aws-sdk/credential-provider-sso': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/credential-provider-web-identity': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/credential-provider-process@3.535.0:
+    resolution: {integrity: sha512-9O1OaprGCnlb/kYl8RwmH7Mlg8JREZctB8r9sa1KhSsWFq/SWO0AuJTyowxD7zL5PkeS4eTvzFFHWCa3OO5epA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@aws-sdk/credential-provider-sso@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-ETuBgcnpfxqadEAqhQFWpKoV1C/NAgvs5CbBc5EJbelJ8f4prTdErIHjrRtVT8c02MXj92QwczsiNYd5IoOqyw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sso': 3.556.0
+      '@aws-sdk/token-providers': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
     dev: false
 
-  /@aws-sdk/endpoint-cache@3.495.0:
-    resolution: {integrity: sha512-XCDrpiS50WaPzPzp7FwsChPHtX9PQQUU4nRzcn2N7IkUtpcFCUx8m1PAZe086VQr6hrbdeE4Z4j8hUPNwVdJGQ==}
+  /@aws-sdk/credential-provider-web-identity@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-R/YAL8Uh8i+dzVjzMnbcWLIGeeRi2mioHVGnVF+minmaIkCiQMZg2HPrdlKm49El+RljT28Nl5YHRuiqzEIwMA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@aws-sdk/client-sts': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-provider-node'
+      - aws-crt
+    dev: false
+
+  /@aws-sdk/endpoint-cache@3.535.0:
+    resolution: {integrity: sha512-sPG2l00iVuporK9AmPWq4UBcJURs2RN+vKA8QLRQANmQS3WFHWHamvGltxCjK79izkeqri882V4XlFpZfWhemA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       mnemonist: 0.38.3
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/lib-dynamodb@3.533.0(@aws-sdk/client-dynamodb@3.533.0):
-    resolution: {integrity: sha512-8pDJZXWd9rdq1sTyvx9zgz9xg5K83aNaavVmlhcYWWFQ3Ykqf1sVPb14dG0MeRLwaWpU3D6Htj6+9m+tSyQ8ag==}
+  /@aws-sdk/lib-dynamodb@3.556.0(@aws-sdk/client-dynamodb@3.556.0):
+    resolution: {integrity: sha512-0CsNQyw7z5Fe4bj0oHnrZgz5grVLQI8OuMWUGxVgTeIL6a6kusWR4Ky7+RveAoiLCAYh3FIVvlqAiD4hJdIizQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@aws-sdk/client-dynamodb': ^3.0.0
     dependencies:
-      '@aws-sdk/client-dynamodb': 3.533.0
-      '@aws-sdk/util-dynamodb': 3.533.0(@aws-sdk/client-dynamodb@3.533.0)
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/client-dynamodb': 3.556.0
+      '@aws-sdk/util-dynamodb': 3.556.0(@aws-sdk/client-dynamodb@3.556.0)
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-bucket-endpoint@3.533.0:
-    resolution: {integrity: sha512-k1KJe8SEDfgXpEBlMmlCBHhUFJekL5pEEfwbcS/cfjfcZIWrLlfTqjnA0+TKrB6EO/8ZZiKaxHrTjhft5AMcqA==}
+  /@aws-sdk/middleware-bucket-endpoint@3.535.0:
+    resolution: {integrity: sha512-7sijlfQsc4UO9Fsl11mU26Y5f9E7g6UoNg/iJUBpC5pgvvmdBRO5UEhbB/gnqvOEPsBXyhmfzbstebq23Qdz7A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-arn-parser': 3.495.0
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
-      '@smithy/util-config-provider': 2.2.1
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-arn-parser': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-endpoint-discovery@3.533.0:
-    resolution: {integrity: sha512-j3RPLzTQfNYUxMj2blZBRrdTBH6BE9Mbqs1JmXL89jwGJ8M1TmMlbwplxmuGKLLKeKgB67DWow1RG58XyniSJA==}
+  /@aws-sdk/middleware-endpoint-discovery@3.535.0:
+    resolution: {integrity: sha512-+EsqJB5A15RoTf0HxUdknF3hp+2WDg0HWc+QERUctzzYXy9l5LIQjmhQ96cWDyFttKmHE+4h6fjMZjJEeWOeYQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/endpoint-cache': 3.495.0
-      '@aws-sdk/types': 3.533.0
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
+      '@aws-sdk/endpoint-cache': 3.535.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-expect-continue@3.533.0:
-    resolution: {integrity: sha512-a9NXE+4DwFQgv9cS+YYg7b8ugBatATkCe/cunFRrTpqMXmIpHE8i4zDEoCZVCi4YMkLaphC/WBAhXNl4T6w8pg==}
+  /@aws-sdk/middleware-expect-continue@3.535.0:
+    resolution: {integrity: sha512-hFKyqUBky0NWCVku8iZ9+PACehx0p6vuMw5YnZf8FVgHP0fode0b/NwQY6UY7oor/GftvRsAlRUAWGNFEGUpwA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-flexible-checksums@3.533.0:
-    resolution: {integrity: sha512-vvD2XPXbR4PKf3/VSx6dzB+1iWzpyy8uGlt1p1y5uvQRetbmCAnzchUd5xn18MUr85MlOKKBfykYzA7gTiVgSA==}
+  /@aws-sdk/middleware-flexible-checksums@3.535.0:
+    resolution: {integrity: sha512-rBIzldY9jjRATxICDX7t77aW6ctqmVDgnuAOgbVT5xgHftt4o7PGWKoMvl/45hYqoQgxVFnCBof9bxkqSBebVA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@aws-crypto/crc32': 3.0.0
       '@aws-crypto/crc32c': 3.0.0
-      '@aws-sdk/types': 3.533.0
-      '@smithy/is-array-buffer': 2.1.1
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-host-header@3.533.0:
-    resolution: {integrity: sha512-y9JaPjvz3pk4DZcFB6Nud//Hc6y4BkkSwiGXfthwFv5kxfaaksHKd8smDjL3RUPqDKl8AI9vxHzTz1UrQQkpQw==}
+  /@aws-sdk/middleware-host-header@3.535.0:
+    resolution: {integrity: sha512-0h6TWjBWtDaYwHMQJI9ulafeS4lLaw1vIxRjbpH0svFRt6Eve+Sy8NlVhECfTU2hNz/fLubvrUxsXoThaLBIew==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-location-constraint@3.533.0:
-    resolution: {integrity: sha512-cZPH7L+aw9uGSIbwWmemIHHUPZ43FYwSx/hnWC8asLs3zLMD26V9TyQFAASlUk9jrzxqJg/SBaxfPHjBT3kg9w==}
+  /@aws-sdk/middleware-location-constraint@3.535.0:
+    resolution: {integrity: sha512-SxfS9wfidUZZ+WnlKRTCRn3h+XTsymXRXPJj8VV6hNRNeOwzNweoG3YhQbTowuuNfXf89m9v6meYkBBtkdacKw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-logger@3.533.0:
-    resolution: {integrity: sha512-W+ou4YgqnHn/xVNcBgfwAUCtXTHGJjjsFffdt69s1Tb7rP5U4gXnl8wHHADajy9tXiKK48fRc2SGF42EthjQIA==}
+  /@aws-sdk/middleware-logger@3.535.0:
+    resolution: {integrity: sha512-huNHpONOrEDrdRTvSQr1cJiRMNf0S52NDXtaPzdxiubTkP+vni2MohmZANMOai/qT0olmEVX01LhZ0ZAOgmg6A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-recursion-detection@3.533.0:
-    resolution: {integrity: sha512-dobVdJ4g1avrVG6QTRHndfvdTxUeloDCn32WLwyOV11XF/2x5p8QJ1VZS+K24xsl29DoJ8bXibZf9xZ7MPwRLg==}
+  /@aws-sdk/middleware-recursion-detection@3.535.0:
+    resolution: {integrity: sha512-am2qgGs+gwqmR4wHLWpzlZ8PWhm4ktj5bYSgDrsOfjhdBlWNxvPoID9/pDAz5RWL48+oH7I6SQzMqxXsFDikrw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-sdk-ec2@3.533.0:
-    resolution: {integrity: sha512-iws4L+qNtbPP0TgEDBSVCXSCd5m0TiHjyuVCAU4ERLekHlxero0ex0l6GDMy/uVZ6XraUXrPBOY1U59kbWpB4g==}
+  /@aws-sdk/middleware-sdk-ec2@3.556.0:
+    resolution: {integrity: sha512-577F9J+H65T/xYde6iy0RnArw3VAHlf9UTfSuHlJvpc9e6o2rd43FISVCNTdA+RCbJpmdWsaZSws0EYGJD+Sag==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-format-url': 3.533.0
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/signature-v4': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-format-url': 3.535.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-sdk-s3@3.533.0:
-    resolution: {integrity: sha512-9bd1+u5bFEQnh/2X9mybdQ4kVWhe6/XeCHC1KrER846Ntd3QYdX61KwJktg0URdqw5QFdqD+rmn0nQ3Ku8AmxA==}
+  /@aws-sdk/middleware-sdk-s3@3.556.0:
+    resolution: {integrity: sha512-4W/dnxqj1B6/uS/5Z+3UHaqDDGjNPgEVlqf5d3ToOFZ31ZfpANwhcCmyX39JklC4aolCEi9renQ5wHnTCC8K8g==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-arn-parser': 3.495.0
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/signature-v4': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-config-provider': 2.2.1
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-arn-parser': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-sdk-sqs@3.533.0:
-    resolution: {integrity: sha512-iQiSvv+RX+SMPEOQA0yyz4ugC0twwOI3RoWlZ/CEx5rOpAwpD29p220PmoCjDGEuwhBkb/7Wd7a3aleE53dWeg==}
+  /@aws-sdk/middleware-sdk-sqs@3.552.0:
+    resolution: {integrity: sha512-s3xy3FJSj5Bpxfk8o48SQ8DCDqZ03V3nlpblrFpCbOfdMFkxkdFkTE3F+bx+uAL+iFfW46lHvsukTb95AZJzZQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-hex-encoding': 2.1.1
-      '@smithy/util-utf8': 2.2.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-signing@3.533.0:
-    resolution: {integrity: sha512-qJZBoNKoSacIkHZfHcQfxmrogQcb0OPEaeEwwH563f8D5qYjQ3yuSaq7X9BKL7W8f9GjUYUJYZJwK3tbDh1ccg==}
+  /@aws-sdk/middleware-signing@3.556.0:
+    resolution: {integrity: sha512-kWrPmU8qd3gI5qzpuW9LtWFaH80cOz1ZJDavXx6PRpYZJ5JaKdUHghwfDlVTzzFYAeJmVsWIkPcLT5d5mY5ZTQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/signature-v4': 2.1.4
-      '@smithy/types': 2.11.0
-      '@smithy/util-middleware': 2.1.4
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-ssec@3.533.0:
-    resolution: {integrity: sha512-UQn/d5x+lWBnsZDwkqm+x9qM9jAwPW2VDXoTrN2UMgMqao+iDki9FxvvHqYYYv4zDS4TYGXI6O9Zhmf5wwqygA==}
+  /@aws-sdk/middleware-ssec@3.537.0:
+    resolution: {integrity: sha512-2QWMrbwd5eBy5KCYn9a15JEWBgrK2qFEKQN2lqb/6z0bhtevIOxIRfC99tzvRuPt6nixFQ+ynKuBjcfT4ZFrdQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/middleware-user-agent@3.533.0:
-    resolution: {integrity: sha512-H5vbkgwFVgp9egQ/CR+gLRXhVJ/jHqq+J9TTug/To4ev183fcNc2OE15ojiNek8phuSsBZITLaQB+DWBTydsAA==}
+  /@aws-sdk/middleware-user-agent@3.540.0:
+    resolution: {integrity: sha512-8Rd6wPeXDnOYzWj1XCmOKcx/Q87L0K1/EHqOBocGjLVbN3gmRxBvpmR1pRTjf7IsWfnnzN5btqtcAkfDPYQUMQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-endpoints': 3.533.0
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-endpoints': 3.540.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/region-config-resolver@3.533.0:
-    resolution: {integrity: sha512-1FLLcohz23aVV+lK3iCUJpjKO/4adXjre0KMg9tvHWwCkOD/sZgLjzlv+BW5Fx2vH3Dgo0kDQ04+XEsbuVC2xA==}
+  /@aws-sdk/region-config-resolver@3.535.0:
+    resolution: {integrity: sha512-IXOznDiaItBjsQy4Fil0kzX/J3HxIOknEphqHbOfUf+LpA5ugcsxuQQONrbEQusCBnfJyymrldBvBhFmtlU9Wg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-config-provider': 2.2.1
-      '@smithy/util-middleware': 2.1.4
+      '@aws-sdk/types': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/s3-request-presigner@3.533.0:
-    resolution: {integrity: sha512-xS0Gp+zgRAMkiSdG2cYyHDX8BRjzKLGrWiPnH/ete+C9Qzfp+OkJAdZuqQQ+33S9M8Z0PwrIR/79RCOz2TRI3Q==}
+  /@aws-sdk/s3-request-presigner@3.556.0:
+    resolution: {integrity: sha512-uVUZn0TlAFaObePEYT4sdM+6QeuaTzOK96w0CbzQs1F3mYVag1r7tZal3BBRfcGNo6WEbZTgd0EXD1q9g0WuwA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/signature-v4-multi-region': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@aws-sdk/util-format-url': 3.533.0
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/signature-v4-multi-region': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@aws-sdk/util-format-url': 3.535.0
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/signature-v4-multi-region@3.533.0:
-    resolution: {integrity: sha512-0S552/0UfESFF0f3+wAzbV5F9vSIsGAaYTEW3wMgD1DAeZGDq37xUZjYFZ+XjKqQ/ZnR+pQf3QVW5geFmbKkgQ==}
+  /@aws-sdk/signature-v4-multi-region@3.556.0:
+    resolution: {integrity: sha512-bWDSK0ggK7QzAOmPZGv29UAIZocL1MNY7XyOvm3P3P1U3tFMoIBilQQBLabXyHoZ9J3Ik0Vv4n95htUhRQ35ow==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/middleware-sdk-s3': 3.533.0
-      '@aws-sdk/types': 3.533.0
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/signature-v4': 2.1.4
-      '@smithy/types': 2.11.0
+      '@aws-sdk/middleware-sdk-s3': 3.556.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/signature-v4': 2.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/token-providers@3.533.0(@aws-sdk/credential-provider-node@3.533.0):
-    resolution: {integrity: sha512-mHaZUeJ6zfbkW0E64dUmzDwReO1LoDYRful+FT1dbKqQr0p+9Q8o4n6fAswwAVfCYHaAeIt68vE0zVkAlbGCqA==}
+  /@aws-sdk/token-providers@3.556.0(@aws-sdk/credential-provider-node@3.556.0):
+    resolution: {integrity: sha512-tvIiugNF0/+2wfuImMrpKjXMx4nCnFWQjQvouObny+wrif/PGqqQYrybwxPJDvzbd965bu1I+QuSv85/ug7xsg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.533.0(@aws-sdk/credential-provider-node@3.533.0)
-      '@aws-sdk/types': 3.533.0
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/client-sso-oidc': 3.556.0(@aws-sdk/credential-provider-node@3.556.0)
+      '@aws-sdk/types': 3.535.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
       - aws-crt
     dev: false
 
-  /@aws-sdk/types@3.533.0:
-    resolution: {integrity: sha512-mFb0701oLRcJ7Y2unlrszzk9rr2P6nt2A4Bdz4K5WOsY4f4hsdbcYkrzA1NPmIUTEttU9JT0YG+8z0XxLEX4Aw==}
+  /@aws-sdk/types@3.535.0:
+    resolution: {integrity: sha512-aY4MYfduNj+sRR37U7XxYR8wemfbKP6lx00ze2M2uubn7mZotuVrWYAafbMSXrdEMSToE5JDhr28vArSOoLcSg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-arn-parser@3.495.0:
-    resolution: {integrity: sha512-hwdA3XAippSEUxs7jpznwD63YYFR+LtQvlEcebPTgWR9oQgG9TfS+39PUfbnEeje1ICuOrN3lrFqFbmP9uzbMg==}
+  /@aws-sdk/util-arn-parser@3.535.0:
+    resolution: {integrity: sha512-smVo29nUPAOprp8Z5Y3GHuhiOtw6c8/EtLCm5AVMtRsTPw4V414ZXL2H66tzmb5kEeSzQlbfBSBEdIFZoxO9kg==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-dynamodb@3.533.0(@aws-sdk/client-dynamodb@3.533.0):
-    resolution: {integrity: sha512-ebbdeORpPUkL/UtsgIjPuaZ0ROLJrbZRNoP2NFCTySW3jIzxRphSOkLs2zk6VZ7Je3bG06DXtZe6Uziihcuvow==}
+  /@aws-sdk/util-dynamodb@3.556.0(@aws-sdk/client-dynamodb@3.556.0):
+    resolution: {integrity: sha512-SF7bEPt8uCiklHkCvDQfGmAl6qADDd/sHHjcWS0zGYPesLkKSJDo/uKUjwuLxzkpHEp+xvB8BYrHFMIefb28AQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@aws-sdk/client-dynamodb': ^3.0.0
     dependencies:
-      '@aws-sdk/client-dynamodb': 3.533.0
+      '@aws-sdk/client-dynamodb': 3.556.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-endpoints@3.533.0:
-    resolution: {integrity: sha512-pmjRqWqno6X61RaJ/iEbSSql79Jyaq9d9SvTkyvo8Ce8Kb+49cflzUY1PP0s40Caj4H+bUkpksVHwO7t2qIakw==}
+  /@aws-sdk/util-endpoints@3.540.0:
+    resolution: {integrity: sha512-1kMyQFAWx6f8alaI6UT65/5YW/7pDWAKAdNwL6vuJLea03KrZRX3PMoONOSJpAS5m3Ot7HlWZvf3wZDNTLELZw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/types': 2.11.0
-      '@smithy/util-endpoints': 1.1.5
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-endpoints': 1.2.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-format-url@3.533.0:
-    resolution: {integrity: sha512-JhQw6wsBoNlEhro9xvZY1uZklaCf37br3LjiRLjqnGwg+VhlA5QFE2QyosDMW28c1mcvzSDnkU0m7/1vDPPfBw==}
+  /@aws-sdk/util-format-url@3.535.0:
+    resolution: {integrity: sha512-ElbNkm0bddu53CuW44Iuux1ZbTV50fydbSh/4ypW3LrmUvHx193ogj0HXQ7X26kmmo9rXcsrLdM92yIeTjidVg==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/querystring-builder': 2.1.4
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/querystring-builder': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-locate-window@3.495.0:
-    resolution: {integrity: sha512-MfaPXT0kLX2tQaR90saBT9fWQq2DHqSSJRzW+MZWsmF+y5LGCOhO22ac/2o6TKSQm7h0HRc2GaADqYYYor62yg==}
+  /@aws-sdk/util-locate-window@3.535.0:
+    resolution: {integrity: sha512-PHJ3SL6d2jpcgbqdgiPxkXpu7Drc2PYViwxSIqvvMKhDwzSB1W3mMvtpzwKM4IE7zLFodZo0GKjJ9AsoXndXhA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-user-agent-browser@3.533.0:
-    resolution: {integrity: sha512-wyzDxH89yQ89+Q/9rWZeYBeegaXkB4nhb9Bd+xG4J3KgaNVuVvaYT6Nbzjg4oPtuC+pPeQp1iSXKs/2QTlsqPA==}
+  /@aws-sdk/util-user-agent-browser@3.535.0:
+    resolution: {integrity: sha512-RWMcF/xV5n+nhaA/Ff5P3yNP3Kur/I+VNZngog4TEs92oB/nwOdAg/2JL8bVAhUbMrjTjpwm7PItziYFQoqyig==}
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/types': 2.12.0
       bowser: 2.11.0
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/util-user-agent-node@3.533.0:
-    resolution: {integrity: sha512-Tu79n4+q1MAPPFEtu7xTgiTQGzOAPe4c2p8vSyrIJEBHclf7cyvZxgziQAyM9Yy4DoRdtnnAeeybao3U4d+CzA==}
+  /@aws-sdk/util-user-agent-node@3.535.0:
+    resolution: {integrity: sha512-dRek0zUuIT25wOWJlsRm97nTkUlh1NDcLsQZIN2Y8KxhwoXXWtJs5vaDPT+qAg+OpcNj80i1zLR/CirqlFg/TQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -2094,9 +2094,9 @@ packages:
       aws-crt:
         optional: true
     dependencies:
-      '@aws-sdk/types': 3.533.0
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/types': 2.11.0
+      '@aws-sdk/types': 3.535.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
@@ -2106,15 +2106,15 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@aws-sdk/xml-builder@3.533.0:
-    resolution: {integrity: sha512-wkqoK76SWokrNhcFbcNxGpDAS2S7VL03u7GcTYwezaA7L20VH4r2sT2u6VUFQ5v+aPZ973BesNTIF4sAItvCaw==}
+  /@aws-sdk/xml-builder@3.535.0:
+    resolution: {integrity: sha512-VXAq/Jz8KIrU84+HqsOJhIKZqG0PNTdi6n6PFQ4xJf44ZQHD/5C7ouH4qCFX5XgZXcgbRIcMVVYGC6Jye0dRng==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@aws/pdk@0.23.31(@aws-cdk/aws-cognito-identitypool-alpha@2.131.0-alpha.0)(aws-cdk-lib@2.126.0)(cdk-nag@2.28.27)(constructs@10.3.0)(projen@0.79.27):
+  /@aws/pdk@0.23.31(@aws-cdk/aws-cognito-identitypool-alpha@2.137.0-alpha.0)(aws-cdk-lib@2.126.0)(cdk-nag@2.28.27)(constructs@10.3.0)(projen@0.79.27):
     resolution: {integrity: sha512-fu5Nf/ISo0zvfoxs6ql3NVCb9tBsZpAirwOKMyMvjE3B+rp836mlghfjEsJ5wc50TqyGBOCoef8DihHyNLZF6Q==}
     hasBin: true
     peerDependencies:
@@ -2124,7 +2124,7 @@ packages:
       constructs: ^10.3.0
       projen: ^0.79.24
     dependencies:
-      '@aws-cdk/aws-cognito-identitypool-alpha': 2.131.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0)
+      '@aws-cdk/aws-cognito-identitypool-alpha': 2.137.0-alpha.0(aws-cdk-lib@2.126.0)(constructs@10.3.0)
       aws-cdk-lib: 2.126.0(constructs@10.3.0)
       cdk-nag: 2.28.27(aws-cdk-lib@2.126.0)(constructs@10.3.0)
       constructs: 10.3.0
@@ -3075,459 +3075,458 @@ packages:
     resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
     dev: true
 
-  /@smithy/abort-controller@2.1.4:
-    resolution: {integrity: sha512-66HO817oIZ2otLIqy06R5muapqZjkgF1jfU0wyNko8cuqZNu8nbS9ljlhcRYw/M/uWRJzB9ih81DLSHhYbBLlQ==}
+  /@smithy/abort-controller@2.2.0:
+    resolution: {integrity: sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/chunked-blob-reader-native@2.1.3:
-    resolution: {integrity: sha512-9RcLADDnQi8N3VMWNSFnhiUUuo19L0yHEV0i0CQPvRzf5o1FKHT7Zenrh3P9KcmECWQum3s/ljMcM+YeWd9tqg==}
+  /@smithy/chunked-blob-reader-native@2.2.0:
+    resolution: {integrity: sha512-VNB5+1oCgX3Fzs072yuRsUoC2N4Zg/LJ11DTxX3+Qu+Paa6AmbIF0E9sc2wthz9Psrk/zcOlTCyuposlIhPjZQ==}
     dependencies:
-      '@smithy/util-base64': 2.2.1
+      '@smithy/util-base64': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/chunked-blob-reader@2.1.1:
-    resolution: {integrity: sha512-NjNFCKxC4jVvn+lUr3Yo4/PmUJj3tbyqH6GNHueyTGS5Q27vlEJ1MkNhUDV8QGxJI7Bodnc2pD18lU2zRfhHlQ==}
+  /@smithy/chunked-blob-reader@2.2.0:
+    resolution: {integrity: sha512-3GJNvRwXBGdkDZZOGiziVYzDpn4j6zfyULHMDKAGIUo72yHALpE9CbhfQp/XcLNVoc1byfMpn6uW5H2BqPjgaQ==}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/config-resolver@2.1.5:
-    resolution: {integrity: sha512-LcBB5JQC3Tx2ZExIJzfvWaajhFIwHrUNQeqxhred2r5nnqrdly9uoCrvM1sxOOdghYuWWm2Kr8tBCDOmxsgeTA==}
+  /@smithy/config-resolver@2.2.0:
+    resolution: {integrity: sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-config-provider': 2.2.1
-      '@smithy/util-middleware': 2.1.4
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-config-provider': 2.3.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/core@1.3.8:
-    resolution: {integrity: sha512-6cFhQ9ChU7MxvOXJn6nuUSONacpNsGHWhfueROQuM/0vibDdZA9FWEdNbVkuVuc+BFI5BnaX3ltERUlpUirpIA==}
+  /@smithy/core@1.4.2:
+    resolution: {integrity: sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-retry': 2.1.7
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-middleware': 2.1.4
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-retry': 2.3.1
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/credential-provider-imds@2.2.6:
-    resolution: {integrity: sha512-+xQe4Pite0kdk9qn0Vyw5BRVh0iSlj+T4TEKRXr4E1wZKtVgIzGlkCrfICSjiPVFkPxk4jMpVboMYdEiiA88/w==}
+  /@smithy/credential-provider-imds@2.3.0:
+    resolution: {integrity: sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/property-provider': 2.1.4
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/eventstream-codec@2.1.4:
-    resolution: {integrity: sha512-UkiieTztP7adg8EuqZvB0Y4LewdleZCJU7Kgt9RDutMsRYqO32fMpWeQHeTHaIMosmzcRZUykMRrhwGJe9mP3A==}
+  /@smithy/eventstream-codec@2.2.0:
+    resolution: {integrity: sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==}
     dependencies:
       '@aws-crypto/crc32': 3.0.0
-      '@smithy/types': 2.11.0
-      '@smithy/util-hex-encoding': 2.1.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/eventstream-serde-browser@2.1.4:
-    resolution: {integrity: sha512-K0SyvrUu/vARKzNW+Wp9HImiC/cJ6K88/n7FTH1slY+MErdKoiSbRLaXbJ9qD6x1Hu28cplHMlhADwZelUx/Ww==}
+  /@smithy/eventstream-serde-browser@2.2.0:
+    resolution: {integrity: sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/eventstream-serde-universal': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/eventstream-serde-universal': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/eventstream-serde-config-resolver@2.1.4:
-    resolution: {integrity: sha512-FH+2AwOwZ0kHPB9sciWJtUqx81V4vizfT3P6T9eslmIC2hi8ch/KFvQlF7jDmwR1aLlPlq6qqLKLqzK/71Ki4A==}
+  /@smithy/eventstream-serde-config-resolver@2.2.0:
+    resolution: {integrity: sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/eventstream-serde-node@2.1.4:
-    resolution: {integrity: sha512-gsc5ZTvVcB9sleLQzsK/rOhgn52+AAsmhEr41WDwAcctccBjh429+b8gT9t+SU8QyajypfsLOZfJQu0+zE515Q==}
+  /@smithy/eventstream-serde-node@2.2.0:
+    resolution: {integrity: sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/eventstream-serde-universal': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/eventstream-serde-universal': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/eventstream-serde-universal@2.1.4:
-    resolution: {integrity: sha512-NKLAsYnZA5s+ntipJRKo1RrRbhYHrsEnmiUoz0EhVYrAih+UELY9sKR+A1ujGaFm3nKDs5fPfiozC2wpXq2zUA==}
+  /@smithy/eventstream-serde-universal@2.2.0:
+    resolution: {integrity: sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/eventstream-codec': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/eventstream-codec': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/fetch-http-handler@2.4.5:
-    resolution: {integrity: sha512-FR1IMGdo0yRFs1tk71zRGSa1MznVLQOVNaPjyNtx6dOcy/u0ovEnXN5NVz6slw5KujFlg3N1w4+UbO8F3WyYUg==}
+  /@smithy/fetch-http-handler@2.5.0:
+    resolution: {integrity: sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==}
     dependencies:
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/querystring-builder': 2.1.4
-      '@smithy/types': 2.11.0
-      '@smithy/util-base64': 2.2.1
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/querystring-builder': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-base64': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/hash-blob-browser@2.1.5:
-    resolution: {integrity: sha512-6HxT9Q25YxkyBLHiFEjNullTo2/w2hWo1IMnUZDn0Sun5D+BWEZiExJ83gKLVlkHvuAZX/bA5A8yxFLQ5FpGuQ==}
+  /@smithy/hash-blob-browser@2.2.0:
+    resolution: {integrity: sha512-SGPoVH8mdXBqrkVCJ1Hd1X7vh1zDXojNN1yZyZTZsCno99hVue9+IYzWDjq/EQDDXxmITB0gBmuyPh8oAZSTcg==}
     dependencies:
-      '@smithy/chunked-blob-reader': 2.1.1
-      '@smithy/chunked-blob-reader-native': 2.1.3
-      '@smithy/types': 2.11.0
+      '@smithy/chunked-blob-reader': 2.2.0
+      '@smithy/chunked-blob-reader-native': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/hash-node@2.1.4:
-    resolution: {integrity: sha512-uvCcpDLXaTTL0X/9ezF8T8sS77UglTfZVQaUOBiCvR0QydeSyio3t0Hj3QooVdyFsKTubR8gCk/ubLk3vAyDng==}
+  /@smithy/hash-node@2.2.0:
+    resolution: {integrity: sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
-      '@smithy/util-buffer-from': 2.1.1
-      '@smithy/util-utf8': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-buffer-from': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/hash-stream-node@2.1.4:
-    resolution: {integrity: sha512-HcDQRs/Fcx7lwAd+/vSW/e7ltdh148D2Pq7XI61CEWcOoQdQ0W8aYBHDRC4zjtXv6hySdmWE+vo3dvdTt7aj8A==}
+  /@smithy/hash-stream-node@2.2.0:
+    resolution: {integrity: sha512-aT+HCATOSRMGpPI7bi7NSsTNVZE/La9IaxLXWoVAYMxHT5hGO3ZOGEMZQg8A6nNL+pdFGtZQtND1eoY084HgHQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
-      '@smithy/util-utf8': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/invalid-dependency@2.1.4:
-    resolution: {integrity: sha512-QzlNBl6jt3nb9jNnE51wTegReVvUdozyMMrFEyb/rc6AzPID1O+qMJYjAAoNw098y0CZVfCpEnoK2+mfBOd8XA==}
+  /@smithy/invalid-dependency@2.2.0:
+    resolution: {integrity: sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/is-array-buffer@2.1.1:
-    resolution: {integrity: sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/md5-js@2.1.4:
-    resolution: {integrity: sha512-WHTnnYJPKE7Sy49DogLuox42TnlwD3cQ6TObPD6WFWjKocWIdpEpIvdJHwWUfSFf0JIi8ON8z6ZEhsnyKVCcLQ==}
-    dependencies:
-      '@smithy/types': 2.11.0
-      '@smithy/util-utf8': 2.2.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-content-length@2.1.4:
-    resolution: {integrity: sha512-C6VRwfcr0w9qRFhDGCpWMVhlEIBFlmlPRP1aX9Cv9xDj9SUwlDrNvoV1oP1vjRYuLxCDgovBBynCwwcluS2wLw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-endpoint@2.4.6:
-    resolution: {integrity: sha512-AsXtUXHPOAS0EGZUSFOsVJvc7p0KL29PGkLxLfycPOcFVLru/oinYB6yvyL73ZZPX2OB8sMYUMrj7eH2kI7V/w==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/middleware-serde': 2.2.1
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
-      '@smithy/url-parser': 2.1.4
-      '@smithy/util-middleware': 2.1.4
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-retry@2.1.7:
-    resolution: {integrity: sha512-8fOP/cJN4oMv+5SRffZC8RkqfWxHqGgn/86JPINY/1DnTRegzf+G5GT9lmIdG1YasuSbU7LISfW9PXil3isPVw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/service-error-classification': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-retry': 2.1.4
-      tslib: 2.6.2
-      uuid: 8.3.2
-    dev: false
-
-  /@smithy/middleware-serde@2.2.1:
-    resolution: {integrity: sha512-VAWRWqnNjgccebndpyK94om4ZTYzXLQxUmNCXYzM/3O9MTfQjTNBgtFtQwyIIez6z7LWcCsXmnKVIOE9mLqAHQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/middleware-stack@2.1.4:
-    resolution: {integrity: sha512-Qqs2ba8Ax1rGKOSGJS2JN23fhhox2WMdRuzx0NYHtXzhxbJOIMmz9uQY6Hf4PY8FPteBPp1+h0j5Fmr+oW12sg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/node-config-provider@2.2.5:
-    resolution: {integrity: sha512-CxPf2CXhjO79IypHJLBATB66Dw6suvr1Yc2ccY39hpR6wdse3pZ3E8RF83SODiNH0Wjmkd0ze4OF8exugEixgA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/property-provider': 2.1.4
-      '@smithy/shared-ini-file-loader': 2.3.5
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/node-http-handler@2.4.3:
-    resolution: {integrity: sha512-bD5zRdEl1u/4vAAMeQnGEUNbH1seISV2Z0Wnn7ltPRl/6B2zND1R9XzTfsOnH1R5jqghpochF/mma8u7uXz0qQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/abort-controller': 2.1.4
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/querystring-builder': 2.1.4
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/property-provider@2.1.4:
-    resolution: {integrity: sha512-nWaY/MImj1BiXZ9WY65h45dcxOx8pl06KYoHxwojDxDL+Q9yLU1YnZpgv8zsHhEftlj9KhePENjQTlNowWVyug==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/protocol-http@3.2.2:
-    resolution: {integrity: sha512-xYBlllOQcOuLoxzhF2u8kRHhIFGQpDeTQj/dBSnw4kfI29WMKL5RnW1m9YjnJAJ49miuIvrkJR+gW5bCQ+Mchw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/querystring-builder@2.1.4:
-    resolution: {integrity: sha512-LXSL0J/nRWvGT+jIj+Fip3j0J1ZmHkUyBFRzg/4SmPNCLeDrtVu7ptKOnTboPsFZu5BxmpYok3kJuQzzRdrhbw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      '@smithy/util-uri-escape': 2.1.1
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/querystring-parser@2.1.4:
-    resolution: {integrity: sha512-U2b8olKXgZAs0eRo7Op11jTNmmcC/sqYmsA7vN6A+jkGnDvJlEl7AetUegbBzU8q3D6WzC5rhR/joIy8tXPzIg==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/service-error-classification@2.1.4:
-    resolution: {integrity: sha512-JW2Hthy21evnvDmYYk1kItOmbp3X5XI5iqorXgFEunb6hQfSDZ7O1g0Clyxg7k/Pcr9pfLk5xDIR2To/IohlsQ==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-    dev: false
-
-  /@smithy/shared-ini-file-loader@2.3.5:
-    resolution: {integrity: sha512-oI99+hOvsM8oAJtxAGmoL/YCcGXtbP0fjPseYGaNmJ4X5xOFTer0KPk7AIH3AL6c5AlYErivEi1X/X78HgTVIw==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/types': 2.11.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/signature-v4@2.1.4:
-    resolution: {integrity: sha512-gnu9gCn0qQ8IdhNjs6o3QVCXzUs33znSDYwVMWo3nX4dM6j7z9u6FC302ShYyVWfO4MkVMuGCCJ6nl3PcH7V1Q==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/eventstream-codec': 2.1.4
-      '@smithy/is-array-buffer': 2.1.1
-      '@smithy/types': 2.11.0
-      '@smithy/util-hex-encoding': 2.1.1
-      '@smithy/util-middleware': 2.1.4
-      '@smithy/util-uri-escape': 2.1.1
-      '@smithy/util-utf8': 2.2.0
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/smithy-client@2.4.5:
-    resolution: {integrity: sha512-igXOM4kPXPo6b5LZXTUqTnrGk20uVd8OXoybC3f89gczzGfziLK4yUNOmiHSdxY9OOMOnnhVe5MpTm01MpFqvA==}
-    engines: {node: '>=14.0.0'}
-    dependencies:
-      '@smithy/middleware-endpoint': 2.4.6
-      '@smithy/middleware-stack': 2.1.4
-      '@smithy/protocol-http': 3.2.2
-      '@smithy/types': 2.11.0
-      '@smithy/util-stream': 2.1.5
-      tslib: 2.6.2
-    dev: false
-
-  /@smithy/types@2.11.0:
-    resolution: {integrity: sha512-AR0SXO7FuAskfNhyGfSTThpLRntDI5bOrU0xrpVYU0rZyjl3LBXInZFMTP/NNSd7IS6Ksdtar0QvnrPRIhVrLQ==}
+  /@smithy/is-array-buffer@2.2.0:
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/url-parser@2.1.4:
-    resolution: {integrity: sha512-1hTy6UYRYqOZlHKH2/2NzdNQ4NNmW2Lp0sYYvztKy+dEQuLvZL9w88zCzFQqqFer3DMcscYOshImxkJTGdV+rg==}
+  /@smithy/md5-js@2.2.0:
+    resolution: {integrity: sha512-M26XTtt9IIusVMOWEAhIvFIr9jYj4ISPPGJROqw6vXngO3IYJCnVVSMFn4Tx1rUTG5BiKJNg9u2nxmBiZC5IlQ==}
     dependencies:
-      '@smithy/querystring-parser': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-base64@2.2.1:
-    resolution: {integrity: sha512-troGfokrpoqv8TGgsb8p4vvM71vqor314514jyQ0i9Zae3qs0jUVbSMCIBB1tseVynXFRcZJAZ9hPQYlifLD5A==}
+  /@smithy/middleware-content-length@2.2.0:
+    resolution: {integrity: sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/util-buffer-from': 2.1.1
-      '@smithy/util-utf8': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-body-length-browser@2.1.1:
-    resolution: {integrity: sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==}
+  /@smithy/middleware-endpoint@2.5.1:
+    resolution: {integrity: sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==}
+    engines: {node: '>=14.0.0'}
     dependencies:
+      '@smithy/middleware-serde': 2.3.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      '@smithy/url-parser': 2.2.0
+      '@smithy/util-middleware': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-body-length-node@2.2.2:
-    resolution: {integrity: sha512-U7DooaT1SfW7XHrOcxthYJnQ+WMaefRrFPxW5Qmypw38Ivv+TKvfVuVHA9V162h8BeW9rzOJwOunjgXd0DdB4w==}
+  /@smithy/middleware-retry@2.3.1:
+    resolution: {integrity: sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/service-error-classification': 2.1.5
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-retry': 2.2.0
+      tslib: 2.6.2
+      uuid: 9.0.1
+    dev: false
+
+  /@smithy/middleware-serde@2.3.0:
+    resolution: {integrity: sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/middleware-stack@2.2.0:
+    resolution: {integrity: sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/node-config-provider@2.3.0:
+    resolution: {integrity: sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/property-provider': 2.2.0
+      '@smithy/shared-ini-file-loader': 2.4.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/node-http-handler@2.5.0:
+    resolution: {integrity: sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/abort-controller': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/querystring-builder': 2.2.0
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/property-provider@2.2.0:
+    resolution: {integrity: sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/protocol-http@3.3.0:
+    resolution: {integrity: sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/querystring-builder@2.2.0:
+    resolution: {integrity: sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      '@smithy/util-uri-escape': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/querystring-parser@2.2.0:
+    resolution: {integrity: sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/service-error-classification@2.1.5:
+    resolution: {integrity: sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+    dev: false
+
+  /@smithy/shared-ini-file-loader@2.4.0:
+    resolution: {integrity: sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/types': 2.12.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/signature-v4@2.3.0:
+    resolution: {integrity: sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-middleware': 2.2.0
+      '@smithy/util-uri-escape': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/smithy-client@2.5.1:
+    resolution: {integrity: sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/middleware-endpoint': 2.5.1
+      '@smithy/middleware-stack': 2.2.0
+      '@smithy/protocol-http': 3.3.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-stream': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/types@2.12.0:
+    resolution: {integrity: sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-buffer-from@2.1.1:
-    resolution: {integrity: sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==}
-    engines: {node: '>=14.0.0'}
+  /@smithy/url-parser@2.2.0:
+    resolution: {integrity: sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==}
     dependencies:
-      '@smithy/is-array-buffer': 2.1.1
+      '@smithy/querystring-parser': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-config-provider@2.2.1:
-    resolution: {integrity: sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==}
+  /@smithy/util-base64@2.3.0:
+    resolution: {integrity: sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-body-length-browser@2.2.0:
+    resolution: {integrity: sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-body-length-node@2.3.0:
+    resolution: {integrity: sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-defaults-mode-browser@2.1.7:
-    resolution: {integrity: sha512-vvIpWsysEdY77R0Qzr6+LRW50ye7eii7AyHM0OJnTi0isHYiXo5M/7o4k8gjK/b1upQJdfjzSBoJVa2SWrI+2g==}
+  /@smithy/util-buffer-from@2.2.0:
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-config-provider@2.3.0:
+    resolution: {integrity: sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==}
+    engines: {node: '>=14.0.0'}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
+  /@smithy/util-defaults-mode-browser@2.2.1:
+    resolution: {integrity: sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@smithy/property-provider': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       bowser: 2.11.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-defaults-mode-node@2.2.7:
-    resolution: {integrity: sha512-qzXkSDyU6Th+rNNcNkG4a7Ix7m5HlMOtSCPxTVKlkz7eVsqbSSPggegbFeQJ2MVELBB4wnzNPsVPJIrpIaJpXA==}
+  /@smithy/util-defaults-mode-node@2.3.1:
+    resolution: {integrity: sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==}
     engines: {node: '>= 10.0.0'}
     dependencies:
-      '@smithy/config-resolver': 2.1.5
-      '@smithy/credential-provider-imds': 2.2.6
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/property-provider': 2.1.4
-      '@smithy/smithy-client': 2.4.5
-      '@smithy/types': 2.11.0
+      '@smithy/config-resolver': 2.2.0
+      '@smithy/credential-provider-imds': 2.3.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/property-provider': 2.2.0
+      '@smithy/smithy-client': 2.5.1
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-endpoints@1.1.5:
-    resolution: {integrity: sha512-tgDpaUNsUtRvNiBulKU1VnpoXU1GINMfZZXunRhUXOTBEAufG1Wp79uDXLau2gg1RZ4dpAR6lXCkrmddihCGUg==}
+  /@smithy/util-endpoints@1.2.0:
+    resolution: {integrity: sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==}
     engines: {node: '>= 14.0.0'}
     dependencies:
-      '@smithy/node-config-provider': 2.2.5
-      '@smithy/types': 2.11.0
+      '@smithy/node-config-provider': 2.3.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-hex-encoding@2.1.1:
-    resolution: {integrity: sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==}
+  /@smithy/util-hex-encoding@2.2.0:
+    resolution: {integrity: sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-middleware@2.1.4:
-    resolution: {integrity: sha512-5yYNOgCN0DL0OplME0pthoUR/sCfipnROkbTO7m872o0GHCVNJj5xOFJ143rvHNA54+pIPMLum4z2DhPC2pVGA==}
+  /@smithy/util-middleware@2.2.0:
+    resolution: {integrity: sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/types': 2.11.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-retry@2.1.4:
-    resolution: {integrity: sha512-JRZwhA3fhkdenSEYIWatC8oLwt4Bdf2LhHbNQApqb7yFoIGMl4twcYI3BcJZ7YIBZrACA9jGveW6tuCd836XzQ==}
+  /@smithy/util-retry@2.2.0:
+    resolution: {integrity: sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==}
     engines: {node: '>= 14.0.0'}
     dependencies:
-      '@smithy/service-error-classification': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/service-error-classification': 2.1.5
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-stream@2.1.5:
-    resolution: {integrity: sha512-FqvBFeTgx+QC4+i8USHqU8Ifs9nYRpW/OBfksojtgkxPIQ2H7ypXDEbnQRAV7PwoNHWcSwPomLYi0svmQQG5ow==}
+  /@smithy/util-stream@2.2.0:
+    resolution: {integrity: sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/fetch-http-handler': 2.4.5
-      '@smithy/node-http-handler': 2.4.3
-      '@smithy/types': 2.11.0
-      '@smithy/util-base64': 2.2.1
-      '@smithy/util-buffer-from': 2.1.1
-      '@smithy/util-hex-encoding': 2.1.1
-      '@smithy/util-utf8': 2.2.0
+      '@smithy/fetch-http-handler': 2.5.0
+      '@smithy/node-http-handler': 2.5.0
+      '@smithy/types': 2.12.0
+      '@smithy/util-base64': 2.3.0
+      '@smithy/util-buffer-from': 2.2.0
+      '@smithy/util-hex-encoding': 2.2.0
+      '@smithy/util-utf8': 2.3.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-uri-escape@2.1.1:
-    resolution: {integrity: sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==}
+  /@smithy/util-uri-escape@2.2.0:
+    resolution: {integrity: sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-utf8@2.2.0:
-    resolution: {integrity: sha512-hBsKr5BqrDrKS8qy+YcV7/htmMGxriA1PREOf/8AGBhHIZnfilVv1Waf1OyKhSbFW15U/8+gcMUQ9/Kk5qwpHQ==}
+  /@smithy/util-utf8@2.3.0:
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/util-buffer-from': 2.1.1
+      '@smithy/util-buffer-from': 2.2.0
       tslib: 2.6.2
     dev: false
 
-  /@smithy/util-waiter@2.1.4:
-    resolution: {integrity: sha512-AK17WaC0hx1wR9juAOsQkJ6DjDxBGEf5TrKhpXtNFEn+cVto9Li3MVsdpAO97AF7bhFXSyC8tJA3F4ThhqwCdg==}
+  /@smithy/util-waiter@2.2.0:
+    resolution: {integrity: sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@smithy/abort-controller': 2.1.4
-      '@smithy/types': 2.11.0
+      '@smithy/abort-controller': 2.2.0
+      '@smithy/types': 2.12.0
       tslib: 2.6.2
     dev: false
 
@@ -4793,7 +4792,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-prettier@5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.4):
+  /eslint-plugin-prettier@5.0.0(eslint-config-prettier@9.0.0)(eslint@8.49.0)(prettier@3.2.5):
     resolution: {integrity: sha512-AgaZCVuYDXHUGxj/ZGu1u8H8CYgDY3iG6w5kUFw4AzMVXzB7VvbKgYR4nATIN+OvUrghMbiDLeimVjVY5ilq3w==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4809,7 +4808,7 @@ packages:
     dependencies:
       eslint: 8.49.0
       eslint-config-prettier: 9.0.0(eslint@8.49.0)
-      prettier: 3.2.4
+      prettier: 3.2.5
       prettier-linter-helpers: 1.0.0
       synckit: 0.8.5
     dev: true
@@ -6625,12 +6624,6 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.2.4:
-    resolution: {integrity: sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
@@ -7567,11 +7560,6 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
-
-  /uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
-    dev: false
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/scripts/codegen.config.ts
+++ b/scripts/codegen.config.ts
@@ -1,0 +1,18 @@
+export const config: Record<string, { command: string; input: string }> = {
+  "client-ec2": {
+    command: "DescribeInstances",
+    input: '{"InstanceIds": ["i-1234567890abcdef0"]}',
+  },
+  "client-elasticache": {
+    command: "DescribeCacheClusters",
+    input: '{"ShowCacheNodeInfo": true}',
+  },
+  "client-iam": {
+    command: "ListGroups",
+    input: '{"PathPrefix": "admin/"}',
+  },
+  "client-sns": {
+    command: "Publish",
+    input: '{"TopicArn": "test", "Message": "test"}',
+  },
+};


### PR DESCRIPTION
- Regenerates clients : `iam`, `ec2`, `elasticache`, `sns`.
- Improves codegen with some ideas from https://github.com/floydspace/effect-aws/pull/46 
	- Exports exceptions with the same name as the original package
	```diff
	import type {
	  ...
	-   UnrecognizedPublicKeyEncodingException,
	+   UnrecognizedPublicKeyEncodingException as SdkUnrecognizedPublicKeyEncodingException,
	  ...
	} from "@aws-sdk/client-iam";
	- export type `ConcurrentModificationError` =
	-   TaggedException<ConcurrentModificationException>;
	+ export type ConcurrentModificationException =
	+   TaggedException<SdkConcurrentModificationException>;
	```
    - Uses all `operator` shapes from model instead of only those of the `service` shape.
    - Setup default values of client generation.