### PR TITLE
fix(client-s3): getObject type was not exported correctly

### DIFF
--- a/.changeset/thirty-mangos-sparkle.md
+++ b/.changeset/thirty-mangos-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@effect-aws/client-s3": patch
+---
+
+Type fix

--- a/packages/client-s3/src/S3Service.ts
+++ b/packages/client-s3/src/S3Service.ts
@@ -428,6 +428,22 @@ interface S3Service$ {
   readonly _: unique symbol;
 
   /**
+   * @see {@link GetObjectCommand}
+   */
+  getObject:
+    | ((
+        args: GetObjectCommandInput,
+        options?: { readonly presigned?: false } & HttpHandlerOptions,
+      ) => Effect.Effect<
+        GetObjectCommandOutput,
+        SdkError | InvalidObjectStateError | NoSuchKeyError
+      >)
+    | ((
+        args: GetObjectCommandInput,
+        options?: { readonly presigned: true } & RequestPresigningArguments,
+      ) => Effect.Effect<string, SdkError | S3ServiceError>);
+
+  /**
    * @see {@link AbortMultipartUploadCommand}
    */
   abortMultipartUpload(
@@ -845,21 +861,6 @@ interface S3Service$ {
     args: GetBucketWebsiteCommandInput,
     options?: HttpHandlerOptions,
   ): Effect.Effect<GetBucketWebsiteCommandOutput, SdkError | S3ServiceError>;
-
-  /**
-   * @see {@link GetObjectCommand}
-   */
-  getObject(
-    args: GetObjectCommandInput,
-    options?: { readonly presigned?: false } & HttpHandlerOptions,
-  ): Effect.Effect<
-    GetObjectCommandOutput,
-    SdkError | InvalidObjectStateError | NoSuchKeyError
-  >;
-  getObject(
-    args: GetObjectCommandInput,
-    options?: { readonly presigned: true } & RequestPresigningArguments,
-  ): Effect.Effect<string, SdkError | S3ServiceError>;
 
   /**
    * @see {@link GetObjectAclCommand}


### PR DESCRIPTION
Type generation omits the "getObject" method in the definition, probably due to the double type function definition

To reproduce
```ts
// KO
yield* S3Service.getObject({Bucket, Key});
// OK
const {getObject} = yield* S3Service;
getObject({Bucket, Key});
```