### PR TITLE
feat: upgrade effect to 4.0.0-beta.93

### DIFF
--- a/.changeset/cold-wasps-sell.md
+++ b/.changeset/cold-wasps-sell.md
@@ -1,0 +1,8 @@
+---
+"@effect-aws/powertools-logger": minor
+"@effect-aws/powertools-tracer": minor
+"@effect-aws/dynamodb": minor
+"@effect-aws/s3": minor
+---
+
+Fix breaking change introduced in effect 4-beta.66

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "@effect/vitest",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -135,12 +135,12 @@
     },
     {
       "name": "@effect/platform-node",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "runtime"
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "runtime"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -43,11 +43,11 @@ new Vitest(project, { sharedSetupFiles: ["vitest.setup.ts"] });
 project.addDevDeps("vitest-mock-extended");
 project.addDevDeps("aws-sdk-client-mock", "aws-sdk-client-mock-vitest@^6.2.1");
 
-const effectDeps = ["effect@4.0.0-beta.48"];
+const effectDeps = ["effect@4.0.0-beta.93"];
 
 project.addScripts({ "codegen-client": "tsx ./scripts/codegen-cli.ts" });
-project.addDeps(...effectDeps, "@effect/platform-node@4.0.0-beta.48");
-project.addDevDeps("@effect/language-service", "@effect/vitest@4.0.0-beta.48");
+project.addDeps(...effectDeps, "@effect/platform-node@4.0.0-beta.93");
+project.addDevDeps("@effect/language-service", "@effect/vitest@4.0.0-beta.93");
 project.tsconfigBase?.file.addOverride("compilerOptions.plugins", [
   { name: "@effect/language-service" },
 ]);
@@ -59,7 +59,7 @@ project.addTask("pages:build", { exec: "vitepress build pages" });
 project.addTask("pages:preview", { exec: "vitepress preview pages" });
 
 const commonDevDeps = [...effectDeps];
-const commonPeerDeps = ["effect@>=4.0.0 <5.0.0"];
+const commonPeerDeps = ["effect@>=4.0.0-beta.66 <5.0.0"];
 
 const commons = new TypeScriptLibProject({
   parent: project,
@@ -117,8 +117,8 @@ const lambda = new TypeScriptLibProject({
   parent: project,
   name: "lambda",
   description: "Effectful AWS Lambda handler",
-  devDeps: [...effectDeps, "@effect/platform-node-shared@4.0.0-beta.48", "@types/aws-lambda"],
-  peerDeps: ["effect@>=4.0.0 <5.0.0", "@effect/platform-node-shared@>=4.0.0 <5.0.0"],
+  devDeps: [...effectDeps, "@effect/platform-node-shared@4.0.0-beta.93", "@types/aws-lambda"],
+  peerDeps: ["effect@>=4.0.0-beta.66 <5.0.0", "@effect/platform-node-shared@>=4.0.0 <5.0.0"],
   addExamples: true,
 });
 
@@ -189,7 +189,7 @@ new TypeScriptLibProject({
     ...effectDeps,
     "@aws-sdk/client-s3@^3",
   ],
-  peerDeps: ["effect@>=4.0.0 <5.0.0"],
+  peerDeps: ["effect@>=4.0.0-beta.66 <5.0.0"],
   workspacePeerDeps: [s3Client],
   addExamples: true,
 });
@@ -200,7 +200,7 @@ new TypeScriptLibProject({
   description: "Effectful AWS HTTP handler",
   deps: ["@smithy/types", "@smithy/protocol-http", "@smithy/querystring-builder"],
   devDeps: [...effectDeps],
-  peerDeps: ["effect@>=4.0.0 <5.0.0"],
+  peerDeps: ["effect@>=4.0.0-beta.66 <5.0.0"],
   workspacePeerDeps: [commons],
 });
 
@@ -210,7 +210,7 @@ new TypeScriptLibProject({
   description: "Effectful AWS Aurora DSQL modules",
   deps: ["@aws-sdk/dsql-signer@^3"],
   devDeps: [...effectDeps],
-  peerDeps: ["effect@>=4.0.0 <5.0.0"],
+  peerDeps: ["effect@>=4.0.0-beta.66 <5.0.0"],
 });
 
 new TypeScriptLibProject({
@@ -219,7 +219,7 @@ new TypeScriptLibProject({
   description: "Effectful AWS CloudFront modules",
   deps: ["@aws-sdk/cloudfront-signer@^3"],
   devDeps: [...effectDeps],
-  peerDeps: ["effect@>=4.0.0 <5.0.0"],
+  peerDeps: ["effect@>=4.0.0-beta.66 <5.0.0"],
 });
 
 project.addGitIgnore("/.direnv"); // flake environment creates .direnv folder

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@effect/docgen": "^0.5.2",
     "@effect/eslint-plugin": "^0.3.2",
     "@effect/language-service": "^0.19.0",
-    "@effect/vitest": "4.0.0-beta.48",
+    "@effect/vitest": "4.0.0-beta.93",
     "@eslint/compat": "^1.2.5",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.19.0",
@@ -67,8 +67,8 @@
     "vitest-mock-extended": "^3.1.0"
   },
   "dependencies": {
-    "@effect/platform-node": "4.0.0-beta.48",
-    "effect": "4.0.0-beta.48"
+    "@effect/platform-node": "4.0.0-beta.93",
+    "effect": "4.0.0-beta.93"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/packages/client-account/.projen/deps.json
+++ b/packages/client-account/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-account/package.json
+++ b/packages/client-account/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-account": "^3",

--- a/packages/client-api-gateway-management-api/.projen/deps.json
+++ b/packages/client-api-gateway-management-api/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-api-gateway-management-api/package.json
+++ b/packages/client-api-gateway-management-api/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3",

--- a/packages/client-api-gateway-v2/.projen/deps.json
+++ b/packages/client-api-gateway-v2/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-api-gateway-v2/package.json
+++ b/packages/client-api-gateway-v2/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-apigatewayv2": "^3",

--- a/packages/client-api-gateway/.projen/deps.json
+++ b/packages/client-api-gateway/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-api-gateway/package.json
+++ b/packages/client-api-gateway/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-api-gateway": "^3",

--- a/packages/client-athena/.projen/deps.json
+++ b/packages/client-athena/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-athena/package.json
+++ b/packages/client-athena/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-athena": "^3",

--- a/packages/client-auto-scaling/.projen/deps.json
+++ b/packages/client-auto-scaling/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-auto-scaling/package.json
+++ b/packages/client-auto-scaling/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-auto-scaling": "^3",

--- a/packages/client-bedrock-runtime/.projen/deps.json
+++ b/packages/client-bedrock-runtime/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-bedrock-runtime/package.json
+++ b/packages/client-bedrock-runtime/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3",

--- a/packages/client-bedrock/.projen/deps.json
+++ b/packages/client-bedrock/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-bedrock/package.json
+++ b/packages/client-bedrock/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3",

--- a/packages/client-cloudformation/.projen/deps.json
+++ b/packages/client-cloudformation/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudformation/package.json
+++ b/packages/client-cloudformation/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3",

--- a/packages/client-cloudfront/.projen/deps.json
+++ b/packages/client-cloudfront/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudfront/package.json
+++ b/packages/client-cloudfront/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudfront": "^3",

--- a/packages/client-cloudsearch/.projen/deps.json
+++ b/packages/client-cloudsearch/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudsearch/package.json
+++ b/packages/client-cloudsearch/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudsearch": "^3",

--- a/packages/client-cloudtrail/.projen/deps.json
+++ b/packages/client-cloudtrail/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudtrail/package.json
+++ b/packages/client-cloudtrail/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudtrail": "^3",

--- a/packages/client-cloudwatch-events/.projen/deps.json
+++ b/packages/client-cloudwatch-events/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudwatch-events/package.json
+++ b/packages/client-cloudwatch-events/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-events": "^3",

--- a/packages/client-cloudwatch-logs/.projen/deps.json
+++ b/packages/client-cloudwatch-logs/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudwatch-logs/package.json
+++ b/packages/client-cloudwatch-logs/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3",

--- a/packages/client-cloudwatch/.projen/deps.json
+++ b/packages/client-cloudwatch/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cloudwatch/package.json
+++ b/packages/client-cloudwatch/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3",

--- a/packages/client-codedeploy/.projen/deps.json
+++ b/packages/client-codedeploy/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-codedeploy/package.json
+++ b/packages/client-codedeploy/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-codedeploy": "^3",

--- a/packages/client-cognito-identity-provider/.projen/deps.json
+++ b/packages/client-cognito-identity-provider/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-cognito-identity-provider/package.json
+++ b/packages/client-cognito-identity-provider/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3",

--- a/packages/client-data-pipeline/.projen/deps.json
+++ b/packages/client-data-pipeline/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-data-pipeline/package.json
+++ b/packages/client-data-pipeline/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-data-pipeline": "^3",

--- a/packages/client-dsql/.projen/deps.json
+++ b/packages/client-dsql/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-dsql/package.json
+++ b/packages/client-dsql/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-dsql": "^3",

--- a/packages/client-dynamodb/.projen/deps.json
+++ b/packages/client-dynamodb/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-dynamodb/package.json
+++ b/packages/client-dynamodb/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3",

--- a/packages/client-ec2/.projen/deps.json
+++ b/packages/client-ec2/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ec2/package.json
+++ b/packages/client-ec2/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ec2": "^3",

--- a/packages/client-ecr/.projen/deps.json
+++ b/packages/client-ecr/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ecr/package.json
+++ b/packages/client-ecr/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ecr": "^3",

--- a/packages/client-ecs/.projen/deps.json
+++ b/packages/client-ecs/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ecs/package.json
+++ b/packages/client-ecs/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ecs": "^3",

--- a/packages/client-elasticache/.projen/deps.json
+++ b/packages/client-elasticache/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-elasticache/package.json
+++ b/packages/client-elasticache/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-elasticache": "^3",

--- a/packages/client-eventbridge/.projen/deps.json
+++ b/packages/client-eventbridge/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-eventbridge/package.json
+++ b/packages/client-eventbridge/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-eventbridge": "^3",

--- a/packages/client-firehose/.projen/deps.json
+++ b/packages/client-firehose/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-firehose/package.json
+++ b/packages/client-firehose/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-firehose": "^3",

--- a/packages/client-glue/.projen/deps.json
+++ b/packages/client-glue/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-glue/package.json
+++ b/packages/client-glue/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-glue": "^3",

--- a/packages/client-iam/.projen/deps.json
+++ b/packages/client-iam/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iam/package.json
+++ b/packages/client-iam/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iam": "^3",

--- a/packages/client-iot-data-plane/.projen/deps.json
+++ b/packages/client-iot-data-plane/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot-data-plane/package.json
+++ b/packages/client-iot-data-plane/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot-data-plane": "^3",

--- a/packages/client-iot-events-data/.projen/deps.json
+++ b/packages/client-iot-events-data/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot-events-data/package.json
+++ b/packages/client-iot-events-data/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot-events-data": "^3",

--- a/packages/client-iot-events/.projen/deps.json
+++ b/packages/client-iot-events/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot-events/package.json
+++ b/packages/client-iot-events/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot-events": "^3",

--- a/packages/client-iot-jobs-data-plane/.projen/deps.json
+++ b/packages/client-iot-jobs-data-plane/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot-jobs-data-plane/package.json
+++ b/packages/client-iot-jobs-data-plane/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot-jobs-data-plane": "^3",

--- a/packages/client-iot-wireless/.projen/deps.json
+++ b/packages/client-iot-wireless/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot-wireless/package.json
+++ b/packages/client-iot-wireless/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot-wireless": "^3",

--- a/packages/client-iot/.projen/deps.json
+++ b/packages/client-iot/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-iot/package.json
+++ b/packages/client-iot/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-iot": "^3",

--- a/packages/client-ivs/.projen/deps.json
+++ b/packages/client-ivs/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ivs/package.json
+++ b/packages/client-ivs/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ivs": "^3",

--- a/packages/client-kafka/.projen/deps.json
+++ b/packages/client-kafka/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-kafka/package.json
+++ b/packages/client-kafka/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-kafka": "^3",

--- a/packages/client-kafkaconnect/.projen/deps.json
+++ b/packages/client-kafkaconnect/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-kafkaconnect/package.json
+++ b/packages/client-kafkaconnect/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-kafkaconnect": "^3",

--- a/packages/client-kinesis/.projen/deps.json
+++ b/packages/client-kinesis/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-kinesis/package.json
+++ b/packages/client-kinesis/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-kinesis": "^3",

--- a/packages/client-kms/.projen/deps.json
+++ b/packages/client-kms/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-kms/package.json
+++ b/packages/client-kms/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3",

--- a/packages/client-lambda/.projen/deps.json
+++ b/packages/client-lambda/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-lambda/package.json
+++ b/packages/client-lambda/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-lambda": "^3",

--- a/packages/client-mq/.projen/deps.json
+++ b/packages/client-mq/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-mq/package.json
+++ b/packages/client-mq/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-mq": "^3",

--- a/packages/client-opensearch-serverless/.projen/deps.json
+++ b/packages/client-opensearch-serverless/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-opensearch-serverless/package.json
+++ b/packages/client-opensearch-serverless/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-opensearchserverless": "^3",

--- a/packages/client-opensearch/.projen/deps.json
+++ b/packages/client-opensearch/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-opensearch/package.json
+++ b/packages/client-opensearch/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-opensearch": "^3",

--- a/packages/client-organizations/.projen/deps.json
+++ b/packages/client-organizations/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-organizations/package.json
+++ b/packages/client-organizations/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-organizations": "^3",

--- a/packages/client-rds/.projen/deps.json
+++ b/packages/client-rds/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-rds/package.json
+++ b/packages/client-rds/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-rds": "^3",

--- a/packages/client-s3/.projen/deps.json
+++ b/packages/client-s3/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-s3/package.json
+++ b/packages/client-s3/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3",

--- a/packages/client-scheduler/.projen/deps.json
+++ b/packages/client-scheduler/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-scheduler/package.json
+++ b/packages/client-scheduler/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-scheduler": "^3",

--- a/packages/client-secrets-manager/.projen/deps.json
+++ b/packages/client-secrets-manager/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-secrets-manager/package.json
+++ b/packages/client-secrets-manager/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3",

--- a/packages/client-ses/.projen/deps.json
+++ b/packages/client-ses/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ses/package.json
+++ b/packages/client-ses/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ses": "^3",

--- a/packages/client-sesv2/.projen/deps.json
+++ b/packages/client-sesv2/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-sesv2/package.json
+++ b/packages/client-sesv2/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "^3",

--- a/packages/client-sfn/.projen/deps.json
+++ b/packages/client-sfn/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-sfn/package.json
+++ b/packages/client-sfn/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-sfn": "^3",

--- a/packages/client-sns/.projen/deps.json
+++ b/packages/client-sns/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-sns/package.json
+++ b/packages/client-sns/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-sns": "^3",

--- a/packages/client-sqs/.projen/deps.json
+++ b/packages/client-sqs/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-sqs/package.json
+++ b/packages/client-sqs/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3",

--- a/packages/client-ssm/.projen/deps.json
+++ b/packages/client-ssm/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-ssm/package.json
+++ b/packages/client-ssm/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-ssm": "^3",

--- a/packages/client-sts/.projen/deps.json
+++ b/packages/client-sts/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-sts/package.json
+++ b/packages/client-sts/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-sts": "^3",

--- a/packages/client-textract/.projen/deps.json
+++ b/packages/client-textract/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-textract/package.json
+++ b/packages/client-textract/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-textract": "^3",

--- a/packages/client-timestream-influxdb/.projen/deps.json
+++ b/packages/client-timestream-influxdb/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-timestream-influxdb/package.json
+++ b/packages/client-timestream-influxdb/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-timestream-influxdb": "^3",

--- a/packages/client-timestream-query/.projen/deps.json
+++ b/packages/client-timestream-query/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-timestream-query/package.json
+++ b/packages/client-timestream-query/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-timestream-query": "^3",

--- a/packages/client-timestream-write/.projen/deps.json
+++ b/packages/client-timestream-write/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/client-timestream-write/package.json
+++ b/packages/client-timestream-write/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-timestream-write": "^3",

--- a/packages/cloudfront/.projen/deps.json
+++ b/packages/cloudfront/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/cloudfront/package.json
+++ b/packages/cloudfront/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/cloudfront-signer": "^3"

--- a/packages/commons/.projen/deps.json
+++ b/packages/commons/.projen/deps.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -25,7 +25,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -28,11 +28,11 @@
     "@aws-sdk/middleware-logger": "^3.972.10",
     "@smithy/core": "^3.24.1",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@smithy/protocol-http": "^5.4.1",

--- a/packages/commons/src/Service.ts
+++ b/packages/commons/src/Service.ts
@@ -67,25 +67,25 @@ type ServiceFnOptions = {
  * @since 0.1.0
  * @category errors
  */
-export const catchServiceExceptions =
-  (errorTags?: NonEmptyReadonlyArray<string>) =>
-  (e: unknown): TaggedException<ServiceError> | Cause.TimeoutError | SdkError => {
-    if (e instanceof ServiceError && (!errorTags || errorTags.includes(e.name))) {
-      class ServiceException extends Data.TaggedError(e.name)<TaggedException<ServiceError>> {}
+export const catchServiceExceptions: (
+  errorTags?: NonEmptyReadonlyArray<string>,
+) => (e: unknown) => TaggedException<ServiceError> | Cause.TimeoutError | SdkError = (errorTags) => (e) => {
+  if (e instanceof ServiceError && (!errorTags || errorTags.includes(e.name))) {
+    class ServiceException extends Data.TaggedError(e.name)<TaggedException<ServiceError>> {}
 
-      return new ServiceException({ ...e, message: e.message, stack: e.stack });
+    return new ServiceException({ ...e, message: e.message, stack: e.stack });
+  }
+  if (e instanceof Error) {
+    // if (Runtime.isFiberFailure(e) && Cause.isFailType(e[Runtime.FiberFailureCauseId])) {
+    //   return e[Runtime.FiberFailureCauseId].error;
+    // }
+    if (e.name === "TimeoutError") {
+      return new Cause.TimeoutError(e.message);
     }
-    if (e instanceof Error) {
-      // if (Runtime.isFiberFailure(e) && Cause.isFailType(e[Runtime.FiberFailureCauseId])) {
-      //   return e[Runtime.FiberFailureCauseId].error;
-      // }
-      if (e.name === "TimeoutError") {
-        return new Cause.TimeoutError(e.message);
-      }
-      return new SdkError({ ...e, name: "SdkError", message: e.message, stack: e.stack });
-    }
-    throw e;
-  };
+    return new SdkError({ ...e, name: "SdkError", message: e.message, stack: e.stack });
+  }
+  throw e;
+};
 
 /**
  * @since 0.1.0
@@ -95,7 +95,7 @@ export const makeServiceFn = (
   client: Client<any, any, BaseResolvedConfig>,
   CommandCtor: CommandCtor<any>,
   fnOptions: ServiceFnOptions,
-): (args: any, options?: HttpHandlerOptions) => Effect.Effect<any, any, any> => {
+) => {
   return (args: any, options?: HttpHandlerOptions) =>
     Effect.gen(function*() {
       const config = yield* fnOptions.resolveClientConfig;
@@ -122,7 +122,7 @@ export const makeServiceStreamFn = (
   client: Client<any, any, BaseResolvedConfig>,
   paginateFn: PaginatorCtor<any>,
   fnOptions: ServiceFnOptions,
-): (args: any, options?: HttpHandlerOptions) => Stream.Stream<any, any, any> => {
+) => {
   return (args: any, options?: HttpHandlerOptions) => {
     const paginator = paginateFn({ client }, args, options);
 

--- a/packages/commons/src/Service.ts
+++ b/packages/commons/src/Service.ts
@@ -67,23 +67,25 @@ type ServiceFnOptions = {
  * @since 0.1.0
  * @category errors
  */
-export const catchServiceExceptions = (errorTags?: NonEmptyReadonlyArray<string>) => (e: unknown) => {
-  if (e instanceof ServiceError && (!errorTags || errorTags.includes(e.name))) {
-    class ServiceException extends Data.TaggedError(e.name)<TaggedException<ServiceError>> {}
+export const catchServiceExceptions =
+  (errorTags?: NonEmptyReadonlyArray<string>) =>
+  (e: unknown): TaggedException<ServiceError> | Cause.TimeoutError | SdkError => {
+    if (e instanceof ServiceError && (!errorTags || errorTags.includes(e.name))) {
+      class ServiceException extends Data.TaggedError(e.name)<TaggedException<ServiceError>> {}
 
-    return new ServiceException({ ...e, message: e.message, stack: e.stack });
-  }
-  if (e instanceof Error) {
-    // if (Runtime.isFiberFailure(e) && Cause.isFailType(e[Runtime.FiberFailureCauseId])) {
-    //   return e[Runtime.FiberFailureCauseId].error;
-    // }
-    if (e.name === "TimeoutError") {
-      return new Cause.TimeoutError(e.message);
+      return new ServiceException({ ...e, message: e.message, stack: e.stack });
     }
-    return new SdkError({ ...e, name: "SdkError", message: e.message, stack: e.stack });
-  }
-  throw e;
-};
+    if (e instanceof Error) {
+      // if (Runtime.isFiberFailure(e) && Cause.isFailType(e[Runtime.FiberFailureCauseId])) {
+      //   return e[Runtime.FiberFailureCauseId].error;
+      // }
+      if (e.name === "TimeoutError") {
+        return new Cause.TimeoutError(e.message);
+      }
+      return new SdkError({ ...e, name: "SdkError", message: e.message, stack: e.stack });
+    }
+    throw e;
+  };
 
 /**
  * @since 0.1.0
@@ -93,7 +95,7 @@ export const makeServiceFn = (
   client: Client<any, any, BaseResolvedConfig>,
   CommandCtor: CommandCtor<any>,
   fnOptions: ServiceFnOptions,
-) => {
+): (args: any, options?: HttpHandlerOptions) => Effect.Effect<any, any, any> => {
   return (args: any, options?: HttpHandlerOptions) =>
     Effect.gen(function*() {
       const config = yield* fnOptions.resolveClientConfig;
@@ -120,7 +122,7 @@ export const makeServiceStreamFn = (
   client: Client<any, any, BaseResolvedConfig>,
   paginateFn: PaginatorCtor<any>,
   fnOptions: ServiceFnOptions,
-) => {
+): (args: any, options?: HttpHandlerOptions) => Stream.Stream<any, any, any> => {
   return (args: any, options?: HttpHandlerOptions) => {
     const paginator = paginateFn({ client }, args, options);
 

--- a/packages/dsql/.projen/deps.json
+++ b/packages/dsql/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/dsql/package.json
+++ b/packages/dsql/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/dsql-signer": "^3"

--- a/packages/dynamodb/.projen/deps.json
+++ b/packages/dynamodb/.projen/deps.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -27,7 +27,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/dynamodb/package.json
+++ b/packages/dynamodb/package.json
@@ -27,12 +27,12 @@
   "devDependencies": {
     "@effect-aws/client-dynamodb": "workspace:^",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect-aws/client-dynamodb": "workspace:^",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3",

--- a/packages/dynamodb/src/DynamoDBDocumentClientInstance.ts
+++ b/packages/dynamodb/src/DynamoDBDocumentClientInstance.ts
@@ -23,7 +23,7 @@ export class DynamoDBDocumentClientInstance
  * @category constructors
  */
 export const make = Effect.all([
-  DynamoDBClientInstance.DynamoDBClientInstance.asEffect(),
+  DynamoDBClientInstance.DynamoDBClientInstance,
   DynamoDBDocumentServiceConfig.toTranslateConfig,
 ]).pipe(
   Effect.map(([client, config]) => DynamoDBDocumentClient.from(client, config)),

--- a/packages/dynamodb/src/DynamoDBDocumentServiceConfig.ts
+++ b/packages/dynamodb/src/DynamoDBDocumentServiceConfig.ts
@@ -41,4 +41,4 @@ export const setDynamoDBDocumentServiceConfig = (config: DynamoDBDocumentService
  * @since 1.0.0
  * @category adapters
  */
-export const toTranslateConfig: Effect.Effect<TranslateConfig> = currentDynamoDBDocumentServiceConfig.asEffect();
+export const toTranslateConfig: Effect.Effect<TranslateConfig> = currentDynamoDBDocumentServiceConfig;

--- a/packages/dynamodb/src/DynamoDBStore.ts
+++ b/packages/dynamodb/src/DynamoDBStore.ts
@@ -103,7 +103,7 @@ export class DynamoDBStore extends Context.Service<
 >()("@effect-aws/dynamodb/DynamoDBStore") {
   static layer = (props: DynamoDBStore.Config) => Layer.effect(this, makeDynamoDBStore(props));
   static layerConfig = (config: Config.Wrap<DynamoDBStore.Config>) =>
-    Layer.effect(this, Config.unwrap(config).asEffect().pipe(Effect.flatMap(makeDynamoDBStore)));
+    Layer.effect(this, Config.unwrap(config).pipe(Effect.flatMap(makeDynamoDBStore)));
 }
 
 /**

--- a/packages/http-handler/.projen/deps.json
+++ b/packages/http-handler/.projen/deps.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -27,7 +27,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/http-handler/package.json
+++ b/packages/http-handler/package.json
@@ -27,12 +27,12 @@
   "devDependencies": {
     "@effect-aws/commons": "workspace:^",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect-aws/commons": "workspace:^",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "@smithy/protocol-http": "^5.4.1",

--- a/packages/lambda/.projen/deps.json
+++ b/packages/lambda/.projen/deps.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "@effect/platform-node-shared",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -16,7 +16,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -31,7 +31,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     }
   ],

--- a/packages/lambda/package.json
+++ b/packages/lambda/package.json
@@ -25,15 +25,15 @@
     "organization": false
   },
   "devDependencies": {
-    "@effect/platform-node-shared": "4.0.0-beta.48",
+    "@effect/platform-node-shared": "4.0.0-beta.93",
     "@types/aws-lambda": "^8.10.159",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect/platform-node-shared": ">=4.0.0 <5.0.0",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "main": "build/cjs/index.js",
   "license": "MIT",

--- a/packages/powertools-logger/.projen/deps.json
+++ b/packages/powertools-logger/.projen/deps.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -32,7 +32,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     }
   ],

--- a/packages/powertools-logger/package.json
+++ b/packages/powertools-logger/package.json
@@ -28,12 +28,12 @@
     "@aws-lambda-powertools/commons": "2.0.0",
     "@aws-lambda-powertools/logger": "2.0.0",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@aws-lambda-powertools/logger": ">=2.0.0",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "main": "build/cjs/index.js",
   "license": "MIT",

--- a/packages/powertools-logger/src/Logger.ts
+++ b/packages/powertools-logger/src/Logger.ts
@@ -156,7 +156,7 @@ const makeLoggerInstance = (logger: Logger) => {
   });
 };
 
-const PowerToolsLoggerEffect = Effect.map(Instance.LoggerInstance.asEffect(), makeLoggerInstance);
+const PowerToolsLoggerEffect = Effect.map(Instance.LoggerInstance, makeLoggerInstance);
 const PowerToolsLoggerLayer = Layer.merge(
   Log.layer([PowerToolsLoggerEffect]),
   Layer.succeed(References.MinimumLogLevel, "All"),

--- a/packages/powertools-logger/src/LoggerOptions.ts
+++ b/packages/powertools-logger/src/LoggerOptions.ts
@@ -39,4 +39,4 @@ export const setLoggerOptions = (options: ConstructorOptions) => Layer.succeed(c
  * @since 1.0.0
  * @category logger options
  */
-export const getLoggerOptions: Effect.Effect<ConstructorOptions> = currentLoggerOptions.asEffect();
+export const getLoggerOptions: Effect.Effect<ConstructorOptions> = currentLoggerOptions;

--- a/packages/powertools-tracer/.projen/deps.json
+++ b/packages/powertools-tracer/.projen/deps.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -41,7 +41,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     },
     {

--- a/packages/powertools-tracer/package.json
+++ b/packages/powertools-tracer/package.json
@@ -30,12 +30,12 @@
     "@effect-aws/lambda": "workspace:^",
     "@types/aws-lambda": "^8.10.159",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@aws-lambda-powertools/tracer": ">=2.0.0",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "dependencies": {
     "aws-xray-sdk-core": "^3.5.3"

--- a/packages/powertools-tracer/src/internal/tracer.ts
+++ b/packages/powertools-tracer/src/internal/tracer.ts
@@ -111,7 +111,7 @@ export const Tracer = Context.Service<XrayTracer, TracerInterface>(
 );
 
 /** @internal */
-export const make = Effect.map(Tracer.asEffect(), (tracer) =>
+export const make = Effect.map(Tracer, (tracer) =>
   EffectTracer.make({
     span: ({ annotations, kind, links, name, parent, startTime }) => {
       return new XraySpan(

--- a/packages/s3/.projen/deps.json
+++ b/packages/s3/.projen/deps.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -32,7 +32,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     }
   ],

--- a/packages/s3/package.json
+++ b/packages/s3/package.json
@@ -28,12 +28,12 @@
     "@aws-sdk/client-s3": "^3",
     "@effect-aws/client-s3": "workspace:^",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect-aws/client-s3": "workspace:^",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "main": "build/cjs/index.js",
   "license": "MIT",

--- a/packages/s3/src/internal/multipartUpload.ts
+++ b/packages/s3/src/internal/multipartUpload.ts
@@ -301,7 +301,7 @@ export const make: Effect.Effect<MultipartUpload, never, S3Service> = Effect.gen
       const dataStream = Stream.fromAsyncIterable(getChunk(Body, partSize), handleBadArgument("uploadObject"));
 
       const [doublet, tailStream] = yield* dataStream.pipe(Stream.peel(Sink.take(2)));
-      const firstPart = yield* Array.head(doublet);
+      const firstPart = yield* Effect.fromOption(Array.head(doublet));
       const secondPart = Array.get(doublet, 1);
 
       if (Option.isNone(secondPart)) {

--- a/packages/s3/src/internal/s3FileSystem.ts
+++ b/packages/s3/src/internal/s3FileSystem.ts
@@ -213,7 +213,7 @@ export const layer = (config: S3FileSystemConfig) => Layer.effect(FileSystem.Fil
 
 /** @internal */
 export const layerConfig = (config: Config.Wrap<S3FileSystemConfig>) =>
-  Config.unwrap(config).asEffect().pipe(
+  Config.unwrap(config).pipe(
     Effect.flatMap(makeFileSystem),
     Layer.effect(FileSystem.FileSystem),
   );

--- a/packages/secrets-manager/.projen/deps.json
+++ b/packages/secrets-manager/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -36,7 +36,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     }
   ],

--- a/packages/secrets-manager/package.json
+++ b/packages/secrets-manager/package.json
@@ -29,12 +29,12 @@
     "@effect-aws/client-secrets-manager": "workspace:^",
     "@fluffy-spoon/substitute": "^1.208.0",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect-aws/client-secrets-manager": "workspace:^",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "main": "build/cjs/index.js",
   "license": "MIT",

--- a/packages/secrets-manager/test/ConfigProvider.test.ts
+++ b/packages/secrets-manager/test/ConfigProvider.test.ts
@@ -24,7 +24,7 @@ describe("fromSecretsManager", () => {
 
     const serviceLayer = SecretsManager.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withSecretsManagerConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,
@@ -49,7 +49,7 @@ describe("fromSecretsManager", () => {
 
     const result = await Config.redacted("my-secret-that-doesnt-exist").pipe(
       Config.withDefault(Redacted.make("mocked-default-value")),
-    ).asEffect().pipe(
+    ).pipe(
       Effect.provide(configProviderLayer),
       Effect.map(Redacted.value),
       Effect.runPromiseExit,
@@ -73,7 +73,7 @@ describe("fromSecretsManager", () => {
 
     const result = await Config.redacted("test").pipe(
       Config.withDefault(Redacted.make("mocked-default-value")),
-    ).asEffect().pipe(
+    ).pipe(
       ConfigProvider.withSecretsManagerConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.map(Redacted.value),
@@ -110,7 +110,7 @@ describe("fromSecretsManager", () => {
 
     const serviceLayer = SecretsManager.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withSecretsManagerConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,
@@ -141,7 +141,7 @@ describe("fromSecretsManager", () => {
 
     const serviceLayer = SecretsManager.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withSecretsManagerConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,

--- a/packages/ssm/.projen/deps.json
+++ b/packages/ssm/.projen/deps.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "effect",
-      "version": "4.0.0-beta.48",
+      "version": "4.0.0-beta.93",
       "type": "build"
     },
     {
@@ -36,7 +36,7 @@
     },
     {
       "name": "effect",
-      "version": ">=4.0.0 <5.0.0",
+      "version": ">=4.0.0-beta.66 <5.0.0",
       "type": "peer"
     }
   ],

--- a/packages/ssm/package.json
+++ b/packages/ssm/package.json
@@ -29,12 +29,12 @@
     "@effect-aws/client-ssm": "workspace:^",
     "@fluffy-spoon/substitute": "^1.208.0",
     "@types/node": "ts5.4",
-    "effect": "4.0.0-beta.48",
+    "effect": "4.0.0-beta.93",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
     "@effect-aws/client-ssm": "workspace:^",
-    "effect": ">=4.0.0 <5.0.0"
+    "effect": ">=4.0.0-beta.66 <5.0.0"
   },
   "main": "build/cjs/index.js",
   "license": "MIT",

--- a/packages/ssm/test/ConfigProvider.test.ts
+++ b/packages/ssm/test/ConfigProvider.test.ts
@@ -24,7 +24,7 @@ describe("fromParameterStore", () => {
 
     const serviceLayer = SSM.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withParameterStoreConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,
@@ -49,7 +49,7 @@ describe("fromParameterStore", () => {
 
     const result = await Config.redacted("my-param-that-doesnt-exist").pipe(
       Config.withDefault(Redacted.make("mocked-default-value")),
-    ).asEffect().pipe(
+    ).pipe(
       Effect.provide(configProviderLayer),
       Effect.map(Redacted.value),
       Effect.runPromiseExit,
@@ -73,7 +73,7 @@ describe("fromParameterStore", () => {
 
     const result = await Config.redacted("test").pipe(
       Config.withDefault(Redacted.make("mocked-default-value")),
-    ).asEffect().pipe(
+    ).pipe(
       ConfigProvider.withParameterStoreConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.map(Redacted.value),
@@ -110,7 +110,7 @@ describe("fromParameterStore", () => {
 
     const serviceLayer = SSM.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withParameterStoreConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,
@@ -141,7 +141,7 @@ describe("fromParameterStore", () => {
 
     const serviceLayer = SSM.baseLayer(() => clientSubstitute);
 
-    const result = await Config.string("test").asEffect().pipe(
+    const result = await Config.string("test").pipe(
       ConfigProvider.withParameterStoreConfigProvider(),
       Effect.provide(serviceLayer),
       Effect.runPromiseExit,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,11 +14,11 @@ importers:
   .:
     dependencies:
       '@effect/platform-node':
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48(effect@4.0.0-beta.48)(ioredis@5.10.1)
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.10.1)
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
     devDependencies:
       '@changesets/changelog-github':
         specifier: ^0.5.0
@@ -39,8 +39,8 @@ importers:
         specifier: ^0.19.0
         version: 0.19.0
       '@effect/vitest':
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48(effect@4.0.0-beta.48)(vitest@3.2.4(@types/node@25.6.0))
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.6.0))
       '@eslint/compat':
         specifier: ^1.2.5
         version: 1.2.5(eslint@9.19.0)
@@ -130,8 +130,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -150,8 +150,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -170,8 +170,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -190,8 +190,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -210,8 +210,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -230,8 +230,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -250,8 +250,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -270,8 +270,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -290,8 +290,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -310,8 +310,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -330,8 +330,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -350,8 +350,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -370,8 +370,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -390,8 +390,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -410,8 +410,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -430,8 +430,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -450,8 +450,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -470,8 +470,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -490,8 +490,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -510,8 +510,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -530,8 +530,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -550,8 +550,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -570,8 +570,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -590,8 +590,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -610,8 +610,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -630,8 +630,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -650,8 +650,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -670,8 +670,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -690,8 +690,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -710,8 +710,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -730,8 +730,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -750,8 +750,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -770,8 +770,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -790,8 +790,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -810,8 +810,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -830,8 +830,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -850,8 +850,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -870,8 +870,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -890,8 +890,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -910,8 +910,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -930,8 +930,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -950,8 +950,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -970,8 +970,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -990,8 +990,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1010,8 +1010,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1036,8 +1036,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1056,8 +1056,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1076,8 +1076,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1096,8 +1096,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1116,8 +1116,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1136,8 +1136,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1156,8 +1156,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1176,8 +1176,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1196,8 +1196,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1216,8 +1216,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1236,8 +1236,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1256,8 +1256,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1276,8 +1276,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1296,8 +1296,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1313,8 +1313,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1342,8 +1342,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1359,8 +1359,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1385,8 +1385,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1411,8 +1411,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1421,8 +1421,8 @@ importers:
   packages/lambda:
     devDependencies:
       '@effect/platform-node-shared':
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48(effect@4.0.0-beta.48)
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)
       '@types/aws-lambda':
         specifier: ^8.10.159
         version: 8.10.159
@@ -1430,8 +1430,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1449,8 +1449,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1478,8 +1478,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1497,8 +1497,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1519,8 +1519,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1541,8 +1541,8 @@ importers:
         specifier: ts5.4
         version: 25.6.0
       effect:
-        specifier: 4.0.0-beta.48
-        version: 4.0.0-beta.48
+        specifier: 4.0.0-beta.93
+        version: 4.0.0-beta.93
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -2306,23 +2306,23 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  '@effect/platform-node-shared@4.0.0-beta.48':
-    resolution: {integrity: sha512-wlhcdDHyacydCgiWdM8JwtQkViQhZsC8uJZ9wMoZXYxlCTvqfdzLeWw4A1UVMoq7sS6/KR1aZVeFkUjrqonncQ==}
+  '@effect/platform-node-shared@4.0.0-beta.93':
+    resolution: {integrity: sha512-XUqZ2u5GglBqY8q2jj4Q7GjN5K/enedk8auZM9rY/l5a/myaQTrQp3QnvpIK4/Yg0WFjLGuctGPMKWRk3OLIrA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.48
+      effect: ^4.0.0-beta.93
 
-  '@effect/platform-node@4.0.0-beta.48':
-    resolution: {integrity: sha512-8J6H0k9rtbp9O1QvKOyOPRcCTJ8WrR7IzZLJtYFTZ4bXVEEMCTo84h0CRpi7ccpA9t7DLqotip0NeFgiBosNKQ==}
+  '@effect/platform-node@4.0.0-beta.93':
+    resolution: {integrity: sha512-QagsCGR0ZOXaCQqS5qGR2mcDng4LiP2bYhiiX1D6UC8cT9vsusVVOHiJWn8CupeDx+yVnPcu81QmA/SDt6GM1w==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: ^4.0.0-beta.48
+      effect: ^4.0.0-beta.93
       ioredis: ^5.7.0
 
-  '@effect/vitest@4.0.0-beta.48':
-    resolution: {integrity: sha512-ONG24EIfUXTrJzIDJctIr6y6JOeml97eoZ53WRUNdwp/tHIAU+U3ME5uUdmtLBKSFeyivYjXGPvEP2DW8f/bCQ==}
+  '@effect/vitest@4.0.0-beta.93':
+    resolution: {integrity: sha512-gMAnZ9PiMeJMDED9s0jWgCOhc2JccrTCxowhur/KriImsHnHIRj4VG/vK0xLw0Axe4AkTWzXNdRsFrYOjBTl3A==}
     peerDependencies:
-      effect: ^4.0.0-beta.48
+      effect: ^4.0.0-beta.93
       vitest: ^3.0.0 || ^4.0.0
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -2762,33 +2762,33 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
     cpu: [x64]
     os: [darwin]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
     cpu: [arm64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
     cpu: [arm]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
     cpu: [x64]
     os: [linux]
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
     cpu: [x64]
     os: [win32]
 
@@ -3242,6 +3242,9 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3837,8 +3840,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  effect@4.0.0-beta.48:
-    resolution: {integrity: sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==}
+  effect@4.0.0-beta.93:
+    resolution: {integrity: sha512-wNS5MKFa3C42uBfIDik2oJ78lhpoYz2hN4oBR0229BeeDCIrkg/FiOvoiPGdCVlWa7MEKxEL5I0f8AILVHSD9A==}
 
   electron-to-chromium@1.5.88:
     resolution: {integrity: sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==}
@@ -4070,8 +4073,8 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
-  fast-check@4.7.0:
-    resolution: {integrity: sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==}
+  fast-check@4.8.0:
+    resolution: {integrity: sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==}
     engines: {node: '>=12.17.0'}
 
   fast-deep-equal@3.1.3:
@@ -4320,9 +4323,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ini@6.0.0:
-    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  ini@7.0.0:
+    resolution: {integrity: sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -4796,12 +4799,12 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
     hasBin: true
 
-  msgpackr@1.11.9:
-    resolution: {integrity: sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==}
+  msgpackr@2.0.4:
+    resolution: {integrity: sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==}
 
   multipasta@0.2.7:
     resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
@@ -5549,8 +5552,11 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@8.1.0:
-    resolution: {integrity: sha512-E9MkTS4xXLnRPYqxH2e6Hr2/49e7WFDKczKcCaFH4VaZs2iNvHMqeIkyUAD9vM8kujy9TjVrRlQ5KkdEJxB2pw==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@8.6.0:
+    resolution: {integrity: sha512-l2FlC6I510GawyEd1qgcE/okihKrzy+BRTEBlu6T0fdbM9m5yxtIH5Oa3ysRsH0zC4EhmWUEaSDsy2QngBeRlw==}
     engines: {node: '>=22.19.0'}
 
   unist-util-is@6.0.0:
@@ -5587,8 +5593,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -5766,8 +5772,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -9458,29 +9464,29 @@ snapshots:
       repeat-string: 1.6.1
       strip-color: 0.1.0
 
-  '@effect/platform-node-shared@4.0.0-beta.48(effect@4.0.0-beta.48)':
+  '@effect/platform-node-shared@4.0.0-beta.93(effect@4.0.0-beta.93)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-beta.48
+      effect: 4.0.0-beta.93
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-beta.48(effect@4.0.0-beta.48)(ioredis@5.10.1)':
+  '@effect/platform-node@4.0.0-beta.93(effect@4.0.0-beta.93)(ioredis@5.10.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-beta.48(effect@4.0.0-beta.48)
-      effect: 4.0.0-beta.48
+      '@effect/platform-node-shared': 4.0.0-beta.93(effect@4.0.0-beta.93)
+      effect: 4.0.0-beta.93
       ioredis: 5.10.1
       mime: 4.1.0
-      undici: 8.1.0
+      undici: 8.6.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.48(effect@4.0.0-beta.48)(vitest@3.2.4(@types/node@25.6.0))':
+  '@effect/vitest@4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.6.0))':
     dependencies:
-      effect: 4.0.0-beta.48
+      effect: 4.0.0-beta.93
       vitest: 3.2.4(@types/node@25.6.0)
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -9787,22 +9793,22 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
     optional: true
 
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
     optional: true
 
   '@nodable/entities@2.1.0': {}
@@ -10279,6 +10285,10 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/sinon@17.0.4':
@@ -10297,7 +10307,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10924,18 +10934,18 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  effect@4.0.0-beta.48:
+  effect@4.0.0-beta.93:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      fast-check: 4.7.0
+      fast-check: 4.8.0
       find-my-way-ts: 0.1.6
-      ini: 6.0.0
+      ini: 7.0.0
       kubernetes-types: 1.30.0
-      msgpackr: 1.11.9
+      msgpackr: 2.0.4
       multipasta: 0.2.7
       toml: 4.1.1
-      uuid: 13.0.0
-      yaml: 2.8.3
+      uuid: 14.0.1
+      yaml: 2.9.0
 
   electron-to-chromium@1.5.88: {}
 
@@ -11316,7 +11326,7 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  fast-check@4.7.0:
+  fast-check@4.8.0:
     dependencies:
       pure-rand: 8.4.0
 
@@ -11589,7 +11599,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@6.0.0: {}
+  ini@7.0.0: {}
 
   internal-slot@1.1.0:
     dependencies:
@@ -12092,21 +12102,21 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
+  msgpackr-extract@3.0.4:
     dependencies:
       node-gyp-build-optional-packages: 5.2.2
     optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
     optional: true
 
-  msgpackr@1.11.9:
+  msgpackr@2.0.4:
     optionalDependencies:
-      msgpackr-extract: 3.0.3
+      msgpackr-extract: 3.0.4
 
   multipasta@0.2.7: {}
 
@@ -12873,7 +12883,9 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@8.1.0: {}
+  undici-types@7.24.6: {}
+
+  undici@8.6.0: {}
 
   unist-util-is@6.0.0:
     dependencies:
@@ -12916,7 +12928,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@13.0.0: {}
+  uuid@14.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 
@@ -13153,7 +13165,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.3: {}
+  yaml@2.9.0: {}
 
   yn@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 0.19.0
       '@effect/vitest':
         specifier: 4.0.0-beta.93
-        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.6.0))
+        version: 4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.9.3))
       '@eslint/compat':
         specifier: ^1.2.5
         version: 1.2.5(eslint@9.19.0)
@@ -55,7 +55,7 @@ importers:
         version: 1.0.1(projen@0.91.6(constructs@10.4.2))
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.21.0
         version: 8.21.0(@typescript-eslint/parser@8.21.0(eslint@9.19.0)(typescript@5.4.5))(eslint@9.19.0)(typescript@5.4.5)
@@ -64,7 +64,7 @@ importers:
         version: 8.21.0(eslint@9.19.0)(typescript@5.4.5)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@25.6.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@25.9.3))
       aws-sdk-client-mock:
         specifier: ^4.1.0
         version: 4.1.0
@@ -97,7 +97,7 @@ importers:
         version: 0.91.6(constructs@10.4.2)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@types/node@25.6.0)(typescript@5.4.5)
+        version: 10.9.1(@types/node@25.9.3)(typescript@5.4.5)
       tsx:
         specifier: ^4.16.5
         version: 4.19.3
@@ -106,16 +106,16 @@ importers:
         version: 5.4.5
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.33.0)(@types/node@25.6.0)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.4.5)
+        version: 1.6.3(@algolia/client-search@5.33.0)(@types/node@25.9.3)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.4.5)
       vitepress-plugin-group-icons:
         specifier: ^1.6.1
-        version: 1.6.1(markdown-it@14.1.0)(vite@5.4.19(@types/node@25.6.0))
+        version: 1.6.1(markdown-it@14.1.0)(vite@5.4.19(@types/node@25.9.3))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@25.6.0)
+        version: 3.2.4(@types/node@25.9.3)
       vitest-mock-extended:
         specifier: ^3.1.0
-        version: 3.1.0(typescript@5.4.5)(vitest@3.2.4(@types/node@25.6.0))
+        version: 3.1.0(typescript@5.4.5)(vitest@3.2.4(@types/node@25.9.3))
 
   packages/client-account:
     dependencies:
@@ -128,7 +128,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -148,7 +148,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -168,7 +168,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -188,7 +188,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -208,7 +208,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -228,7 +228,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -248,7 +248,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -268,7 +268,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -288,7 +288,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -308,7 +308,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -328,7 +328,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -348,7 +348,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -368,7 +368,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -388,7 +388,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -408,7 +408,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -428,7 +428,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -448,7 +448,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -468,7 +468,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -488,7 +488,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -508,7 +508,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -528,7 +528,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -548,7 +548,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -568,7 +568,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -588,7 +588,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -608,7 +608,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -628,7 +628,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -648,7 +648,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -668,7 +668,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -688,7 +688,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -708,7 +708,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -728,7 +728,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -748,7 +748,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -768,7 +768,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -788,7 +788,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -808,7 +808,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -828,7 +828,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -848,7 +848,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -868,7 +868,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -888,7 +888,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -908,7 +908,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -928,7 +928,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -948,7 +948,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -968,7 +968,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -988,7 +988,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1008,7 +1008,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1034,7 +1034,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1054,7 +1054,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1074,7 +1074,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1094,7 +1094,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1114,7 +1114,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1134,7 +1134,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1154,7 +1154,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1174,7 +1174,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1194,7 +1194,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1214,7 +1214,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1234,7 +1234,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1254,7 +1254,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1274,7 +1274,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1294,7 +1294,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1311,7 +1311,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1340,7 +1340,7 @@ importers:
         version: 3.24.1
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1357,7 +1357,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1383,7 +1383,7 @@ importers:
         version: link:../client-dynamodb/dist
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1409,7 +1409,7 @@ importers:
         version: link:../commons/dist
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1428,7 +1428,7 @@ importers:
         version: 8.10.159
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1447,7 +1447,7 @@ importers:
         version: 2.0.0
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1476,7 +1476,7 @@ importers:
         version: 8.10.159
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1495,7 +1495,7 @@ importers:
         version: link:../client-s3/dist
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1517,7 +1517,7 @@ importers:
         version: 1.208.0
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1539,7 +1539,7 @@ importers:
         version: 1.208.0
       '@types/node':
         specifier: ts5.4
-        version: 25.6.0
+        version: 25.9.3
       effect:
         specifier: 4.0.0-beta.93
         version: 4.0.0-beta.93
@@ -1793,10 +1793,12 @@ packages:
   '@aws-sdk/client-iot-events-data@3.1045.0':
     resolution: {integrity: sha512-REZR5ntligrJgrPuyVZRExmQ3Qk3F8sPXOQiI6srDkLcczeUJz1sC/tI5fDhCjIuO1zN8I2IT9/lXDkORNb0Aw==}
     engines: {node: '>=20.0.0'}
+    deprecated: The IoTEventsData client was removed from the SDK.
 
   '@aws-sdk/client-iot-events@3.1045.0':
     resolution: {integrity: sha512-UH6BOZWhq0K95GKwGbtSieC9wb/UsvsaUglHNbdsMGOjGO9RsJI1Cn5ZAciPytcNYgnfuiW9p0Td8dW8ae6aQA==}
     engines: {node: '>=20.0.0'}
+    deprecated: The IoTEvents client was removed from the SDK.
 
   '@aws-sdk/client-iot-jobs-data-plane@3.1045.0':
     resolution: {integrity: sha512-Q6YizcgbF5GBXTWNluHJ0lZk8eWdheabeoWTrlZb+5GxVngQElxx4OvIUSbtC+6GRglRmFnWAk+evKHrAGMySg==}
@@ -2968,6 +2970,7 @@ packages:
   '@smithy/core@3.24.1':
     resolution: {integrity: sha512-3mT7o4qQyUWttYnVK3A0Z/u3Xha3E81tXn32Tz6vjZiUXhBrkEivpw1hBYfh84iFF9CSzkBU9Y1DJ3Q6RQ231g==}
     engines: {node: '>=18.0.0'}
+    deprecated: Deprecated due to bug in browser bundling instructions https://github.com/smithy-lang/smithy-typescript/issues/2025
 
   '@smithy/credential-provider-imds@4.3.1':
     resolution: {integrity: sha512-0S/acwHnqX4WrjXzhdiDRxsG2s9SC0cpPIK9nZ1R6UOHd+j7uL28+4bHu22urbLk2TVw3fkp6na/+fkUt/pLNQ==}
@@ -3240,9 +3243,6 @@ packages:
   '@types/node@20.17.16':
     resolution: {integrity: sha512-vOTpLduLkZXePLxHiHsBLp98mHGnl8RptV4YAO3HfKO5UHjDvySGbxKtpYfy8Sx5+WKcgc45qNreJJRVM3L6mw==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
-
   '@types/node@25.9.3':
     resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
@@ -3325,6 +3325,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -5548,9 +5549,6 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -9484,10 +9482,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/vitest@4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.6.0))':
+  '@effect/vitest@4.0.0-beta.93(effect@4.0.0-beta.93)(vitest@3.2.4(@types/node@25.9.3))':
     dependencies:
       effect: 4.0.0-beta.93
-      vitest: 3.2.4(@types/node@25.6.0)
+      vitest: 3.2.4(@types/node@25.9.3)
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -9751,7 +9749,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -10216,7 +10214,7 @@ snapshots:
 
   '@types/cls-hooked@4.3.9':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/dedent@0.7.0': {}
 
@@ -10232,7 +10230,7 @@ snapshots:
   '@types/glob@7.1.3':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
 
   '@types/hast@3.0.4':
     dependencies:
@@ -10280,10 +10278,6 @@ snapshots:
   '@types/node@20.17.16':
     dependencies:
       undici-types: 6.19.8
-
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
 
   '@types/node@25.9.3':
     dependencies:
@@ -10394,12 +10388,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@25.6.0))(vue@3.5.17(typescript@5.4.5))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@25.9.3))(vue@3.5.17(typescript@5.4.5))':
     dependencies:
-      vite: 5.4.19(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
       vue: 3.5.17(typescript@5.4.5)
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.6.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@25.9.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -10414,7 +10408,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@25.6.0)
+      vitest: 3.2.4(@types/node@25.9.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -10426,13 +10420,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.19(@types/node@25.6.0))':
+  '@vitest/mocker@3.2.4(vite@5.4.19(@types/node@25.9.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.19(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -11850,7 +11844,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -12785,14 +12779,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
-  ts-node@10.9.1(@types/node@25.6.0)(typescript@5.4.5):
+  ts-node@10.9.1(@types/node@25.9.3)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.9
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       acorn: 8.14.0
       acorn-walk: 8.3.2
       arg: 4.1.3
@@ -12881,8 +12875,6 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  undici-types@7.19.2: {}
-
   undici-types@7.24.6: {}
 
   undici@8.6.0: {}
@@ -12947,13 +12939,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.2.4(@types/node@25.6.0):
+  vite-node@3.2.4(@types/node@25.9.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.19(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -12965,26 +12957,26 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.19(@types/node@25.6.0):
+  vite@5.4.19(@types/node@25.9.3):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.40.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
       fsevents: 2.3.3
 
-  vitepress-plugin-group-icons@1.6.1(markdown-it@14.1.0)(vite@5.4.19(@types/node@25.6.0)):
+  vitepress-plugin-group-icons@1.6.1(markdown-it@14.1.0)(vite@5.4.19(@types/node@25.9.3)):
     dependencies:
       '@iconify-json/logos': 1.2.4
       '@iconify-json/vscode-icons': 1.2.23
       '@iconify/utils': 2.3.0
       markdown-it: 14.1.0
-      vite: 5.4.19(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.3(@algolia/client-search@5.33.0)(@types/node@25.6.0)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.4.5):
+  vitepress@1.6.3(@algolia/client-search@5.33.0)(@types/node@25.9.3)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.4.5):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.33.0)(search-insights@2.17.3)
@@ -12993,7 +12985,7 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.19(@types/node@25.6.0))(vue@3.5.17(typescript@5.4.5))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.19(@types/node@25.9.3))(vue@3.5.17(typescript@5.4.5))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.17
       '@vueuse/core': 12.8.2(typescript@5.4.5)
@@ -13002,7 +12994,7 @@ snapshots:
       mark.js: 8.11.1
       minisearch: 7.1.2
       shiki: 2.5.0
-      vite: 5.4.19(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
       vue: 3.5.17(typescript@5.4.5)
     optionalDependencies:
       postcss: 8.5.6
@@ -13033,17 +13025,17 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest-mock-extended@3.1.0(typescript@5.4.5)(vitest@3.2.4(@types/node@25.6.0)):
+  vitest-mock-extended@3.1.0(typescript@5.4.5)(vitest@3.2.4(@types/node@25.9.3)):
     dependencies:
       ts-essentials: 10.0.4(typescript@5.4.5)
       typescript: 5.4.5
-      vitest: 3.2.4(@types/node@25.6.0)
+      vitest: 3.2.4(@types/node@25.9.3)
 
-  vitest@3.2.4(@types/node@25.6.0):
+  vitest@3.2.4(@types/node@25.9.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.19(@types/node@25.6.0))
+      '@vitest/mocker': 3.2.4(vite@5.4.19(@types/node@25.9.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13061,11 +13053,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.19(@types/node@25.6.0)
-      vite-node: 3.2.4(@types/node@25.6.0)
+      vite: 5.4.19(@types/node@25.9.3)
+      vite-node: 3.2.4(@types/node@25.9.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.9.3
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
## Summary

Upgrade `effect` and `@effect/*` from `4.0.0-beta.48` → `4.0.0-beta.93` (via projen) and migrate to the API shape introduced in **effect@4.0.0-beta.66** — see https://github.com/Effect-TS/effect-smol/pull/2159 (Yieldable removal; underlying change Effect-TS/effect-smol#2163).

## Changes

- **beta.66 `Yieldable` removal migration**:
  - drop `.asEffect()` — `Context.Service`/`Reference` and `Config` now extend `Effect` directly (powertools-logger, powertools-tracer, dynamodb, s3, and the ssm/secrets-manager ConfigProvider tests)
  - `yield* Option` → `Effect.fromOption` (s3 `multipartUpload`)
  - fix `TS4023` in `commons/Service.ts` via explicit return-type annotations
- raise the `effect` **peer range** floor to `>=4.0.0-beta.66 <5.0.0` across all 70 packages, since the migrated code relies on the beta.66 shape and would fail on older effect.

## Verification

- `pnpm -r --filter './packages/*' compile` — green
- full test suite — 409 tests passing
- generator (`scripts/generate-client.ts`) emits byte-identical output for un-drifted clients under beta.93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
