### PR TITLE
fix: expose service shape type

### DIFF
--- a/.changeset/early-melons-hug.md
+++ b/.changeset/early-melons-hug.md
@@ -1,0 +1,55 @@
+---
+"@effect-aws/client-api-gateway-management-api": patch
+"@effect-aws/client-cognito-identity-provider": patch
+"@effect-aws/client-opensearch-serverless": patch
+"@effect-aws/client-iot-jobs-data-plane": patch
+"@effect-aws/client-timestream-influxdb": patch
+"@effect-aws/client-cloudwatch-events": patch
+"@effect-aws/client-timestream-query": patch
+"@effect-aws/client-timestream-write": patch
+"@effect-aws/client-bedrock-runtime": patch
+"@effect-aws/client-cloudwatch-logs": patch
+"@effect-aws/client-iot-events-data": patch
+"@effect-aws/client-secrets-manager": patch
+"@effect-aws/client-api-gateway-v2": patch
+"@effect-aws/client-iot-data-plane": patch
+"@effect-aws/client-organizations": patch
+"@effect-aws/client-auto-scaling": patch
+"@effect-aws/client-iot-wireless": patch
+"@effect-aws/client-api-gateway": patch
+"@effect-aws/client-cloudsearch": patch
+"@effect-aws/client-elasticache": patch
+"@effect-aws/client-eventbridge": patch
+"@effect-aws/client-cloudtrail": patch
+"@effect-aws/client-cloudwatch": patch
+"@effect-aws/client-codedeploy": patch
+"@effect-aws/client-iot-events": patch
+"@effect-aws/client-opensearch": patch
+"@effect-aws/client-scheduler": patch
+"@effect-aws/client-dynamodb": patch
+"@effect-aws/client-firehose": patch
+"@effect-aws/client-textract": patch
+"@effect-aws/client-account": patch
+"@effect-aws/client-bedrock": patch
+"@effect-aws/client-kinesis": patch
+"@effect-aws/client-athena": patch
+"@effect-aws/client-lambda": patch
+"@effect-aws/lib-dynamodb": patch
+"@effect-aws/client-ec2": patch
+"@effect-aws/client-ecr": patch
+"@effect-aws/client-ecs": patch
+"@effect-aws/client-iam": patch
+"@effect-aws/client-iot": patch
+"@effect-aws/client-kms": patch
+"@effect-aws/client-rds": patch
+"@effect-aws/client-ses": patch
+"@effect-aws/client-sfn": patch
+"@effect-aws/client-sns": patch
+"@effect-aws/client-sqs": patch
+"@effect-aws/client-ssm": patch
+"@effect-aws/client-sts": patch
+"@effect-aws/client-mq": patch
+"@effect-aws/client-s3": patch
+---
+
+expose service shape type as alternative of inferring it with Context.Tag.Service

--- a/packages/client-account/src/AccountService.ts
+++ b/packages/client-account/src/AccountService.ts
@@ -343,4 +343,9 @@ export declare namespace AccountService {
   export interface Config extends Omit<AccountClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = AccountService$;
 }

--- a/packages/client-account/src/index.ts
+++ b/packages/client-account/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Account {
    * @alias AccountService.Config
    */
   export type Config = AccountService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias AccountService.Type
+   */
+  export type Type = AccountService.Type;
 }
 
 /**

--- a/packages/client-api-gateway-management-api/src/ApiGatewayManagementApiService.ts
+++ b/packages/client-api-gateway-management-api/src/ApiGatewayManagementApiService.ts
@@ -124,4 +124,9 @@ export declare namespace ApiGatewayManagementApiService {
   export interface Config extends Omit<ApiGatewayManagementApiClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ApiGatewayManagementApiService$;
 }

--- a/packages/client-api-gateway-management-api/src/index.ts
+++ b/packages/client-api-gateway-management-api/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace ApiGatewayManagementApi {
    * @alias ApiGatewayManagementApiService.Config
    */
   export type Config = ApiGatewayManagementApiService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ApiGatewayManagementApiService.Type
+   */
+  export type Type = ApiGatewayManagementApiService.Type;
 }
 
 /**

--- a/packages/client-api-gateway-v2/src/ApiGatewayV2Service.ts
+++ b/packages/client-api-gateway-v2/src/ApiGatewayV2Service.ts
@@ -1168,4 +1168,9 @@ export declare namespace ApiGatewayV2Service {
   export interface Config extends Omit<ApiGatewayV2ClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ApiGatewayV2Service$;
 }

--- a/packages/client-api-gateway-v2/src/index.ts
+++ b/packages/client-api-gateway-v2/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace ApiGatewayV2 {
    * @alias ApiGatewayV2Service.Config
    */
   export type Config = ApiGatewayV2Service.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ApiGatewayV2Service.Type
+   */
+  export type Type = ApiGatewayV2Service.Type;
 }
 
 /**

--- a/packages/client-api-gateway/src/APIGatewayService.ts
+++ b/packages/client-api-gateway/src/APIGatewayService.ts
@@ -2477,4 +2477,9 @@ export declare namespace APIGatewayService {
   export interface Config extends Omit<APIGatewayClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = APIGatewayService$;
 }

--- a/packages/client-api-gateway/src/index.ts
+++ b/packages/client-api-gateway/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace APIGateway {
    * @alias APIGatewayService.Config
    */
   export type Config = APIGatewayService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias APIGatewayService.Type
+   */
+  export type Type = APIGatewayService.Type;
 }
 
 /**

--- a/packages/client-athena/src/AthenaService.ts
+++ b/packages/client-athena/src/AthenaService.ts
@@ -1109,4 +1109,9 @@ export declare namespace AthenaService {
   export interface Config extends Omit<AthenaClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = AthenaService$;
 }

--- a/packages/client-athena/src/index.ts
+++ b/packages/client-athena/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Athena {
    * @alias AthenaService.Config
    */
   export type Config = AthenaService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias AthenaService.Type
+   */
+  export type Type = AthenaService.Type;
 }
 
 /**

--- a/packages/client-auto-scaling/src/AutoScalingService.ts
+++ b/packages/client-auto-scaling/src/AutoScalingService.ts
@@ -1098,4 +1098,9 @@ export declare namespace AutoScalingService {
   export interface Config extends Omit<AutoScalingClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = AutoScalingService$;
 }

--- a/packages/client-auto-scaling/src/index.ts
+++ b/packages/client-auto-scaling/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace AutoScaling {
    * @alias AutoScalingService.Config
    */
   export type Config = AutoScalingService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias AutoScalingService.Type
+   */
+  export type Type = AutoScalingService.Type;
 }
 
 /**

--- a/packages/client-bedrock-runtime/src/BedrockRuntimeService.ts
+++ b/packages/client-bedrock-runtime/src/BedrockRuntimeService.ts
@@ -295,4 +295,9 @@ export declare namespace BedrockRuntimeService {
   export interface Config extends Omit<BedrockRuntimeClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = BedrockRuntimeService$;
 }

--- a/packages/client-bedrock-runtime/src/index.ts
+++ b/packages/client-bedrock-runtime/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace BedrockRuntime {
    * @alias BedrockRuntimeService.Config
    */
   export type Config = BedrockRuntimeService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias BedrockRuntimeService.Type
+   */
+  export type Type = BedrockRuntimeService.Type;
 }
 
 /**

--- a/packages/client-bedrock/src/BedrockService.ts
+++ b/packages/client-bedrock/src/BedrockService.ts
@@ -1287,4 +1287,9 @@ export declare namespace BedrockService {
   export interface Config extends Omit<BedrockClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = BedrockService$;
 }

--- a/packages/client-bedrock/src/index.ts
+++ b/packages/client-bedrock/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Bedrock {
    * @alias BedrockService.Config
    */
   export type Config = BedrockService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias BedrockService.Type
+   */
+  export type Type = BedrockService.Type;
 }
 
 /**

--- a/packages/client-cloudsearch/src/CloudSearchService.ts
+++ b/packages/client-cloudsearch/src/CloudSearchService.ts
@@ -576,4 +576,9 @@ export declare namespace CloudSearchService {
   export interface Config extends Omit<CloudSearchClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CloudSearchService$;
 }

--- a/packages/client-cloudsearch/src/index.ts
+++ b/packages/client-cloudsearch/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CloudSearch {
    * @alias CloudSearchService.Config
    */
   export type Config = CloudSearchService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CloudSearchService.Type
+   */
+  export type Type = CloudSearchService.Type;
 }
 
 /**

--- a/packages/client-cloudtrail/src/CloudTrailService.ts
+++ b/packages/client-cloudtrail/src/CloudTrailService.ts
@@ -1590,4 +1590,9 @@ export declare namespace CloudTrailService {
   export interface Config extends Omit<CloudTrailClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CloudTrailService$;
 }

--- a/packages/client-cloudtrail/src/index.ts
+++ b/packages/client-cloudtrail/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CloudTrail {
    * @alias CloudTrailService.Config
    */
   export type Config = CloudTrailService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CloudTrailService.Type
+   */
+  export type Type = CloudTrailService.Type;
 }
 
 /**

--- a/packages/client-cloudwatch-events/src/CloudWatchEventsService.ts
+++ b/packages/client-cloudwatch-events/src/CloudWatchEventsService.ts
@@ -972,4 +972,9 @@ export declare namespace CloudWatchEventsService {
   export interface Config extends Omit<CloudWatchEventsClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CloudWatchEventsService$;
 }

--- a/packages/client-cloudwatch-events/src/index.ts
+++ b/packages/client-cloudwatch-events/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CloudWatchEvents {
    * @alias CloudWatchEventsService.Config
    */
   export type Config = CloudWatchEventsService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CloudWatchEventsService.Type
+   */
+  export type Type = CloudWatchEventsService.Type;
 }
 
 /**

--- a/packages/client-cloudwatch-logs/src/CloudWatchLogsService.ts
+++ b/packages/client-cloudwatch-logs/src/CloudWatchLogsService.ts
@@ -1772,4 +1772,9 @@ export declare namespace CloudWatchLogsService {
   export interface Config extends Omit<CloudWatchLogsClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CloudWatchLogsService$;
 }

--- a/packages/client-cloudwatch-logs/src/index.ts
+++ b/packages/client-cloudwatch-logs/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CloudWatchLogs {
    * @alias CloudWatchLogsService.Config
    */
   export type Config = CloudWatchLogsService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CloudWatchLogsService.Type
+   */
+  export type Type = CloudWatchLogsService.Type;
 }
 
 /**

--- a/packages/client-cloudwatch/src/CloudWatchService.ts
+++ b/packages/client-cloudwatch/src/CloudWatchService.ts
@@ -738,4 +738,9 @@ export declare namespace CloudWatchService {
   export interface Config extends Omit<CloudWatchClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CloudWatchService$;
 }

--- a/packages/client-cloudwatch/src/index.ts
+++ b/packages/client-cloudwatch/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CloudWatch {
    * @alias CloudWatchService.Config
    */
   export type Config = CloudWatchService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CloudWatchService.Type
+   */
+  export type Type = CloudWatchService.Type;
 }
 
 /**

--- a/packages/client-codedeploy/src/CodeDeployService.ts
+++ b/packages/client-codedeploy/src/CodeDeployService.ts
@@ -1242,4 +1242,9 @@ export declare namespace CodeDeployService {
   export interface Config extends Omit<CodeDeployClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CodeDeployService$;
 }

--- a/packages/client-codedeploy/src/index.ts
+++ b/packages/client-codedeploy/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CodeDeploy {
    * @alias CodeDeployService.Config
    */
   export type Config = CodeDeployService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CodeDeployService.Type
+   */
+  export type Type = CodeDeployService.Type;
 }
 
 /**

--- a/packages/client-cognito-identity-provider/src/CognitoIdentityProviderService.ts
+++ b/packages/client-cognito-identity-provider/src/CognitoIdentityProviderService.ts
@@ -2871,4 +2871,9 @@ export declare namespace CognitoIdentityProviderService {
   export interface Config extends Omit<CognitoIdentityProviderClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = CognitoIdentityProviderService$;
 }

--- a/packages/client-cognito-identity-provider/src/index.ts
+++ b/packages/client-cognito-identity-provider/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace CognitoIdentityProvider {
    * @alias CognitoIdentityProviderService.Config
    */
   export type Config = CognitoIdentityProviderService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias CognitoIdentityProviderService.Type
+   */
+  export type Type = CognitoIdentityProviderService.Type;
 }
 
 /**

--- a/packages/client-dynamodb/src/DynamoDBService.ts
+++ b/packages/client-dynamodb/src/DynamoDBService.ts
@@ -1201,4 +1201,9 @@ export declare namespace DynamoDBService {
   export interface Config extends Omit<DynamoDBClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = DynamoDBService$;
 }

--- a/packages/client-dynamodb/src/index.ts
+++ b/packages/client-dynamodb/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace DynamoDB {
    * @alias DynamoDBService.Config
    */
   export type Config = DynamoDBService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias DynamoDBService.Type
+   */
+  export type Type = DynamoDBService.Type;
 }
 
 /**

--- a/packages/client-ec2/src/EC2Service.ts
+++ b/packages/client-ec2/src/EC2Service.ts
@@ -10288,4 +10288,9 @@ export declare namespace EC2Service {
   export interface Config extends Omit<EC2ClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = EC2Service$;
 }

--- a/packages/client-ec2/src/index.ts
+++ b/packages/client-ec2/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace EC2 {
    * @alias EC2Service.Config
    */
   export type Config = EC2Service.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias EC2Service.Type
+   */
+  export type Type = EC2Service.Type;
 }
 
 /**

--- a/packages/client-ecr/src/ECRService.ts
+++ b/packages/client-ecr/src/ECRService.ts
@@ -1030,4 +1030,9 @@ export declare namespace ECRService {
   export interface Config extends Omit<ECRClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ECRService$;
 }

--- a/packages/client-ecr/src/index.ts
+++ b/packages/client-ecr/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace ECR {
    * @alias ECRService.Config
    */
   export type Config = ECRService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ECRService.Type
+   */
+  export type Type = ECRService.Type;
 }
 
 /**

--- a/packages/client-ecs/src/ECSService.ts
+++ b/packages/client-ecs/src/ECSService.ts
@@ -1213,4 +1213,9 @@ export declare namespace ECSService {
   export interface Config extends Omit<ECSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ECSService$;
 }

--- a/packages/client-ecs/src/index.ts
+++ b/packages/client-ecs/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace ECS {
    * @alias ECSService.Config
    */
   export type Config = ECSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ECSService.Type
+   */
+  export type Type = ECSService.Type;
 }
 
 /**

--- a/packages/client-elasticache/src/ElastiCacheService.ts
+++ b/packages/client-elasticache/src/ElastiCacheService.ts
@@ -1760,4 +1760,9 @@ export declare namespace ElastiCacheService {
   export interface Config extends Omit<ElastiCacheClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ElastiCacheService$;
 }

--- a/packages/client-elasticache/src/index.ts
+++ b/packages/client-elasticache/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace ElastiCache {
    * @alias ElastiCacheService.Config
    */
   export type Config = ElastiCacheService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ElastiCacheService.Type
+   */
+  export type Type = ElastiCacheService.Type;
 }
 
 /**

--- a/packages/client-eventbridge/src/EventBridgeService.ts
+++ b/packages/client-eventbridge/src/EventBridgeService.ts
@@ -1078,4 +1078,9 @@ export declare namespace EventBridgeService {
   export interface Config extends Omit<EventBridgeClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = EventBridgeService$;
 }

--- a/packages/client-eventbridge/src/index.ts
+++ b/packages/client-eventbridge/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace EventBridge {
    * @alias EventBridgeService.Config
    */
   export type Config = EventBridgeService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias EventBridgeService.Type
+   */
+  export type Type = EventBridgeService.Type;
 }
 
 /**

--- a/packages/client-firehose/src/FirehoseService.ts
+++ b/packages/client-firehose/src/FirehoseService.ts
@@ -308,4 +308,9 @@ export declare namespace FirehoseService {
   export interface Config extends Omit<FirehoseClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = FirehoseService$;
 }

--- a/packages/client-firehose/src/index.ts
+++ b/packages/client-firehose/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Firehose {
    * @alias FirehoseService.Config
    */
   export type Config = FirehoseService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias FirehoseService.Type
+   */
+  export type Type = FirehoseService.Type;
 }
 
 /**

--- a/packages/client-iam/src/IAMService.ts
+++ b/packages/client-iam/src/IAMService.ts
@@ -2961,4 +2961,9 @@ export declare namespace IAMService {
   export interface Config extends Omit<IAMClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IAMService$;
 }

--- a/packages/client-iam/src/index.ts
+++ b/packages/client-iam/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IAM {
    * @alias IAMService.Config
    */
   export type Config = IAMService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IAMService.Type
+   */
+  export type Type = IAMService.Type;
 }
 
 /**

--- a/packages/client-iot-data-plane/src/IoTDataPlaneService.ts
+++ b/packages/client-iot-data-plane/src/IoTDataPlaneService.ts
@@ -249,4 +249,9 @@ export declare namespace IoTDataPlaneService {
   export interface Config extends Omit<IoTDataPlaneClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTDataPlaneService$;
 }

--- a/packages/client-iot-data-plane/src/index.ts
+++ b/packages/client-iot-data-plane/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoTDataPlane {
    * @alias IoTDataPlaneService.Config
    */
   export type Config = IoTDataPlaneService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTDataPlaneService.Type
+   */
+  export type Type = IoTDataPlaneService.Type;
 }
 
 /**

--- a/packages/client-iot-events-data/src/IoTEventsDataService.ts
+++ b/packages/client-iot-events-data/src/IoTEventsDataService.ts
@@ -326,4 +326,9 @@ export declare namespace IoTEventsDataService {
   export interface Config extends Omit<IoTEventsDataClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTEventsDataService$;
 }

--- a/packages/client-iot-events-data/src/index.ts
+++ b/packages/client-iot-events-data/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoTEventsData {
    * @alias IoTEventsDataService.Config
    */
   export type Config = IoTEventsDataService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTEventsDataService.Type
+   */
+  export type Type = IoTEventsDataService.Type;
 }
 
 /**

--- a/packages/client-iot-events/src/IoTEventsService.ts
+++ b/packages/client-iot-events/src/IoTEventsService.ts
@@ -642,4 +642,9 @@ export declare namespace IoTEventsService {
   export interface Config extends Omit<IoTEventsClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTEventsService$;
 }

--- a/packages/client-iot-events/src/index.ts
+++ b/packages/client-iot-events/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoTEvents {
    * @alias IoTEventsService.Config
    */
   export type Config = IoTEventsService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTEventsService.Type
+   */
+  export type Type = IoTEventsService.Type;
 }
 
 /**

--- a/packages/client-iot-jobs-data-plane/src/IoTJobsDataPlaneService.ts
+++ b/packages/client-iot-jobs-data-plane/src/IoTJobsDataPlaneService.ts
@@ -198,4 +198,9 @@ export declare namespace IoTJobsDataPlaneService {
   export interface Config extends Omit<IoTJobsDataPlaneClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTJobsDataPlaneService$;
 }

--- a/packages/client-iot-jobs-data-plane/src/index.ts
+++ b/packages/client-iot-jobs-data-plane/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoTJobsDataPlane {
    * @alias IoTJobsDataPlaneService.Config
    */
   export type Config = IoTJobsDataPlaneService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTJobsDataPlaneService.Type
+   */
+  export type Type = IoTJobsDataPlaneService.Type;
 }
 
 /**

--- a/packages/client-iot-wireless/src/IoTWirelessService.ts
+++ b/packages/client-iot-wireless/src/IoTWirelessService.ts
@@ -2351,4 +2351,9 @@ export declare namespace IoTWirelessService {
   export interface Config extends Omit<IoTWirelessClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTWirelessService$;
 }

--- a/packages/client-iot-wireless/src/index.ts
+++ b/packages/client-iot-wireless/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoTWireless {
    * @alias IoTWirelessService.Config
    */
   export type Config = IoTWirelessService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTWirelessService.Type
+   */
+  export type Type = IoTWirelessService.Type;
 }
 
 /**

--- a/packages/client-iot/src/IoTService.ts
+++ b/packages/client-iot/src/IoTService.ts
@@ -5601,4 +5601,9 @@ export declare namespace IoTService {
   export interface Config extends Omit<IoTClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = IoTService$;
 }

--- a/packages/client-iot/src/index.ts
+++ b/packages/client-iot/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace IoT {
    * @alias IoTService.Config
    */
   export type Config = IoTService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias IoTService.Type
+   */
+  export type Type = IoTService.Type;
 }
 
 /**

--- a/packages/client-kinesis/src/KinesisService.ts
+++ b/packages/client-kinesis/src/KinesisService.ts
@@ -822,4 +822,9 @@ export declare namespace KinesisService {
   export interface Config extends Omit<KinesisClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = KinesisService$;
 }

--- a/packages/client-kinesis/src/index.ts
+++ b/packages/client-kinesis/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Kinesis {
    * @alias KinesisService.Config
    */
   export type Config = KinesisService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias KinesisService.Type
+   */
+  export type Type = KinesisService.Type;
 }
 
 /**

--- a/packages/client-kms/src/KMSService.ts
+++ b/packages/client-kms/src/KMSService.ts
@@ -1333,4 +1333,9 @@ export declare namespace KMSService {
   export interface Config extends Omit<KMSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = KMSService$;
 }

--- a/packages/client-kms/src/index.ts
+++ b/packages/client-kms/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace KMS {
    * @alias KMSService.Config
    */
   export type Config = KMSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias KMSService.Type
+   */
+  export type Type = KMSService.Type;
 }
 
 /**

--- a/packages/client-lambda/src/LambdaService.ts
+++ b/packages/client-lambda/src/LambdaService.ts
@@ -1538,4 +1538,9 @@ export declare namespace LambdaService {
   export interface Config extends Omit<LambdaClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = LambdaService$;
 }

--- a/packages/client-lambda/src/index.ts
+++ b/packages/client-lambda/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Lambda {
    * @alias LambdaService.Config
    */
   export type Config = LambdaService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias LambdaService.Type
+   */
+  export type Type = LambdaService.Type;
 }
 
 /**

--- a/packages/client-mq/src/MqService.ts
+++ b/packages/client-mq/src/MqService.ts
@@ -479,4 +479,9 @@ export declare namespace MqService {
   export interface Config extends Omit<MqClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = MqService$;
 }

--- a/packages/client-mq/src/index.ts
+++ b/packages/client-mq/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Mq {
    * @alias MqService.Config
    */
   export type Config = MqService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias MqService.Type
+   */
+  export type Type = MqService.Type;
 }
 
 /**

--- a/packages/client-opensearch-serverless/src/OpenSearchServerlessService.ts
+++ b/packages/client-opensearch-serverless/src/OpenSearchServerlessService.ts
@@ -691,4 +691,9 @@ export declare namespace OpenSearchServerlessService {
   export interface Config extends Omit<OpenSearchServerlessClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = OpenSearchServerlessService$;
 }

--- a/packages/client-opensearch-serverless/src/index.ts
+++ b/packages/client-opensearch-serverless/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace OpenSearchServerless {
    * @alias OpenSearchServerlessService.Config
    */
   export type Config = OpenSearchServerlessService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias OpenSearchServerlessService.Type
+   */
+  export type Type = OpenSearchServerlessService.Type;
 }
 
 /**

--- a/packages/client-opensearch/src/OpenSearchService.ts
+++ b/packages/client-opensearch/src/OpenSearchService.ts
@@ -1557,4 +1557,9 @@ export declare namespace OpenSearchService {
   export interface Config extends Omit<OpenSearchClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = OpenSearchService$;
 }

--- a/packages/client-opensearch/src/index.ts
+++ b/packages/client-opensearch/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace OpenSearch {
    * @alias OpenSearchService.Config
    */
   export type Config = OpenSearchService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias OpenSearchService.Type
+   */
+  export type Type = OpenSearchService.Type;
 }
 
 /**

--- a/packages/client-organizations/src/OrganizationsService.ts
+++ b/packages/client-organizations/src/OrganizationsService.ts
@@ -1448,4 +1448,9 @@ export declare namespace OrganizationsService {
   export interface Config extends Omit<OrganizationsClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = OrganizationsService$;
 }

--- a/packages/client-organizations/src/index.ts
+++ b/packages/client-organizations/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Organizations {
    * @alias OrganizationsService.Config
    */
   export type Config = OrganizationsService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias OrganizationsService.Type
+   */
+  export type Type = OrganizationsService.Type;
 }
 
 /**

--- a/packages/client-rds/src/RDSService.ts
+++ b/packages/client-rds/src/RDSService.ts
@@ -3302,4 +3302,9 @@ export declare namespace RDSService {
   export interface Config extends Omit<RDSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = RDSService$;
 }

--- a/packages/client-rds/src/index.ts
+++ b/packages/client-rds/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace RDS {
    * @alias RDSService.Config
    */
   export type Config = RDSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias RDSService.Type
+   */
+  export type Type = RDSService.Type;
 }
 
 /**

--- a/packages/client-s3/src/S3Service.ts
+++ b/packages/client-s3/src/S3Service.ts
@@ -1617,4 +1617,9 @@ export declare namespace S3Service {
   export interface Config extends Omit<S3ClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = S3Service$;
 }

--- a/packages/client-s3/src/index.ts
+++ b/packages/client-s3/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace S3 {
    * @alias S3Service.Config
    */
   export type Config = S3Service.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias S3Service.Type
+   */
+  export type Type = S3Service.Type;
 }
 
 /**

--- a/packages/client-scheduler/src/SchedulerService.ts
+++ b/packages/client-scheduler/src/SchedulerService.ts
@@ -306,4 +306,9 @@ export declare namespace SchedulerService {
   export interface Config extends Omit<SchedulerClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SchedulerService$;
 }

--- a/packages/client-scheduler/src/index.ts
+++ b/packages/client-scheduler/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Scheduler {
    * @alias SchedulerService.Config
    */
   export type Config = SchedulerService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SchedulerService.Type
+   */
+  export type Type = SchedulerService.Type;
 }
 
 /**

--- a/packages/client-secrets-manager/src/SecretsManagerService.ts
+++ b/packages/client-secrets-manager/src/SecretsManagerService.ts
@@ -562,4 +562,9 @@ export declare namespace SecretsManagerService {
   export interface Config extends Omit<SecretsManagerClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SecretsManagerService$;
 }

--- a/packages/client-secrets-manager/src/index.ts
+++ b/packages/client-secrets-manager/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SecretsManager {
    * @alias SecretsManagerService.Config
    */
   export type Config = SecretsManagerService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SecretsManagerService.Type
+   */
+  export type Type = SecretsManagerService.Type;
 }
 
 /**

--- a/packages/client-ses/src/SESService.ts
+++ b/packages/client-ses/src/SESService.ts
@@ -1261,4 +1261,9 @@ export declare namespace SESService {
   export interface Config extends Omit<SESClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SESService$;
 }

--- a/packages/client-ses/src/index.ts
+++ b/packages/client-ses/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SES {
    * @alias SESService.Config
    */
   export type Config = SESService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SESService.Type
+   */
+  export type Type = SESService.Type;
 }
 
 /**

--- a/packages/client-sfn/src/SFNService.ts
+++ b/packages/client-sfn/src/SFNService.ts
@@ -824,4 +824,9 @@ export declare namespace SFNService {
   export interface Config extends Omit<SFNClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SFNService$;
 }

--- a/packages/client-sfn/src/index.ts
+++ b/packages/client-sfn/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SFN {
    * @alias SFNService.Config
    */
   export type Config = SFNService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SFNService.Type
+   */
+  export type Type = SFNService.Type;
 }
 
 /**

--- a/packages/client-sns/src/SNSService.ts
+++ b/packages/client-sns/src/SNSService.ts
@@ -906,4 +906,9 @@ export declare namespace SNSService {
   export interface Config extends Omit<SNSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SNSService$;
 }

--- a/packages/client-sns/src/index.ts
+++ b/packages/client-sns/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SNS {
    * @alias SNSService.Config
    */
   export type Config = SNSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SNSService.Type
+   */
+  export type Type = SNSService.Type;
 }
 
 /**

--- a/packages/client-sqs/src/SQSService.ts
+++ b/packages/client-sqs/src/SQSService.ts
@@ -636,4 +636,9 @@ export declare namespace SQSService {
   export interface Config extends Omit<SQSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SQSService$;
 }

--- a/packages/client-sqs/src/index.ts
+++ b/packages/client-sqs/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SQS {
    * @alias SQSService.Config
    */
   export type Config = SQSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SQSService.Type
+   */
+  export type Type = SQSService.Type;
 }
 
 /**

--- a/packages/client-ssm/src/SSMService.ts
+++ b/packages/client-ssm/src/SSMService.ts
@@ -2876,4 +2876,9 @@ export declare namespace SSMService {
   export interface Config extends Omit<SSMClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = SSMService$;
 }

--- a/packages/client-ssm/src/index.ts
+++ b/packages/client-ssm/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace SSM {
    * @alias SSMService.Config
    */
   export type Config = SSMService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias SSMService.Type
+   */
+  export type Type = SSMService.Type;
 }
 
 /**

--- a/packages/client-sts/src/STSService.ts
+++ b/packages/client-sts/src/STSService.ts
@@ -240,4 +240,9 @@ export declare namespace STSService {
   export interface Config extends Omit<STSClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = STSService$;
 }

--- a/packages/client-sts/src/index.ts
+++ b/packages/client-sts/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace STS {
    * @alias STSService.Config
    */
   export type Config = STSService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias STSService.Type
+   */
+  export type Type = STSService.Type;
 }
 
 /**

--- a/packages/client-textract/src/TextractService.ts
+++ b/packages/client-textract/src/TextractService.ts
@@ -716,4 +716,9 @@ export declare namespace TextractService {
   export interface Config extends Omit<TextractClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = TextractService$;
 }

--- a/packages/client-textract/src/index.ts
+++ b/packages/client-textract/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace Textract {
    * @alias TextractService.Config
    */
   export type Config = TextractService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias TextractService.Type
+   */
+  export type Type = TextractService.Type;
 }
 
 /**

--- a/packages/client-timestream-influxdb/src/TimestreamInfluxDBService.ts
+++ b/packages/client-timestream-influxdb/src/TimestreamInfluxDBService.ts
@@ -435,4 +435,9 @@ export declare namespace TimestreamInfluxDBService {
   export interface Config extends Omit<TimestreamInfluxDBClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = TimestreamInfluxDBService$;
 }

--- a/packages/client-timestream-influxdb/src/index.ts
+++ b/packages/client-timestream-influxdb/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace TimestreamInfluxDB {
    * @alias TimestreamInfluxDBService.Config
    */
   export type Config = TimestreamInfluxDBService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias TimestreamInfluxDBService.Type
+   */
+  export type Type = TimestreamInfluxDBService.Type;
 }
 
 /**

--- a/packages/client-timestream-query/src/TimestreamQueryService.ts
+++ b/packages/client-timestream-query/src/TimestreamQueryService.ts
@@ -385,4 +385,9 @@ export declare namespace TimestreamQueryService {
   export interface Config extends Omit<TimestreamQueryClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = TimestreamQueryService$;
 }

--- a/packages/client-timestream-query/src/index.ts
+++ b/packages/client-timestream-query/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace TimestreamQuery {
    * @alias TimestreamQueryService.Config
    */
   export type Config = TimestreamQueryService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias TimestreamQueryService.Type
+   */
+  export type Type = TimestreamQueryService.Type;
 }
 
 /**

--- a/packages/client-timestream-write/src/TimestreamWriteService.ts
+++ b/packages/client-timestream-write/src/TimestreamWriteService.ts
@@ -492,4 +492,9 @@ export declare namespace TimestreamWriteService {
   export interface Config extends Omit<TimestreamWriteClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = TimestreamWriteService$;
 }

--- a/packages/client-timestream-write/src/index.ts
+++ b/packages/client-timestream-write/src/index.ts
@@ -34,6 +34,12 @@ export declare namespace TimestreamWrite {
    * @alias TimestreamWriteService.Config
    */
   export type Config = TimestreamWriteService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias TimestreamWriteService.Type
+   */
+  export type Type = TimestreamWriteService.Type;
 }
 
 /**

--- a/packages/lib-dynamodb/src/DynamoDBDocumentService.ts
+++ b/packages/lib-dynamodb/src/DynamoDBDocumentService.ts
@@ -369,4 +369,9 @@ export declare namespace DynamoDBDocumentService {
    * @since 1.0.0
    */
   export type Config = TranslateConfig;
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = DynamoDBDocumentService$;
 }

--- a/packages/lib-dynamodb/src/index.ts
+++ b/packages/lib-dynamodb/src/index.ts
@@ -29,6 +29,12 @@ export declare namespace DynamoDBDocument {
    * @alias DynamoDBDocumentService.Config
    */
   export type Config = DynamoDBDocumentService.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias DynamoDBDocumentService.Type
+   */
+  export type Type = DynamoDBDocumentService.Type;
 }
 
 /**

--- a/scripts/generate-client.ts
+++ b/scripts/generate-client.ts
@@ -301,6 +301,12 @@ export declare namespace ${sdkName} {
    * @alias ${sdkName}Service.Config
    */
   export type Config = ${sdkName}Service.Config;
+
+  /**
+   * @since 1.0.0
+   * @alias ${sdkName}Service.Type
+   */
+  export type Type = ${sdkName}Service.Type;
 }
 
 /**
@@ -508,6 +514,11 @@ export declare namespace ${sdkName}Service {
   export interface Config extends Omit<${sdkName}ClientConfig, "logger"> {
     readonly logger?: ServiceLogger.ServiceLoggerConstructorProps | true;
   }
+
+  /**
+   * @since 1.0.0
+   */
+  export type Type = ${sdkName}Service$;
 }
 `,
   );


### PR DESCRIPTION
fixes #164 

if you need to get the shape of the service you used to do `Context.Tag.Service<SNSService>`

now you can use `SNSService.Type`